### PR TITLE
RM-7581 (v2.28): Fix DOM elements being used without checking their existence on the page when closing a DropDownMenu

### DIFF
--- a/Remotion/Web/Core/Res/HTML/DropDownMenu.js
+++ b/Remotion/Web/Core/Res/HTML/DropDownMenu.js
@@ -488,10 +488,10 @@ function DropDownMenu_ClosePopUp (updateFocus)
   if (_dropDownMenu_blurTimer !== null)
     clearTimeout(_dropDownMenu_blurTimer);
 
-  if (_dropDownMenu_currentPopup !== null)
+  if (_dropDownMenu_currentPopup !== null
+      && document.body.contains(_dropDownMenu_currentPopup))
   {
     const menuPopup = _dropDownMenu_currentPopup;
-    _dropDownMenu_currentPopup = null;
     const $menuButton = $('a[aria-controls="' + menuPopup.id + '"]');
     $menuButton.unbind('focus', DropDownMenu_BlurHandler);
     $menuButton.unbind('blur', DropDownMenu_BlurHandler);
@@ -503,15 +503,17 @@ function DropDownMenu_ClosePopUp (updateFocus)
     menuPopup.parentElement.removeChild(menuPopup);
   }
 
-  if (_dropDownMenu_currentStatusPopup !== null)
+  if (_dropDownMenu_currentStatusPopup !== null
+      && document.body.contains(_dropDownMenu_currentStatusPopup))
   {
     const statusPopup = _dropDownMenu_currentStatusPopup;
-    _dropDownMenu_currentStatusPopup = null;
     // Clear the role=alert before removing to item to prevent screenreaders (JAWS) from announcing the old value during removal.
     statusPopup.removeAttribute('role');
     statusPopup.parentElement.removeChild(statusPopup);
   }
 
+  _dropDownMenu_currentPopup = null;
+  _dropDownMenu_currentStatusPopup = null;
   _dropDownMenu_currentMenu = null;
 }
 


### PR DESCRIPTION
https://re-motion.atlassian.net/browse/RM-7581

(cherry picked from commit dcd62dbac7b781ea9daddbe2862da5d4b0d7b87c)