### PR TITLE
RM-7546 (v2.28): Unify focus setting in the list click handler of BocAutoCompleteReferenceValue

### DIFF
--- a/Remotion/ObjectBinding/Web/Res/HTML/BocAutoCompleteReferenceValue.jquery.js
+++ b/Remotion/ObjectBinding/Web/Res/HTML/BocAutoCompleteReferenceValue.jquery.js
@@ -1045,9 +1045,7 @@
                 activeItem.addClass (CLASSES.ACTIVE);
                 activeItem.attr("aria-selected", "true");
 
-                select(false);
-                // TODO provide option to avoid setting focus again after selection? useful for cleanup-on-focus
-                input.focus();
+                select(true);
 
                 return false;
             }).mousedown(function() {


### PR DESCRIPTION
https://re-motion.atlassian.net/browse/RM-7546

(cherry picked from commit 16096ef1b61f5d0d67a1bfc92158a36c1de118e5)
