### PR TITLE
RM-7319 (v2.26): Added retry loop for the flaky ResolveBorderElementA test.

### DIFF
--- a/Remotion/Web/Development.WebTesting.IntegrationTests/ScreenshotCreation/ScreenshotTesting.cs
+++ b/Remotion/Web/Development.WebTesting.IntegrationTests/ScreenshotCreation/ScreenshotTesting.cs
@@ -187,7 +187,7 @@ namespace Remotion.Web.Development.WebTesting.IntegrationTests.ScreenshotCreatio
       else
         path = Path.Combine (savePath, string.Join (".", typeName, helper.BrowserConfiguration.BrowserName, testName, "png"));
 
-      screenshotBuilder.Save (path);
+      screenshotBuilder.Save (path, true);
 
       // Try to find the resource which belongs to the current test
       var resourcePrefixes = GenerateResourcePrefixes (typeName, helper.BrowserConfiguration.BrowserName, testPrefix, testName);

--- a/Remotion/Web/Development.WebTesting.IntegrationTests/ScreenshotTest.cs
+++ b/Remotion/Web/Development.WebTesting.IntegrationTests/ScreenshotTest.cs
@@ -268,14 +268,19 @@ namespace Remotion.Web.Development.WebTesting.IntegrationTests
     [Test]
     public void ResolveBorderElementA ()
     {
-      var home = Start();
+      RetryTest (
+          () =>
+          {
+            var home = Start();
 
-      ScreenshotTestingDelegate<IFluentScreenshotElement<ElementScope>> test =
-          (builder, target) => { builder.Crop (target, new WebPadding (1)); };
+            ScreenshotTestingDelegate<IFluentScreenshotElement<ElementScope>> test =
+                (builder, target) => { builder.Crop (target, new WebPadding (1)); };
 
-      var element = home.Scope.FindId ("borderElementA").ForElementScopeScreenshot();
+            var element = home.Scope.FindId ("borderElementA").ForElementScopeScreenshot();
 
-      Helper.RunScreenshotTestExact<IFluentScreenshotElement<ElementScope>, ScreenshotTest> (element, ScreenshotTestingType.Both, test);
+            Helper.RunScreenshotTestExact<IFluentScreenshotElement<ElementScope>, ScreenshotTest> (element, ScreenshotTestingType.Both, test);
+          },
+          2);
     }
 
     [Category ("Screenshot")]
@@ -542,6 +547,26 @@ namespace Remotion.Web.Development.WebTesting.IntegrationTests
 
       Assert.That (derivedNode.GetChildren(), Is.Not.Null);
       Assert.That (derivedNode.GetLabel(), Is.Not.Null);
+    }
+
+    private void RetryTest (Action action, int retries)
+    {
+      if (retries < 0)
+        throw new ArgumentOutOfRangeException ("retries", "Retries must be greater than or equal to zero.");
+
+      for (int i = 0; i <= retries; i++)
+      {
+        try
+        {
+          action();
+        }
+        catch (AssertionException) when (i < retries)
+        {
+          continue;
+        }
+
+        return;
+      }
     }
 
     private ControlObject PrepareTest ()

--- a/Remotion/Web/Development.WebTesting/ScreenshotCreation/ScreenshotBuilder.cs
+++ b/Remotion/Web/Development.WebTesting/ScreenshotCreation/ScreenshotBuilder.cs
@@ -20,6 +20,7 @@ using System.Drawing.Drawing2D;
 using System.Drawing.Imaging;
 using System.IO;
 using JetBrains.Annotations;
+using log4net;
 using Remotion.Utilities;
 using Remotion.Web.Development.WebTesting.ScreenshotCreation.Transformations;
 
@@ -30,6 +31,8 @@ namespace Remotion.Web.Development.WebTesting.ScreenshotCreation
   /// </summary>
   public class ScreenshotBuilder
   {
+    private static readonly ILog s_log = LogManager.GetLogger (typeof (ScreenshotBuilder));
+
     private class TransformationHelper<T> : IDisposable
     {
       private readonly ScreenshotTransformationContext<T> _context;
@@ -226,8 +229,13 @@ namespace Remotion.Web.Development.WebTesting.ScreenshotCreation
       if (_drawMouseCursor && _screenshot.CursorInformation.IsVisible)
         _screenshot.CursorInformation.Draw (_graphics);
 
-      if (!@override && File.Exists (path))
+      var isFileExisting = File.Exists (path);
+
+      if (!@override && isFileExisting)
         throw new InvalidOperationException (string.Format ("A screenshot with the file name '{0}' does already exist.", path));
+
+      if (isFileExisting)
+        s_log.InfoFormat ("Overwriting existing screenshot with file name '{0}'.", path);
 
       var directory = Path.GetDirectoryName (path);
       if (Directory.Exists (directory))


### PR DESCRIPTION
re-motion.atlassian.net/browse/RM-7319

(cherry picked from commit 306de13a331b1de75cdb8b5fd977dc4b5b2a37bc)
(cherry picked from commit c32f9155eb8f608ec95af1ea7d7f3155be16ab03)