### PR TITLE
RM-7283 (v2.25): Added retry loop use for the flaky ResolveBorderElementB test.

### DIFF
--- a/Remotion/Web/Development.WebTesting.IntegrationTests/ScreenshotTest.cs
+++ b/Remotion/Web/Development.WebTesting.IntegrationTests/ScreenshotTest.cs
@@ -287,14 +287,19 @@ namespace Remotion.Web.Development.WebTesting.IntegrationTests
     [Test]
     public void ResolveBorderElementB ()
     {
-      var home = Start();
+      RetryTest (
+          () =>
+          {
+            var home = Start();
 
-      ScreenshotTestingDelegate<IFluentScreenshotElement<ElementScope>> test =
-          (builder, target) => { builder.Crop (target, new WebPadding (1)); };
+            ScreenshotTestingDelegate<IFluentScreenshotElement<ElementScope>> test =
+                (builder, target) => { builder.Crop (target, new WebPadding (1)); };
 
-      var element = home.Scope.FindId ("borderElementB").ForElementScopeScreenshot();
+            var element = home.Scope.FindId ("borderElementB").ForElementScopeScreenshot();
 
-      Helper.RunScreenshotTestExact<IFluentScreenshotElement<ElementScope>, ScreenshotTest> (element, ScreenshotTestingType.Both, test);
+            Helper.RunScreenshotTestExact<IFluentScreenshotElement<ElementScope>, ScreenshotTest> (element, ScreenshotTestingType.Both, test);
+          },
+          2);
     }
 
     [Category ("Screenshot")]


### PR DESCRIPTION
re-motion.atlassian.net/browse/RM-7283 

(cherry picked from commit 67a824b9b6e284ee90a17e71a8b55f304312798a)
(cherry picked from commit dcad36bf69bc3a301c1a6f3b97fd138c3b05c057)