### PR TITLE
RM-7760 (v2.28): Fix DropDownMenu CSS rules being overridden by BocList rules

### DIFF
--- a/Remotion/ObjectBinding/Web/Res/Themes/NovaGray/Html/BocList.css
+++ b/Remotion/ObjectBinding/Web/Res/Themes/NovaGray/Html/BocList.css
@@ -400,6 +400,22 @@ tr.bocListDataRow td.bocListDataCell span.CommandText
 
 
 /* Style to override the BocList's anchor style for drop down menus rendered inside a cell. */
+td.bocListDataCell div ul.DropDownMenuOptions li a
+{
+  display: block;
+}
+
+td.bocListDataCell div ul.DropDownMenuOptions li.DropDownMenuItemDisabled.selected a,
+td.bocListDataCell div ul.DropDownMenuOptions li.DropDownMenuItemDisabled a:active,
+td.bocListDataCell div ul.DropDownMenuOptions li.DropDownMenuItemDisabled a:focus,
+td.bocListDataCell div ul.DropDownMenuOptions li.DropDownMenuItemDisabled a:hover
+{
+  background-color: #ECEEEC;
+  border-style: none;
+  padding: 2px;
+  color: gray;
+}
+
 td.bocListDataCell div span.DropDownMenuSelect a.DropDownMenuLabel,
 td.bocListDataCell div span.DropDownMenuSelect:focus a.DropDownMenuLabel,
 td.bocListDataCell div span.DropDownMenuSelect:hover a.DropDownMenuLabel


### PR DESCRIPTION
https://re-motion.atlassian.net/browse/RM-7760

(cherry picked from commit ee06f907ad0de4352deeba47f8d16cec9fa6a6f8)