### PR TITLE
RM-7576 Fix issue where remaining browser processes are not closed correctly

### DIFF
--- a/Remotion/Web/Development.WebTesting/BrowserSession/BrowserSessionBase.cs
+++ b/Remotion/Web/Development.WebTesting/BrowserSession/BrowserSessionBase.cs
@@ -33,9 +33,7 @@ namespace Remotion.Web.Development.WebTesting.BrowserSession
   public abstract class BrowserSessionBase<T> : IBrowserSession
       where T : IBrowserConfiguration
   {
-    private TimeSpan _driverShutdownWaitTime = TimeSpan.FromSeconds (60);
-    private TimeSpan _browserShutdownWaitTime = TimeSpan.FromMilliseconds (500);
-    private TimeSpan _browserSubProcessShutdownWaitTime = TimeSpan.FromMilliseconds (250);
+    private readonly TimeSpan _browserProcessesShutdownTime = TimeSpan.FromSeconds (60);
 
     private readonly T _browserConfiguration;
     private readonly Coypu.BrowserSession _value;
@@ -111,26 +109,18 @@ namespace Remotion.Web.Development.WebTesting.BrowserSession
       var driverProcess = FindDriverProcess();
       var browserProcess = FindBrowserProcess();
 
-      List<Process> browserSubProcesses;
-      if (browserProcess == null)
-        browserSubProcesses = new List<Process>();
-      else
-        browserSubProcesses = FindSubProcesses (browserProcess).ToList();
+      var processesToClose = new List<Process>();
+      if (driverProcess != null)
+        processesToClose.Add (driverProcess);
+      if (browserProcess != null)
+        processesToClose.Add (browserProcess);
+      if (browserProcess != null)
+        processesToClose.AddRange (FindSubProcesses (browserProcess));
 
       // Dispose the underlying BrowserSession
       _value.Dispose();
 
-      // Check driver and main browser for null
-      if (driverProcess != null)
-      {
-        ProcessUtils.GracefulProcessShutdown (driverProcess, _driverShutdownWaitTime);
-      }
-
-      if (browserProcess != null)
-      {
-        ProcessUtils.GracefulProcessShutdown (browserProcess, _browserShutdownWaitTime);
-        browserSubProcesses.ForEach (p => ProcessUtils.GracefulProcessShutdown (p, _browserSubProcessShutdownWaitTime));
-      }
+      ProcessUtils.GracefulProcessShutdown (processesToClose, _browserProcessesShutdownTime);
     }
 
     /// <summary>

--- a/Remotion/Web/Development.WebTesting/Utilities/ProcessUtils.cs
+++ b/Remotion/Web/Development.WebTesting/Utilities/ProcessUtils.cs
@@ -15,9 +15,12 @@
 // along with re-motion; if not, see http://www.gnu.org/licenses.
 // 
 using System;
+using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics;
+using System.Linq;
 using System.Runtime.InteropServices;
+using System.Text;
 using JetBrains.Annotations;
 using log4net;
 using Remotion.Utilities;
@@ -118,32 +121,75 @@ namespace Remotion.Web.Development.WebTesting.Utilities
     {
       ArgumentUtility.CheckNotNull ("process", process);
 
+      GracefulProcessShutdown (new[] { process }, timeout);
+    }
+
+    /// <summary>
+    /// Tries to shutdown a list of processes gracefully and if they are not closed after <paramref name="timeout"/> it ensures that they are closed.
+    /// </summary>
+    /// <param name="processes">The processes that should be shut down.</param>
+    /// <param name="timeout">The wait timeout after a shutdown has been requested.</param>
+    /// <remarks>
+    /// <p>
+    /// This method will block until the processes have exited. Shutdown procedure is as follows:
+    /// </p>
+    /// <list type="number">
+    /// <item>
+    /// <description>Check if the processes have already exited.</description>
+    /// </item>
+    /// <item>
+    /// <description>Close the main windows of the processes and wait for the processes to exit or the <paramref name="timeout"/> to run out.</description>
+    /// </item>
+    /// <item>
+    /// <description>If the processes are still not closed, kill them and wait for the processes to exit or the <paramref name="timeout"/> is reached.</description>
+    /// </item>
+    /// </list>
+    /// </remarks>
+    public static void GracefulProcessShutdown (IReadOnlyList<Process> processes, TimeSpan timeout)
+    {
+      ArgumentUtility.CheckNotNullOrItemsNull (nameof (processes), processes);
+
       var timeoutInMilliseconds = (int) timeout.TotalMilliseconds;
       if (timeoutInMilliseconds < 0)
         throw new ArgumentOutOfRangeException ("timeout", "Timeout can not be smaller that zero.");
 
+      IReadOnlyList<Process> remainingProcesses = processes.ToList();
+
+      // Clear out any processes that already exited
+      remainingProcesses = WaitForProcessesExits (remainingProcesses, TimeSpan.Zero);
+
+      // Try to gracefully close the process
+      var anyMainWindowClosed = remainingProcesses.Any (CloseMainWindow);
+      if (anyMainWindowClosed)
+        remainingProcesses = WaitForProcessesExits (remainingProcesses, timeout);
+
+      // Force closing the process and wait for process exits
+      foreach (var remainingProcess in remainingProcesses)
+        KillProcess (remainingProcess);
+
+      remainingProcesses = WaitForProcessesExits (remainingProcesses, timeout);
+      if (remainingProcesses.Any())
+        throw CreateProcessesDidNotExitInTimeException (remainingProcesses, timeout);
+    }
+
+    private static bool CloseMainWindow (Process process)
+    {
       try
       {
-        if (process.HasExited)
-          return;
+        return process.CloseMainWindow();
       }
-      catch (Win32Exception)
+      catch (InvalidOperationException)
       {
-        // HasExited can throw Win32Exceptions in certain cases (for example when the process is running with admin rights).
-        // We ignore the exception, because it is still possible to kill the process and the following methods do not throw the same exception.
-        // Tested with process running with admin rights.
-        // If there is an unexpected exception which causes any of the other methods to fail, we have to decide how we want to handle that.
+        // Thrown if the process has already exited, or no process is associated with the Process object.
+        // https://docs.microsoft.com/en-us/dotnet/api/system.diagnostics.process.closemainwindow#remarks
+        // This exception can be swallowed safely, as we are sure that a process is associated and the process has
+        // already exited, therefore the method can return true at this point.
+        return true;
       }
-      
-      // Try to gracefully close the process
-      if (process.CloseMainWindow())
-      {
-        // No exception is thrown when calling .WaitForExit(..) on an already exited process.
-        if (process.WaitForExit (timeoutInMilliseconds))
-          return;
-      }
+    }
 
-      // Force closing the process
+    private static void KillProcess (Process process)
+    {
       try
       {
         process.Kill();
@@ -160,14 +206,44 @@ namespace Remotion.Web.Development.WebTesting.Utilities
         // https://docs.microsoft.com/en-us/dotnet/api/system.diagnostics.process.kill#System_Diagnostics_Process_Kill
         // This exception can be swallowed safely, as we are sure that a process is associated and the process has
         // already exited, therefore the method can return at this point.
-        return;
+      }
+    }
+
+    /// <summary>
+    /// Waits for the specified <paramref name="processes"/> to exit or until the <paramref name="sharedTimeout"/> is reached.
+    /// </summary>
+    /// <param name="processes">The processes that should be waited on to exit.</param>
+    /// <param name="sharedTimeout">The wait timeout after which waiting will be canceled.</param>
+    /// <returns>A subset of the specified <paramref name="processes"/> that did not exit withing the <paramref name="sharedTimeout"/>.</returns>
+    [MustUseReturnValue]
+    private static IReadOnlyList<Process> WaitForProcessesExits (IEnumerable<Process> processes, TimeSpan sharedTimeout)
+    {
+      var remainingProcesses = new List<Process>();
+
+      // Go through all processes and call .WaitForExit on each using a shared timeout
+      // If the timeout runs out still go through all remaining process to make sure to clear any exited processes
+      var stopwatch = Stopwatch.StartNew();
+      foreach (var process in processes)
+      {
+        var timeToTimeoutEnd = sharedTimeout - stopwatch.Elapsed;
+
+        // Use 0 (process.WaitForExit returns instantly) if we exceeded our timeout, otherwise use the remaining timeout
+        var remainingTimeoutInMilliseconds = Math.Max ((int) timeToTimeoutEnd.TotalMilliseconds, 0);
+        if (!process.WaitForExit (remainingTimeoutInMilliseconds))
+          remainingProcesses.Add (process);
       }
 
-      // No exception is thrown when calling .WaitForExit(..) on an already exited process.
-      if (process.WaitForExit (timeoutInMilliseconds))
-        return;
+      return remainingProcesses;
+    }
 
-      throw new InvalidOperationException (string.Format ("Process '{0}' (id: '{1}') did not exit in the expected amount of time.", process.ProcessName, process.Id));
+    private static Exception CreateProcessesDidNotExitInTimeException (IEnumerable<Process> processes, TimeSpan timeout)
+    {
+      var stringBuilder = new StringBuilder();
+      stringBuilder.AppendFormat ("The following processes did not exit within the timeout of {0:0.##} seconds:", timeout.TotalSeconds).AppendLine();
+      foreach (var process in processes)
+        stringBuilder.AppendFormat (" - Process '{0}' (id: {1})", process.ProcessName, process.Id).AppendLine();
+
+      return new InvalidOperationException (stringBuilder.ToString());
     }
 
     /// <summary>


### PR DESCRIPTION
https://re-motion.atlassian.net/browse/RM-7576

While this might not fix the problem of the hanging edge process, it fixes the cleanup of the browser processes. Previously, a thrown exception would cause processes to not get shut down at all. This problem is fixed by shutting down all processes at once using a shared timeout.