### PR TITLE
RM-7814 add null guard on properties of type and assembly

### DIFF
--- a/Remotion/Core/Core/Configuration/ProviderHelperBase.cs
+++ b/Remotion/Core/Core/Configuration/ProviderHelperBase.cs
@@ -20,6 +20,7 @@ using System.Configuration;
 using System.Configuration.Provider;
 using System.IO;
 using System.Reflection;
+using Remotion.Reflection;
 using Remotion.Utilities;
 
 namespace Remotion.Configuration
@@ -267,12 +268,12 @@ namespace Remotion.Configuration
       Type actualType = TypeUtility.GetType (providerSettings.Type, throwOnError: true)!;
 
       if (!providerType.IsAssignableFrom (actualType))
-        throw new ArgumentException (string.Format ("Provider must implement the class '{0}'.", providerType.FullName));
+        throw new ArgumentException (string.Format ("Provider must implement the class '{0}'.", providerType.GetFullNameSafe()));
 
       foreach (Type interfaceType in providerInterfaces)
       {
         if (!interfaceType.IsAssignableFrom (actualType))
-          throw new ArgumentException (string.Format ("Provider must implement the interface '{0}'.", interfaceType.FullName));
+          throw new ArgumentException (string.Format ("Provider must implement the interface '{0}'.", interfaceType.GetFullNameSafe()));
       }
 
       return (ExtendedProviderBase) Activator.CreateInstance (actualType, new object[] {name, collection})!;

--- a/Remotion/Core/Core/Core.Core.csproj
+++ b/Remotion/Core/Core/Core.Core.csproj
@@ -128,6 +128,15 @@
     <Compile Include="..\..\..\SharedSource\Core\FunctionalProgramming\EnumerableUtility.cs">
       <Link>SharedSource\FunctionalProgramming\EnumerableUtility.cs</Link>
     </Compile>
+    <Compile Include="..\..\..\SharedSource\Core\Reflection\AssemblyExtensions.cs">
+      <Link>SharedSource\Reflection\AssemblyExtensions.cs</Link>
+    </Compile>
+    <Compile Include="..\..\..\SharedSource\Core\Reflection\AssemblyNameExtensions.cs">
+      <Link>SharedSource\Reflection\AssemblyNameExtensions.cs</Link>
+    </Compile>
+    <Compile Include="..\..\..\SharedSource\Core\Reflection\TypeExtensions.cs">
+      <Link>SharedSource\Reflection\TypeExtensions.cs</Link>
+    </Compile>
     <Compile Include="..\..\..\SharedSource\Core\ReSharperAnnotations\AssertionConditionAttribute.cs">
       <Link>SharedSource\ReSharperAnnotations\AssertionConditionAttribute.cs</Link>
     </Compile>
@@ -227,6 +236,8 @@
     <Compile Include="FunctionalProgramming\EnumerableUtility.Partial.cs" />
     <Compile Include="IHandleAttribute.cs" />
     <Compile Include="Obsolete\Reflection\TypeDiscovery\ContextAwareTypeDiscoveryUtility.cs" />
+    <Compile Include="Reflection\AssemblyExtensions.cs" />
+    <Compile Include="Reflection\AssemblyNameExtensions.cs" />
     <Compile Include="Reflection\MethodInfoExtensions.cs" />
     <Compile Include="Reflection\MethodResolver.cs" />
     <Compile Include="Reflection\PropertyInfoExtensions.cs" />

--- a/Remotion/Core/Core/Logging/Log4NetLogManager.cs
+++ b/Remotion/Core/Core/Logging/Log4NetLogManager.cs
@@ -21,6 +21,7 @@ using log4net.Config;
 using log4net.Core;
 using log4net.Layout;
 using log4net.Repository.Hierarchy;
+using Remotion.Reflection;
 using Remotion.ServiceLocation;
 using Remotion.Utilities;
 
@@ -87,7 +88,7 @@ namespace Remotion.Logging
         var message = string.Format (
             "Cannot set a default threshold for the logger repository of type '{1}' configured for assembly '{0}'. The repository does not derive "
             + "from the '{2}' class.", 
-            repositoryAssembly.GetName().Name,
+            repositoryAssembly.GetName().GetNameSafe(),
             loggerRepository.GetType(),
             typeof (Hierarchy));
         throw new InvalidOperationException (message);

--- a/Remotion/Core/Core/Reflection/AssemblyExtensions.cs
+++ b/Remotion/Core/Core/Reflection/AssemblyExtensions.cs
@@ -1,0 +1,24 @@
+﻿// This file is part of the re-motion Core Framework (www.re-motion.org)
+// Copyright (c) rubicon IT GmbH, www.rubicon.eu
+// 
+// The re-motion Core Framework is free software; you can redistribute it 
+// and/or modify it under the terms of the GNU Lesser General Public License 
+// as published by the Free Software Foundation; either version 2.1 of the 
+// License, or (at your option) any later version.
+// 
+// re-motion is distributed in the hope that it will be useful, 
+// but WITHOUT ANY WARRANTY; without even the implied warranty of 
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the 
+// GNU Lesser General Public License for more details.
+// 
+// You should have received a copy of the GNU Lesser General Public License
+// along with re-motion; if not, see http://www.gnu.org/licenses.
+// 
+using System;
+
+namespace Remotion.Reflection
+{
+  public static partial class AssemblyExtensions
+  {
+  }
+}

--- a/Remotion/Core/Core/Reflection/AssemblyNameExtensions.cs
+++ b/Remotion/Core/Core/Reflection/AssemblyNameExtensions.cs
@@ -1,0 +1,24 @@
+﻿// This file is part of the re-motion Core Framework (www.re-motion.org)
+// Copyright (c) rubicon IT GmbH, www.rubicon.eu
+// 
+// The re-motion Core Framework is free software; you can redistribute it 
+// and/or modify it under the terms of the GNU Lesser General Public License 
+// as published by the Free Software Foundation; either version 2.1 of the 
+// License, or (at your option) any later version.
+// 
+// re-motion is distributed in the hope that it will be useful, 
+// but WITHOUT ANY WARRANTY; without even the implied warranty of 
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the 
+// GNU Lesser General Public License for more details.
+// 
+// You should have received a copy of the GNU Lesser General Public License
+// along with re-motion; if not, see http://www.gnu.org/licenses.
+// 
+using System;
+
+namespace Remotion.Reflection
+{
+  public static partial class AssemblyNameExtensions
+  {
+  }
+}

--- a/Remotion/Core/Core/Reflection/TypeDiscovery/AssemblyFinding/AssemblyFinder.cs
+++ b/Remotion/Core/Core/Reflection/TypeDiscovery/AssemblyFinding/AssemblyFinder.cs
@@ -110,8 +110,7 @@ namespace Remotion.Reflection.TypeDiscovery.AssemblyFinding
             rootAssemblies.Select (r=>r.Assembly).Distinct().Select (a => new KeyValuePair<Assembly, object?> (a, null)));
 
         // used to avoid loading assemblies twice.
-        // TODO RM-7754: If the FullName property is null, special handling is needed. Note that simply using a dummy value won't suffice since it can result in errenous assembly detection. Throwing a meaningful exception may be sufficient.
-        var processedAssemblyNames = new HashSet<string> (processedAssemblies.Keys.Select (a => a.FullName!));
+        var processedAssemblyNames = new HashSet<string> (processedAssemblies.Keys.Select (a => a.GetFullNameChecked()));
 
         var result = new ConcurrentBag<Assembly>();
 
@@ -123,8 +122,7 @@ namespace Remotion.Reflection.TypeDiscovery.AssemblyFinding
           // Parallel starts here
           foreach (var referencedAssemblyName in nonprocessedAssemblyNames.AsParallel())
           {
-            // TODO RM-7756: currentRoot.FullName must not be null.
-            var referencedAssembly = _assemblyLoader.TryLoadAssembly (referencedAssemblyName, currentRoot.FullName!);
+            var referencedAssembly = _assemblyLoader.TryLoadAssembly (referencedAssemblyName, currentRoot.GetFullNameChecked());
             if (referencedAssembly != null) // might return null if filtered by the loader
             {
               if (processedAssemblies.TryAdd (referencedAssembly, null))

--- a/Remotion/Core/Core/Reflection/TypeDiscovery/AssemblyFinding/RootAssembly.cs
+++ b/Remotion/Core/Core/Reflection/TypeDiscovery/AssemblyFinding/RootAssembly.cs
@@ -50,7 +50,7 @@ namespace Remotion.Reflection.TypeDiscovery.AssemblyFinding
 
     public override string ToString ()
     {
-      return Assembly.FullName + (FollowReferences ? ", including references" : "");
+      return Assembly.GetFullNameSafe() + (FollowReferences ? ", including references" : "");
     }
   }
 }

--- a/Remotion/Core/Core/Reflection/TypeDiscovery/AssemblyLoading/FilteringAssemblyLoader.cs
+++ b/Remotion/Core/Core/Reflection/TypeDiscovery/AssemblyLoading/FilteringAssemblyLoader.cs
@@ -141,7 +141,7 @@ namespace Remotion.Reflection.TypeDiscovery.AssemblyLoading
       catch (Exception ex)
       {
         string message = string.Format ("The assembly {0} triggered an unexpected exception of type {1}.\r\nUnexpected exception message: {2}", 
-                                        assemblyDescriptionText, ex.GetType().FullName, ex.Message);
+                                        assemblyDescriptionText, ex.GetType().GetFullNameSafe(), ex.Message);
         throw new AssemblyLoaderException (message, ex);
       }
     }

--- a/Remotion/Core/Core/Reflection/TypeDiscovery/AssemblyLoading/RegexAssemblyLoaderFilter.cs
+++ b/Remotion/Core/Core/Reflection/TypeDiscovery/AssemblyLoading/RegexAssemblyLoaderFilter.cs
@@ -87,7 +87,7 @@ namespace Remotion.Reflection.TypeDiscovery.AssemblyLoading
       switch (_matchTarget)
       {
         case MatchTargetKind.SimpleName:
-          return _matchExpression.IsMatch (assemblyName.Name!); // TODO RM-7770: assemblyName.Name should be checked for null.
+          return _matchExpression.IsMatch (assemblyName.GetNameChecked());
         default:
           return _matchExpression.IsMatch (assemblyName.FullName);
       }

--- a/Remotion/Core/Core/Reflection/TypeExtensions.cs
+++ b/Remotion/Core/Core/Reflection/TypeExtensions.cs
@@ -22,10 +22,7 @@ using Remotion.Utilities;
 
 namespace Remotion.Reflection
 {
-  /// <summary>
-  /// Defines extension methods for working with <see cref="PropertyInfo"/>.
-  /// </summary>
-  public static class TypeExtensions
+  public static partial class TypeExtensions
   {
     private static readonly ConcurrentDictionary<Tuple<Type, Type>, bool> s_canAscribeCache = 
         new ConcurrentDictionary<Tuple<Type, Type>, bool>();

--- a/Remotion/Core/Core/Reflection/TypeExtensions.cs
+++ b/Remotion/Core/Core/Reflection/TypeExtensions.cs
@@ -159,7 +159,7 @@ namespace Remotion.Reflection
         else
         {
           string message = 
-              String.Format ("The type {0} implements the given interface type {1} more than once.", type.FullName, ascribeeType.FullName);
+              String.Format ("The type {0} implements the given interface type {1} more than once.", type.GetFullNameSafe(), ascribeeType.GetFullNameSafe());
           throw new AmbiguousMatchException (message);
         }
       }

--- a/Remotion/Core/Core/Utilities/AdvancedEnumConverter.cs
+++ b/Remotion/Core/Core/Utilities/AdvancedEnumConverter.cs
@@ -17,6 +17,7 @@
 using System;
 using System.ComponentModel;
 using System.Globalization;
+using Remotion.Reflection;
 
 namespace Remotion.Utilities
 {
@@ -122,7 +123,7 @@ namespace Remotion.Utilities
         if (value != null && _underlyingType == value.GetType())
         {
           if (!EnumUtility.IsValidEnumValue(UnderlyingEnumType, value))
-            throw new ArgumentOutOfRangeException (string.Format ("The value {0} is not supported for enumeration '{1}'.", value, UnderlyingEnumType.FullName), (Exception?) null);
+            throw new ArgumentOutOfRangeException (string.Format ("The value {0} is not supported for enumeration '{1}'.", value, UnderlyingEnumType.GetFullNameSafe()), (Exception?) null);
 
           return Enum.ToObject (UnderlyingEnumType, value);
         }

--- a/Remotion/Core/Core/Utilities/AttributeWithMetadata.cs
+++ b/Remotion/Core/Core/Utilities/AttributeWithMetadata.cs
@@ -17,6 +17,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using Remotion.Reflection;
 
 namespace Remotion.Utilities
 {
@@ -97,7 +98,7 @@ namespace Remotion.Utilities
 
     public override string ToString ()
     {
-      return "AttributeMetadata: DeclaringType: " + _declaringType.FullName + "; Attibute: " + _attribute.ToString();
+      return "AttributeMetadata: DeclaringType: " + _declaringType.GetFullNameSafe() + "; Attibute: " + _attribute.ToString();
     }
   }
 }

--- a/Remotion/Core/Core/Utilities/EnumUtility.cs
+++ b/Remotion/Core/Core/Utilities/EnumUtility.cs
@@ -20,6 +20,7 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Globalization;
 using Remotion.Collections;
+using Remotion.Reflection;
 
 namespace Remotion.Utilities
 {
@@ -91,7 +92,7 @@ namespace Remotion.Utilities
       if (!enumType.IsEnum)
       {
         throw new ArgumentException (
-            string.Format ("Argument was of type '{0}' but only enum-types are supported with this overload.", enumType.FullName), "enumValue");
+            string.Format ("Argument was of type '{0}' but only enum-types are supported with this overload.", enumType.GetFullNameSafe()), "enumValue");
       }
 
       var enumMetadata = GetEnumMetadata (enumType);
@@ -119,7 +120,7 @@ namespace Remotion.Utilities
       if (!enumType.IsEnum)
       {
         throw new ArgumentException (
-            string.Format ("Argument was a type representing '{0}' but only enum-types are supported.", enumType.FullName), "enumType");
+            string.Format ("Argument was a type representing '{0}' but only enum-types are supported.", enumType.GetFullNameSafe()), "enumType");
       }
 
       var enumMetadata = GetEnumMetadata (enumType);
@@ -166,7 +167,7 @@ namespace Remotion.Utilities
       if (!enumType.IsEnum)
       {
         throw new ArgumentException (
-            string.Format ("Argument was a type representing '{0}' but only enum-types are supported.", enumType.FullName), "enumType");
+            string.Format ("Argument was a type representing '{0}' but only enum-types are supported.", enumType.GetFullNameSafe()), "enumType");
       }
 
       return GetEnumMetadata (enumType).IsFlagsEnum;

--- a/Remotion/Core/Core/Utilities/FileUtility.Partial.cs
+++ b/Remotion/Core/Core/Utilities/FileUtility.Partial.cs
@@ -17,6 +17,7 @@
 using System;
 using System.IO;
 using System.Reflection;
+using Remotion.Reflection;
 
 namespace Remotion.Utilities
 {
@@ -41,7 +42,7 @@ namespace Remotion.Utilities
           Stream from = assembly.GetManifestResourceStream (typeWhoseNamespaceTheStringResourceResidesIn, stringResourceName)!,
               to = new FileStream (filePath, FileMode.Create))
       {
-        Assertion.IsNotNull (from, "Resource '{0}' does not exist in assembly '{1}'.", stringResourceName, assembly.FullName!);
+        Assertion.IsNotNull (from, "Resource '{0}' does not exist in assembly '{1}'.", stringResourceName, assembly.GetFullNameSafe());
         from.CopyTo (to);
       }
     }

--- a/Remotion/Core/Core/Utilities/TypeUtility.AbbreviationBuilder.cs
+++ b/Remotion/Core/Core/Utilities/TypeUtility.AbbreviationBuilder.cs
@@ -29,7 +29,7 @@ namespace Remotion.Utilities
         ArgumentUtility.DebugCheckNotNull ("type", type);
 
         // TODO RM-7763: properties should be checked for null. Consider passing the properties instead of the type/assembly into the next method to use only the null-checked values.
-        var typeNameBuilder = new StringBuilder (type.FullName!.Length + 20 + (includeVersionAndCulture ? type.Assembly!.GetFullNameSafe().Length : 0));
+        var typeNameBuilder = new StringBuilder (type.GetFullNameChecked().Length + 20 + (includeVersionAndCulture ? type.Assembly!.GetFullNameChecked().Length : 0));
         BuildAbbreviatedTypeName (typeNameBuilder, type, includeVersionAndCulture, false);
         return typeNameBuilder.ToString();
       }
@@ -48,7 +48,7 @@ namespace Remotion.Utilities
         if (canAbbreviate)
         {
           var nsLength = string.IsNullOrEmpty (ns) ? 0 : ns.Length + 1;
-          var name = StripTypeParametersFromName (type.FullName!.Substring (nsLength));
+          var name = StripTypeParametersFromName (type.GetFullNameChecked().Substring (nsLength));
           typeNameBuilder.Append (asm).Append ("::");
 
           if (ns.Length > asm.Length)
@@ -60,7 +60,7 @@ namespace Remotion.Utilities
         }
         else
         {
-          typeNameBuilder.Append (StripTypeParametersFromName (type.FullName!));
+          typeNameBuilder.Append (StripTypeParametersFromName (type.GetFullNameChecked()));
           BuildAbbreviatedTypeParameters (typeNameBuilder, type, includeVersionAndCulture);
           typeNameBuilder.Append (", ").Append (asm);
         }

--- a/Remotion/Core/Core/Utilities/TypeUtility.AbbreviationBuilder.cs
+++ b/Remotion/Core/Core/Utilities/TypeUtility.AbbreviationBuilder.cs
@@ -16,6 +16,7 @@
 // 
 using System;
 using System.Text;
+using Remotion.Reflection;
 
 namespace Remotion.Utilities
 {
@@ -28,7 +29,7 @@ namespace Remotion.Utilities
         ArgumentUtility.DebugCheckNotNull ("type", type);
 
         // TODO RM-7763: properties should be checked for null. Consider passing the properties instead of the type/assembly into the next method to use only the null-checked values.
-        var typeNameBuilder = new StringBuilder (type.FullName!.Length + 20 + (includeVersionAndCulture ? type.Assembly!.FullName!.Length : 0));
+        var typeNameBuilder = new StringBuilder (type.FullName!.Length + 20 + (includeVersionAndCulture ? type.Assembly!.GetFullNameSafe().Length : 0));
         BuildAbbreviatedTypeName (typeNameBuilder, type, includeVersionAndCulture, false);
         return typeNameBuilder.ToString();
       }
@@ -65,7 +66,7 @@ namespace Remotion.Utilities
         }
 
         if (includeVersionAndCulture)
-          typeNameBuilder.Append (type.Assembly!.FullName!.Substring (asm.Length));
+          typeNameBuilder.Append (type.Assembly!.GetFullNameChecked().Substring (asm.Length));
 
         if (needsBrackets)
           typeNameBuilder.Append ("]");

--- a/Remotion/Core/Core/Utilities/TypeUtility.AbbreviationBuilder.cs
+++ b/Remotion/Core/Core/Utilities/TypeUtility.AbbreviationBuilder.cs
@@ -37,7 +37,7 @@ namespace Remotion.Utilities
       private void BuildAbbreviatedTypeName (StringBuilder typeNameBuilder, Type type, bool includeVersionAndCulture, bool isTypeParameter)
       {
         string ns = type.Namespace ?? string.Empty;
-        string asm = type.Assembly!.GetName().Name!;
+        string asm = type.Assembly!.GetName().GetNameChecked();
         bool canAbbreviate = ns.StartsWith (asm);
 
         // put type paramters in [brackets] if they include commas, so the commas cannot be confused with type parameter separators

--- a/Remotion/Core/Core/Utilities/TypeUtility.cs
+++ b/Remotion/Core/Core/Utilities/TypeUtility.cs
@@ -117,7 +117,7 @@ namespace Remotion.Utilities
       ArgumentUtility.CheckNotNull ("type", type);
 
       // C# compiler 7.2 already provides caching for anonymous method.
-      return s_partialAssemblyQualifiedNameCache.GetOrAdd (type, key => key.FullName + ", " + key.Assembly.GetName ().Name);
+      return s_partialAssemblyQualifiedNameCache.GetOrAdd (type, key => key.FullName + ", " + key.Assembly.GetName ().GetNameChecked());
     }
 
     /// <summary>

--- a/Remotion/Core/Core/Utilities/TypeUtility.cs
+++ b/Remotion/Core/Core/Utilities/TypeUtility.cs
@@ -117,7 +117,7 @@ namespace Remotion.Utilities
       ArgumentUtility.CheckNotNull ("type", type);
 
       // C# compiler 7.2 already provides caching for anonymous method.
-      return s_partialAssemblyQualifiedNameCache.GetOrAdd (type, key => key.FullName + ", " + key.Assembly.GetName ().GetNameChecked());
+      return s_partialAssemblyQualifiedNameCache.GetOrAdd (type, key => key.GetFullNameChecked() + ", " + key.Assembly.GetName ().GetNameChecked());
     }
 
     /// <summary>

--- a/Remotion/Core/ExtensibleEnums/ExtensibleEnum.cs
+++ b/Remotion/Core/ExtensibleEnums/ExtensibleEnum.cs
@@ -17,6 +17,7 @@
 using System;
 using System.Reflection;
 using System.Threading;
+using Remotion.Reflection;
 using Remotion.Utilities;
 
 namespace Remotion.ExtensibleEnums
@@ -115,7 +116,7 @@ namespace Remotion.ExtensibleEnums
     /// and hash code calculations.</param>
     protected ExtensibleEnum (Type declaringType, string valueName)
         : this (
-            ArgumentUtility.CheckNotNull ("declaringType", declaringType).FullName, 
+            ArgumentUtility.CheckNotNull ("declaringType", declaringType).GetFullNameChecked(), 
             ArgumentUtility.CheckNotNullOrEmpty ("valueName", valueName))
     {
     }

--- a/Remotion/Core/Extensions/Utilities/MemberAccessUtility.cs
+++ b/Remotion/Core/Extensions/Utilities/MemberAccessUtility.cs
@@ -16,6 +16,7 @@
 // 
 using System;
 using System.Reflection;
+using Remotion.Reflection;
 
 namespace Remotion.Utilities
 {
@@ -50,7 +51,7 @@ namespace Remotion.Utilities
       if (attributes == null || attributes.Length == 0)
         return null;
       if (attributes.Length > 1)
-        throw new NotSupportedException (String.Format ("Cannot get member value for multiple attributes. Reflection object {0} has {1} instances of attribute {2}", reflectionObject.Name, attributes.Length, attributeType.FullName));
+        throw new NotSupportedException (String.Format ("Cannot get member value for multiple attributes. Reflection object {0} has {1} instances of attribute {2}", reflectionObject.Name, attributes.Length, attributeType.GetFullNameSafe()));
       return GetFieldOrPropertyValue (attributes[0], fieldOrProperty);
     }
 
@@ -65,7 +66,7 @@ namespace Remotion.Utilities
         return member;
 
       if (throwExceptionIfNotFound)
-        throw new ArgumentException (String.Format ("{0} is not an instance field or property of type {1}.", fieldOrPropertyName, type.FullName), "fieldOrPropertyName");
+        throw new ArgumentException (String.Format ("{0} is not an instance field or property of type {1}.", fieldOrPropertyName, type.GetFullNameSafe()), "fieldOrPropertyName");
       return null;
     }
 
@@ -94,7 +95,7 @@ namespace Remotion.Utilities
       else if (fieldOrProperty is PropertyInfo)
         return ((PropertyInfo) fieldOrProperty).GetValue (obj, new object[0]);
       else
-        throw new ArgumentException (String.Format ("Argument must be either FieldInfo or PropertyInfo but is {0}.", fieldOrProperty.GetType ().FullName), "fieldOrProperty");
+        throw new ArgumentException (String.Format ("Argument must be either FieldInfo or PropertyInfo but is {0}.", fieldOrProperty.GetType ().GetFullNameSafe()), "fieldOrProperty");
     }
 
 
@@ -122,7 +123,7 @@ namespace Remotion.Utilities
       else if (fieldOrProperty is PropertyInfo)
         ((PropertyInfo) fieldOrProperty).SetValue (obj, value, new object[0]);
       else
-        throw new ArgumentException (String.Format ("Argument must be either FieldInfo or PropertyInfo but is {0}.", fieldOrProperty.GetType ().FullName), "fieldOrProperty");
+        throw new ArgumentException (String.Format ("Argument must be either FieldInfo or PropertyInfo but is {0}.", fieldOrProperty.GetType ().GetFullNameSafe()), "fieldOrProperty");
     }
 
     public static Type GetFieldOrPropertyType (MemberInfo fieldOrProperty)

--- a/Remotion/Core/Reflection.CodeGeneration/CustomClassEmitter.cs
+++ b/Remotion/Core/Reflection.CodeGeneration/CustomClassEmitter.cs
@@ -70,9 +70,9 @@ namespace Remotion.Reflection.CodeGeneration
     {
       ArgumentUtility.CheckNotNull ("baseType", baseType);
       if (baseType.IsInterface)
-        throw new ArgumentException ("Base type must not be an interface (" + baseType.FullName + ").", "baseType");
+        throw new ArgumentException ("Base type must not be an interface (" + baseType.GetFullNameSafe() + ").", "baseType");
       if (baseType.IsSealed)
-        throw new ArgumentException ("Base type must not be sealed (" + baseType.FullName + ").", "baseType");
+        throw new ArgumentException ("Base type must not be sealed (" + baseType.GetFullNameSafe() + ").", "baseType");
       return baseType;
     }
 
@@ -82,7 +82,7 @@ namespace Remotion.Reflection.CodeGeneration
       foreach (Type interfaceType in interfaces)
       {
         if (!interfaceType.IsInterface)
-          throw new ArgumentException ("Interface type must not be a class or value type (" + interfaceType.FullName + ").", "interfaces");
+          throw new ArgumentException ("Interface type must not be a class or value type (" + interfaceType.GetFullNameSafe() + ").", "interfaces");
       }
       return interfaces;
     }
@@ -429,7 +429,7 @@ namespace Remotion.Reflection.CodeGeneration
       if (keepSimpleName)
         return baseOrInterfaceMember.Name;
       else
-        return string.Format ("{0}.{1}", baseOrInterfaceMember.DeclaringType!.FullName, baseOrInterfaceMember.Name);
+        return string.Format ("{0}.{1}", baseOrInterfaceMember.DeclaringType!.GetFullNameChecked(), baseOrInterfaceMember.Name);
     }
   }
 }

--- a/Remotion/Core/Reflection.CodeGeneration/CustomMethodEmitter.cs
+++ b/Remotion/Core/Reflection.CodeGeneration/CustomMethodEmitter.cs
@@ -137,7 +137,7 @@ namespace Remotion.Reflection.CodeGeneration
       ArgumentUtility.CheckNotNull ("baseMethod", baseMethod);
 
       if (baseMethod.IsAbstract)
-        throw new ArgumentException (string.Format ("The given method {0}.{1} is abstract.", baseMethod.DeclaringType!.FullName, baseMethod.Name),
+        throw new ArgumentException (string.Format ("The given method {0}.{1} is abstract.", baseMethod.DeclaringType!.GetFullNameSafe(), baseMethod.Name),
             "baseMethod");
       
       AddDelegatingCallStatements (baseMethod, new TypeReferenceWrapper (SelfReference.Self, _declaringType.TypeBuilder), false);

--- a/Remotion/Core/Reflection.CodeGeneration/DPExtensions/PropertyReference.cs
+++ b/Remotion/Core/Reflection.CodeGeneration/DPExtensions/PropertyReference.cs
@@ -52,7 +52,7 @@ namespace Remotion.Reflection.CodeGeneration.DPExtensions
       MethodInfo? getMethod = Reference.GetGetMethod(true);
       if (getMethod == null)
       {
-        string message = string.Format("The property {0}.{1} cannot be loaded, it has no getter.", Reference.DeclaringType!.FullName, Reference.Name);
+        string message = string.Format("The property {0}.{1} cannot be loaded, it has no getter.", Reference.DeclaringType!.GetFullNameSafe(), Reference.Name);
         throw new InvalidOperationException (message);
       }
       if (getMethod.IsStatic)
@@ -70,7 +70,7 @@ namespace Remotion.Reflection.CodeGeneration.DPExtensions
       MethodInfo? setMethod = Reference.GetSetMethod (true);
       if (setMethod == null)
       {
-        string message = string.Format ("The property {0}.{1} cannot be stored, it has no setter.", Reference.DeclaringType!.FullName, Reference.Name);
+        string message = string.Format ("The property {0}.{1} cannot be stored, it has no setter.", Reference.DeclaringType!.GetFullNameSafe(), Reference.Name);
         throw new InvalidOperationException (message);
       }
       if (setMethod.IsStatic)

--- a/Remotion/Core/Reflection/ReflectionBasedMemberInformationNameResolver.cs
+++ b/Remotion/Core/Reflection/ReflectionBasedMemberInformationNameResolver.cs
@@ -95,7 +95,7 @@ namespace Remotion.Reflection
 
     private string GetEnumNameInternal (Enum enumValue)
     {
-      return enumValue.GetType().FullName + "." + enumValue;
+      return enumValue.GetType().GetFullNameChecked() + "." + enumValue;
     }
   }
 }

--- a/Remotion/Core/Reflection/TypeAdapter.cs
+++ b/Remotion/Core/Reflection/TypeAdapter.cs
@@ -152,7 +152,7 @@ namespace Remotion.Reflection
     public ITypeInformation GetUnderlyingTypeOfEnum ()
     {
       if (!_type.IsEnum)
-        throw new InvalidOperationException (string.Format ("The type '{0}' is not an enum type.", _type.FullName));
+        throw new InvalidOperationException (string.Format ("The type '{0}' is not an enum type.", _type.GetFullNameSafe()));
       return TypeAdapter.Create (Enum.GetUnderlyingType (_type));
     }
 
@@ -165,7 +165,7 @@ namespace Remotion.Reflection
     {
       var underlyingType = Nullable.GetUnderlyingType (_type);
       if (underlyingType == null)
-        throw new InvalidOperationException (string.Format ("The type '{0}' is not a nullable value type.", _type.FullName));
+        throw new InvalidOperationException (string.Format ("The type '{0}' is not a nullable value type.", _type.GetFullNameSafe()));
       return TypeAdapter.Create (underlyingType);
     }
 

--- a/Remotion/Core/Tools/AppDomainAssemblyResolver.cs
+++ b/Remotion/Core/Tools/AppDomainAssemblyResolver.cs
@@ -17,6 +17,7 @@
 using System;
 using System.IO;
 using System.Reflection;
+using Remotion.Reflection;
 using Remotion.Utilities;
 
 namespace Remotion.Tools
@@ -94,11 +95,11 @@ namespace Remotion.Tools
 
     private string? GetAssemblyLocation (AssemblyName assemblyName)
     {
-      var dllLocation = Path.Combine (_assemblyDirectory, assemblyName.Name + ".dll");
+      var dllLocation = Path.Combine (_assemblyDirectory, assemblyName.GetNameChecked() + ".dll");
       if (File.Exists (dllLocation))
         return dllLocation;
 
-      var exeLocation = Path.Combine (_assemblyDirectory, assemblyName.Name + ".exe");
+      var exeLocation = Path.Combine (_assemblyDirectory, assemblyName.GetNameChecked() + ".exe");
       if (File.Exists (exeLocation))
         return exeLocation;
 

--- a/Remotion/Core/Tools/AppDomainAssemblyResolver.cs
+++ b/Remotion/Core/Tools/AppDomainAssemblyResolver.cs
@@ -39,7 +39,7 @@ namespace Remotion.Tools
       // TODO RM-7761: null guard should be added.
       return (AppDomainAssemblyResolver) appDomain.CreateInstanceFromAndUnwrap (
                                              typeof (AppDomainAssemblyResolver).Assembly.Location,
-                                             typeof (AppDomainAssemblyResolver).FullName!,
+                                             typeof (AppDomainAssemblyResolver).GetFullNameChecked(),
                                              false,
                                              BindingFlags.Public | BindingFlags.Instance,
                                              null,

--- a/Remotion/Core/Tools/Console/CommandLine/CommandLineAttributes.cs
+++ b/Remotion/Core/Tools/Console/CommandLine/CommandLineAttributes.cs
@@ -17,6 +17,7 @@
 using System;
 using System.Collections;
 using System.Reflection;
+using Remotion.Reflection;
 using Remotion.Utilities;
 
 namespace Remotion.Tools.Console.CommandLine
@@ -207,7 +208,7 @@ namespace Remotion.Tools.Console.CommandLine
       {
         throw new ApplicationException (
             string.Format (
-                "Attribute {0} can only be applied to enumeration fields or properties.", typeof (CommandLineEnumArgumentAttribute).FullName));
+                "Attribute {0} can only be applied to enumeration fields or properties.", typeof (CommandLineEnumArgumentAttribute).GetFullNameSafe()));
       }
       ((CommandLineEnumArgument) Argument).EnumType = enumType;
     }
@@ -235,7 +236,7 @@ namespace Remotion.Tools.Console.CommandLine
       {
         throw new ApplicationException (
             string.Format (
-                "Attribute {0} can only be applied to enumeration fields or properties.", typeof (CommandLineEnumArgumentAttribute).FullName));
+                "Attribute {0} can only be applied to enumeration fields or properties.", typeof (CommandLineEnumArgumentAttribute).GetFullNameSafe()));
       }
 
       Argument.EnumType = _enumType;

--- a/Remotion/Core/Tools/Console/CommandLine/CommandLineReflectionUtility.cs
+++ b/Remotion/Core/Tools/Console/CommandLine/CommandLineReflectionUtility.cs
@@ -16,6 +16,7 @@
 // 
 using System;
 using System.Reflection;
+using Remotion.Reflection;
 
 namespace Remotion.Tools.Console.CommandLine
 {
@@ -33,7 +34,7 @@ namespace Remotion.Tools.Console.CommandLine
       else if (fieldOrProperty is PropertyInfo)
         ((PropertyInfo) fieldOrProperty).SetValue (obj, value, new object[0]);
       else
-        throw new ArgumentException (String.Format ("Argument must be either FieldInfo or PropertyInfo but is {0}.", fieldOrProperty.GetType ().FullName), "fieldOrProperty");
+        throw new ArgumentException (String.Format ("Argument must be either FieldInfo or PropertyInfo but is {0}.", fieldOrProperty.GetType ().GetFullNameSafe()), "fieldOrProperty");
     }
 
     public static Type GetFieldOrPropertyType (MemberInfo fieldOrProperty)

--- a/Remotion/Core/Tools/Console/ConsoleApplication/ConsoleApplication.cs
+++ b/Remotion/Core/Tools/Console/ConsoleApplication/ConsoleApplication.cs
@@ -17,6 +17,7 @@
 using System;
 using System.Diagnostics;
 using System.IO;
+using Remotion.Reflection;
 using Remotion.Tools.Console.CommandLine;
 
 namespace Remotion.Tools.Console.ConsoleApplication
@@ -148,7 +149,7 @@ namespace Remotion.Tools.Console.ConsoleApplication
           _errorWriter.WriteLine ("Execution aborted. Exception stack:");
           for (; e != null; e = e.InnerException)
           {
-            _errorWriter.Write (e.GetType ().FullName);
+            _errorWriter.Write (e.GetType ().GetFullNameSafe());
             _errorWriter.Write (": ");
             _errorWriter.WriteLine (e.Message);
             _errorWriter.WriteLine (e.StackTrace);

--- a/Remotion/Core/Xml/SchemaLoaderBase.cs
+++ b/Remotion/Core/Xml/SchemaLoaderBase.cs
@@ -19,6 +19,7 @@ using System.IO;
 using System.Reflection;
 using System.Xml;
 using System.Xml.Schema;
+using Remotion.Reflection;
 
 namespace Remotion.Xml
 {
@@ -47,7 +48,7 @@ namespace Remotion.Xml
       using (Stream? schemaStream = assembly.GetManifestResourceStream (type, schemaFileName))
       {
         if (schemaStream == null)
-          throw new ApplicationException (string.Format ("Error loading schema resource '{0}' from assembly '{1}'.", schemaFileName, assembly.FullName));
+          throw new ApplicationException (string.Format ("Error loading schema resource '{0}' from assembly '{1}'.", schemaFileName, assembly.GetFullNameSafe()));
 
         using (XmlReader xmlReader = XmlReader.Create (schemaStream))
         {

--- a/Remotion/Core/Xml/XmlSerializationUtility.cs
+++ b/Remotion/Core/Xml/XmlSerializationUtility.cs
@@ -18,6 +18,7 @@ using System;
 using System.Xml;
 using System.Xml.Schema;
 using System.Xml.Serialization;
+using Remotion.Reflection;
 using Remotion.Utilities;
 
 namespace Remotion.Xml
@@ -118,7 +119,7 @@ namespace Remotion.Xml
         throw new ArgumentException (
             string.Format (
                 "Cannot determine the xml namespace of type '{0}' because no neither an XmlTypeAttribute nor an XmlRootAttribute has been provided.",
-                type.FullName),
+                type.GetFullNameSafe()),
             "type");
       }
 
@@ -129,7 +130,7 @@ namespace Remotion.Xml
         throw new ArgumentException (
             string.Format (
                 "Cannot determine the xml namespace of type '{0}' because neither an XmlTypeAttribute nor an XmlRootAttribute is used to define a namespace for the type.",
-                type.FullName),
+                type.GetFullNameSafe()),
             "type");
       }
 

--- a/Remotion/Data/DomainObjects.ObjectBinding/BindableDomainObjectSearchAllService.cs
+++ b/Remotion/Data/DomainObjects.ObjectBinding/BindableDomainObjectSearchAllService.cs
@@ -21,6 +21,7 @@ using System.Reflection;
 using Remotion.Data.DomainObjects.Queries;
 using Remotion.ObjectBinding;
 using Remotion.ObjectBinding.BindableObject;
+using Remotion.Reflection;
 using Remotion.Utilities;
 using Remotion.Utilities.ReSharperAnnotations;
 
@@ -102,7 +103,7 @@ namespace Remotion.Data.DomainObjects.ObjectBinding
     [ReflectionAPI]
     private IQuery GetQuery<T> () where T : DomainObject
     {
-      return s_queryCache.GetQuery<T> (typeof (T).AssemblyQualifiedName, source => from x in source select x);
+      return s_queryCache.GetQuery<T> (typeof (T).GetAssemblyQualifiedNameChecked(), source => from x in source select x);
     }
   }
 }

--- a/Remotion/Data/DomainObjects.ObjectBinding/BindableDomainObjectSearchAllService.cs
+++ b/Remotion/Data/DomainObjects.ObjectBinding/BindableDomainObjectSearchAllService.cs
@@ -91,7 +91,7 @@ namespace Remotion.Data.DomainObjects.ObjectBinding
       if (!_bindableObjectTypeCache.GetOrAdd (type, BindableObjectProvider.IsBindableObjectImplementation))
       {
         var message = string.Format ("This service only supports queries for bindable DomainObject types, the given type '{0}' is not a bindable "
-            + "type. Derive from BindableDomainObject or apply the BindableDomainObjectAttribute.", type.FullName);
+            + "type. Derive from BindableDomainObject or apply the BindableDomainObjectAttribute.", type.GetFullNameSafe());
         throw new ArgumentException (message, "type");
       }
 

--- a/Remotion/Data/DomainObjects.RdbmsTools/Program.cs
+++ b/Remotion/Data/DomainObjects.RdbmsTools/Program.cs
@@ -15,6 +15,7 @@
 // along with re-motion; if not, see http://www.gnu.org/licenses.
 // 
 using System;
+using Remotion.Reflection;
 using Remotion.Tools.Console.CommandLine;
 
 namespace Remotion.Data.DomainObjects.RdbmsTools
@@ -48,7 +49,7 @@ namespace Remotion.Data.DomainObjects.RdbmsTools
         {
           System.Console.Error.WriteLine ("Execution aborted. Exception stack:");
           for (; e != null; e = e.InnerException)
-            System.Console.Error.WriteLine ("{0}: {1}\n{2}", e.GetType().FullName, e.Message, e.StackTrace);
+            System.Console.Error.WriteLine ("{0}: {1}\n{2}", e.GetType().GetFullNameSafe(), e.Message, e.StackTrace);
         }
         else
         {

--- a/Remotion/Data/DomainObjects.Security/SecurityClientTransactionExtension.cs
+++ b/Remotion/Data/DomainObjects.Security/SecurityClientTransactionExtension.cs
@@ -42,7 +42,7 @@ namespace Remotion.Data.DomainObjects.Security
 
     public static string DefaultKey
     {
-      get { return typeof (SecurityClientTransactionExtension).FullName; }
+      get { return typeof (SecurityClientTransactionExtension).GetFullNameChecked(); }
     }
 
     [NonSerialized]

--- a/Remotion/Data/DomainObjects.UberProfIntegration/LateBoundDelegateFactory.cs
+++ b/Remotion/Data/DomainObjects.UberProfIntegration/LateBoundDelegateFactory.cs
@@ -17,6 +17,7 @@
 using System;
 using System.Linq;
 using System.Reflection;
+using Remotion.Reflection;
 using Remotion.Utilities;
 
 namespace Remotion.Data.DomainObjects.UberProfIntegration
@@ -67,7 +68,7 @@ namespace Remotion.Data.DomainObjects.UberProfIntegration
       return new MissingMethodException (
           String.Format (
               "Type {0} does not define a method {3} {1}({2}).",
-              targetType.AssemblyQualifiedName,
+              targetType.GetAssemblyQualifiedNameSafe(),
               methodName,
               string.Join (", ", parameters),
               returnType == typeof (void) ? "void" : returnType.FullName),

--- a/Remotion/Data/DomainObjects.UberProfIntegration/LateBoundDelegateFactory.cs
+++ b/Remotion/Data/DomainObjects.UberProfIntegration/LateBoundDelegateFactory.cs
@@ -71,7 +71,7 @@ namespace Remotion.Data.DomainObjects.UberProfIntegration
               targetType.GetAssemblyQualifiedNameSafe(),
               methodName,
               string.Join (", ", parameters),
-              returnType == typeof (void) ? "void" : returnType.FullName),
+              returnType == typeof (void) ? "void" : returnType.GetFullNameSafe()),
           innerException);
     }
   }

--- a/Remotion/Data/DomainObjects.UberProfIntegration/LinqToSqlExtension.cs
+++ b/Remotion/Data/DomainObjects.UberProfIntegration/LinqToSqlExtension.cs
@@ -23,6 +23,7 @@ using Remotion.Data.DomainObjects.Infrastructure.ObjectPersistence;
 using Remotion.Data.DomainObjects.Mapping;
 using Remotion.Data.DomainObjects.Queries;
 using Remotion.Data.DomainObjects.Tracing;
+using Remotion.Reflection;
 using Remotion.Utilities;
 
 namespace Remotion.Data.DomainObjects.UberProfIntegration
@@ -176,7 +177,7 @@ namespace Remotion.Data.DomainObjects.UberProfIntegration
 
     public string Key
     {
-      get { return typeof (LinqToSqlExtension).FullName; }
+      get { return typeof (LinqToSqlExtension).GetFullNameChecked(); }
     }
 
     public void TransactionInitialize (ClientTransaction clientTransaction)

--- a/Remotion/Data/DomainObjects.Validation/DomainObjectAttributesBasedValidationRuleCollectorProvider.cs
+++ b/Remotion/Data/DomainObjects.Validation/DomainObjectAttributesBasedValidationRuleCollectorProvider.cs
@@ -114,7 +114,7 @@ namespace Remotion.Data.DomainObjects.Validation
         if (annotatedPropertiesSet.Any (p => !interfaceImplementations.Contains (p)))
         {
           throw new InvalidOperationException (
-              string.Format ("Annotated properties of mixin '{0}' have to be part of an interface.", annotatedType.FullName));
+              string.Format ("Annotated properties of mixin '{0}' have to be part of an interface.", annotatedType.GetFullNameSafe()));
         }
 
         var interfacePropertyMappingsForAnnotatedProperties = interfacePropertyMappings

--- a/Remotion/Data/DomainObjects.Validation/ValidationClientTransactionExtension.cs
+++ b/Remotion/Data/DomainObjects.Validation/ValidationClientTransactionExtension.cs
@@ -19,6 +19,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using Remotion.Data.DomainObjects.Infrastructure.ObjectPersistence;
+using Remotion.Reflection;
 using Remotion.Utilities;
 using Remotion.Validation;
 using Remotion.Validation.Results;
@@ -31,7 +32,7 @@ namespace Remotion.Data.DomainObjects.Validation
 
     public static string DefaultKey
     {
-      get { return typeof (ValidationClientTransactionExtension).FullName; }
+      get { return typeof (ValidationClientTransactionExtension).GetFullNameChecked(); }
     }
 
     public ValidationClientTransactionExtension (IValidatorProvider validatorProvider)
@@ -98,7 +99,7 @@ namespace Remotion.Data.DomainObjects.Validation
       var domainObject = validatedInstance as DomainObject;
       if (domainObject != null)
         return string.Format ("Object '{0}' with ID '{1}':", domainObject.ID.ClassID, domainObject.ID.Value);
-      return string.Format ("Validation error on object of Type '{0}':", validatedInstance.GetType ().FullName);
+      return string.Format ("Validation error on object of Type '{0}':", validatedInstance.GetType ().GetFullNameSafe());
     }
 
     private List<ValidationResult> Validate (IReadOnlyList<PersistableData> domainObjectsToValidate, Dictionary<Type, IValidator> validatorCache)

--- a/Remotion/Data/DomainObjects/ConfigurationLoader/ReflectionBasedConfigurationLoader/MappingReflector.cs
+++ b/Remotion/Data/DomainObjects/ConfigurationLoader/ReflectionBasedConfigurationLoader/MappingReflector.cs
@@ -136,7 +136,7 @@ namespace Remotion.Data.DomainObjects.ConfigurationLoader.ReflectionBasedConfigu
 
     private Type[] GetDomainObjectTypesSorted ()
     {
-      return GetDomainObjectTypes().OrderBy (t => t.FullName, StringComparer.OrdinalIgnoreCase).ToArray();
+      return GetDomainObjectTypes().OrderBy (t => t.GetFullNameChecked(), StringComparer.OrdinalIgnoreCase).ToArray();
     }
 
     bool IMappingLoader.ResolveTypes

--- a/Remotion/Data/DomainObjects/ConfigurationLoader/ReflectionBasedConfigurationLoader/RelationReflector.cs
+++ b/Remotion/Data/DomainObjects/ConfigurationLoader/ReflectionBasedConfigurationLoader/RelationReflector.cs
@@ -55,12 +55,12 @@ namespace Remotion.Data.DomainObjects.ConfigurationLoader.ReflectionBasedConfigu
 
       if (endPoints.Right.IsAnonymous)
       {
-        return string.Format ("{0}:{1}", endPoints.Left.ClassDefinition.ClassType.FullName, leftPropertyName);
+        return string.Format ("{0}:{1}", endPoints.Left.ClassDefinition.ClassType.GetFullNameChecked(), leftPropertyName);
       }
       else
       {
         var rightPropertyName = NameResolver.GetPropertyName (endPoints.Right.PropertyInfo);
-        return string.Format ("{0}:{1}->{2}", endPoints.Left.ClassDefinition.ClassType.FullName, leftPropertyName, rightPropertyName);
+        return string.Format ("{0}:{1}->{2}", endPoints.Left.ClassDefinition.ClassType.GetFullNameChecked(), leftPropertyName, rightPropertyName);
       }
     }
 

--- a/Remotion/Data/DomainObjects/DataManagement/PropertyValue.cs
+++ b/Remotion/Data/DomainObjects/DataManagement/PropertyValue.cs
@@ -18,6 +18,7 @@ using System;
 using System.Collections;
 using Remotion.Data.DomainObjects.Infrastructure.Serialization;
 using Remotion.Data.DomainObjects.Mapping;
+using Remotion.Reflection;
 using Remotion.Utilities;
 
 namespace Remotion.Data.DomainObjects.DataManagement
@@ -77,7 +78,7 @@ namespace Remotion.Data.DomainObjects.DataManagement
       {
         var message = string.Format ("The property '{0}' (declared on class '{1}') is invalid because its values cannot be copied. Only value types, "
             + "strings, the Type type, byte arrays, types implementing IStructualEquatable, and ObjectIDs are currently supported, but the property's type is '{2}'.",
-            definition.PropertyName, definition.ClassDefinition.ID, definition.PropertyType.FullName);
+            definition.PropertyName, definition.ClassDefinition.ID, definition.PropertyType.GetFullNameSafe());
         throw new NotSupportedException (message);
       }
 

--- a/Remotion/Data/DomainObjects/DataManagement/RelationEndPoints/RelationEndPointManager.cs
+++ b/Remotion/Data/DomainObjects/DataManagement/RelationEndPoints/RelationEndPointManager.cs
@@ -21,6 +21,7 @@ using Remotion.Data.DomainObjects.DataManagement.Commands;
 using Remotion.Data.DomainObjects.Infrastructure;
 using Remotion.Data.DomainObjects.Infrastructure.Serialization;
 using Remotion.Data.DomainObjects.Mapping;
+using Remotion.Reflection;
 using Remotion.Utilities;
 
 namespace Remotion.Data.DomainObjects.DataManagement.RelationEndPoints
@@ -48,7 +49,7 @@ namespace Remotion.Data.DomainObjects.DataManagement.RelationEndPoints
       Assertion.IsTrue (
           endPointDefinition.Cardinality == CardinalityType.One && !endPointDefinition.IsVirtual,
           "The end point definition of type '{0}' cannot be mapped to a null object.",
-          endPointDefinition.GetType().FullName);
+          endPointDefinition.GetType().GetFullNameSafe());
 
       return new NullRealObjectEndPoint (clientTransaction, endPointDefinition);
     }

--- a/Remotion/Data/DomainObjects/DomainImplementation/Transport/XmlTransportItem.cs
+++ b/Remotion/Data/DomainObjects/DomainImplementation/Transport/XmlTransportItem.cs
@@ -21,6 +21,7 @@ using System.Xml.Schema;
 using System.Xml.Serialization;
 using Remotion.Data.DomainObjects.Mapping;
 using Remotion.ExtensibleEnums;
+using Remotion.Reflection;
 using Remotion.Utilities;
 
 namespace Remotion.Data.DomainObjects.DomainImplementation.Transport
@@ -186,7 +187,7 @@ namespace Remotion.Data.DomainObjects.DomainImplementation.Transport
       else if (IsObjectID (valueType))
         writer.WriteAttributeString ("Type", "ObjectID");
       else
-        writer.WriteAttributeString ("Type", valueType.AssemblyQualifiedName);
+        writer.WriteAttributeString ("Type", valueType.GetAssemblyQualifiedNameChecked());
       
       return valueType;
     }

--- a/Remotion/Data/DomainObjects/DomainObject.cs
+++ b/Remotion/Data/DomainObjects/DomainObject.cs
@@ -22,6 +22,7 @@ using Remotion.Data.DomainObjects.DataManagement;
 using Remotion.Data.DomainObjects.DomainImplementation;
 using Remotion.Data.DomainObjects.Infrastructure;
 using Remotion.Data.DomainObjects.Infrastructure.ObjectLifetime;
+using Remotion.Reflection;
 using Remotion.TypePipe;
 using Remotion.Utilities;
 
@@ -252,7 +253,7 @@ namespace Remotion.Data.DomainObjects
         // ReSharper restore DoNotCallOverridableMethodsInConstructor
         string message = String.Format (
             "The GetObjectData method on type {0} did not call DomainObject's BaseGetObjectData method.",
-            publicDomainObjectType.FullName);
+            publicDomainObjectType.GetFullNameSafe());
         throw new SerializationException (message, ex);
       }
     }

--- a/Remotion/Data/DomainObjects/Infrastructure/DomainObjectMixinCodeGenerationBridge.cs
+++ b/Remotion/Data/DomainObjects/Infrastructure/DomainObjectMixinCodeGenerationBridge.cs
@@ -18,6 +18,7 @@ using System;
 using System.Reflection;
 using System.Runtime.Serialization;
 using Remotion.Mixins;
+using Remotion.Reflection;
 using Remotion.Utilities;
 
 namespace Remotion.Data.DomainObjects.Infrastructure
@@ -46,7 +47,7 @@ namespace Remotion.Data.DomainObjects.Infrastructure
         }
         catch (MissingMethodException ex)
         {
-          throw new MissingMethodException ("No deserialization constructor was found on type " + concreteDeserializedType.FullName + ".", ex);
+          throw new MissingMethodException ("No deserialization constructor was found on type " + concreteDeserializedType.GetFullNameSafe() + ".", ex);
         }
       }
 

--- a/Remotion/Data/DomainObjects/Infrastructure/LoggingClientTransactionListener.cs
+++ b/Remotion/Data/DomainObjects/Infrastructure/LoggingClientTransactionListener.cs
@@ -23,6 +23,7 @@ using Remotion.Data.DomainObjects.Infrastructure.ObjectPersistence;
 using Remotion.Data.DomainObjects.Mapping;
 using Remotion.Data.DomainObjects.Queries;
 using Remotion.Logging;
+using Remotion.Reflection;
 
 namespace Remotion.Data.DomainObjects.Infrastructure
 {
@@ -67,7 +68,7 @@ namespace Remotion.Data.DomainObjects.Infrastructure
     public void NewObjectCreating (ClientTransaction clientTransaction, Type type)
     {
       if (s_log.IsDebugEnabled())
-        s_log.DebugFormat ("{0} NewObjectCreating: {1}", clientTransaction.ID, type.FullName);
+        s_log.DebugFormat ("{0} NewObjectCreating: {1}", clientTransaction.ID, type.GetFullNameSafe());
     }
 
     public void ObjectsLoading (ClientTransaction clientTransaction, IReadOnlyList<ObjectID> objectIDs)

--- a/Remotion/Data/DomainObjects/Infrastructure/ObjectIDStringSerialization/ObjectIDStringSerializer.cs
+++ b/Remotion/Data/DomainObjects/Infrastructure/ObjectIDStringSerialization/ObjectIDStringSerializer.cs
@@ -17,6 +17,7 @@
 using System;
 using System.Text;
 using Remotion.Data.DomainObjects.Mapping;
+using Remotion.Reflection;
 using Remotion.Utilities;
 
 namespace Remotion.Data.DomainObjects.Infrastructure.ObjectIDStringSerialization
@@ -32,9 +33,9 @@ namespace Remotion.Data.DomainObjects.Infrastructure.ObjectIDStringSerialization
     public static readonly ObjectIDStringSerializer Instance = new ObjectIDStringSerializer();
 
     private static readonly string s_delimiterAsString = Delimiter.ToString();
-    private static readonly string s_delimitedGuidTypeName = Delimiter + typeof (Guid).FullName;
-    private static readonly string s_delimitedInt32TypeName = Delimiter + typeof (Int32).FullName;
-    private static readonly string s_delimitedStringTypeName = Delimiter + typeof (String).FullName;
+    private static readonly string s_delimitedGuidTypeName = Delimiter + typeof (Guid).GetFullNameChecked();
+    private static readonly string s_delimitedInt32TypeName = Delimiter + typeof (Int32).GetFullNameChecked();
+    private static readonly string s_delimitedStringTypeName = Delimiter + typeof (String).GetFullNameChecked();
 
     private ObjectIDStringSerializer ()
     {
@@ -169,7 +170,7 @@ namespace Remotion.Data.DomainObjects.Infrastructure.ObjectIDStringSerialization
       else if (value is String)
         return s_delimitedStringTypeName;
       else
-        throw new FormatException (string.Format ("ObjectIDs with a value of type '{0}' are not supported.", value.GetType().FullName));
+        throw new FormatException (string.Format ("ObjectIDs with a value of type '{0}' are not supported.", value.GetType().GetFullNameSafe()));
     }
   }
 }

--- a/Remotion/Data/DomainObjects/Infrastructure/PropertyAccessorData.cs
+++ b/Remotion/Data/DomainObjects/Infrastructure/PropertyAccessorData.cs
@@ -16,6 +16,7 @@
 // 
 using System;
 using Remotion.Data.DomainObjects.Mapping;
+using Remotion.Reflection;
 using Remotion.Utilities;
 
 namespace Remotion.Data.DomainObjects.Infrastructure
@@ -107,7 +108,7 @@ namespace Remotion.Data.DomainObjects.Infrastructure
       {
         string message = String.Format (
             "The domain object type {0} does not have a mapping property named '{1}'.",
-            classDefinition.ClassType.FullName,
+            classDefinition.ClassType.GetFullNameSafe(),
             propertyIdentifier);
 
         throw new ArgumentException (message, "propertyIdentifier");

--- a/Remotion/Data/DomainObjects/Infrastructure/PropertyIndexer.cs
+++ b/Remotion/Data/DomainObjects/Infrastructure/PropertyIndexer.cs
@@ -20,6 +20,7 @@ using System.Collections.Generic;
 using System.Linq;
 using JetBrains.Annotations;
 using Remotion.Data.DomainObjects.Mapping;
+using Remotion.Reflection;
 using Remotion.Utilities;
 
 namespace Remotion.Data.DomainObjects.Infrastructure
@@ -242,7 +243,7 @@ namespace Remotion.Data.DomainObjects.Infrastructure
       {
         var message = string.Format (
             "The domain object type '{0}' does not have or inherit a mapping property with the short name '{1}'.",
-            typeToStartSearch.FullName,
+            typeToStartSearch.GetFullNameSafe(),
             shortPropertyName);
         throw new ArgumentException (message, "shortPropertyName");
       }

--- a/Remotion/Data/DomainObjects/Infrastructure/Serialization/FlattenedDeserializationInfo.cs
+++ b/Remotion/Data/DomainObjects/Infrastructure/Serialization/FlattenedDeserializationInfo.cs
@@ -20,6 +20,7 @@ using System.Collections.Generic;
 using System.Linq.Expressions;
 using System.Reflection;
 using System.Runtime.Serialization;
+using Remotion.Reflection;
 using Remotion.Utilities;
 
 namespace Remotion.Data.DomainObjects.Infrastructure.Serialization
@@ -126,13 +127,13 @@ namespace Remotion.Data.DomainObjects.Infrastructure.Serialization
       catch (InvalidCastException ex)
       {
         string message = string.Format ("{0} stream: The serialization stream contains an object of type {1} at position {2}, but an object of "
-            + "type {3} was expected.", streamName, uncastValue.GetType ().FullName, originalPosition, typeof (T).FullName);
+            + "type {3} was expected.", streamName, uncastValue.GetType ().GetFullNameSafe(), originalPosition, typeof (T).GetFullNameSafe());
         throw new SerializationException (message, ex);
       }
       catch (NullReferenceException ex)
       {
         string message = string.Format ("{0} stream: The serialization stream contains a null value at position {1}, but an object of type {2} was "
-            + "expected.", streamName, originalPosition, typeof (T).FullName);
+            + "expected.", streamName, originalPosition, typeof (T).GetFullNameSafe());
         throw new SerializationException (message, ex);
       }
       return value;

--- a/Remotion/Data/DomainObjects/Infrastructure/TypePipe/DomainObjectCreator.cs
+++ b/Remotion/Data/DomainObjects/Infrastructure/TypePipe/DomainObjectCreator.cs
@@ -18,6 +18,7 @@ using System;
 using System.Runtime.Serialization;
 using Remotion.Data.DomainObjects.Infrastructure.ObjectLifetime;
 using Remotion.Data.DomainObjects.Mapping;
+using Remotion.Reflection;
 using Remotion.ServiceLocation;
 using Remotion.TypePipe;
 using Remotion.TypePipe.Implementation;
@@ -101,7 +102,7 @@ namespace Remotion.Data.DomainObjects.Infrastructure.TypePipe
     {
       if (domainObjectType.IsSealed)
       {
-        var message = string.Format ("Cannot instantiate type '{0}' as it is sealed.", domainObjectType.FullName);
+        var message = string.Format ("Cannot instantiate type '{0}' as it is sealed.", domainObjectType.GetFullNameSafe());
         throw new NonInterceptableTypeException (message, domainObjectType);
       }
 
@@ -110,7 +111,7 @@ namespace Remotion.Data.DomainObjects.Infrastructure.TypePipe
       {
         var message1 = string.Format (
             "Cannot instantiate type '{0}' as it is abstract; for classes with automatic properties, InstantiableAttribute must be used.",
-            classDefinition.ClassType.FullName);
+            classDefinition.ClassType.GetFullNameSafe());
         throw new NonInterceptableTypeException (message1, classDefinition.ClassType);
       }
     }

--- a/Remotion/Data/DomainObjects/Infrastructure/TypePipe/InterceptedPropertyCollector.cs
+++ b/Remotion/Data/DomainObjects/Infrastructure/TypePipe/InterceptedPropertyCollector.cs
@@ -58,7 +58,7 @@ namespace Remotion.Data.DomainObjects.Infrastructure.TypePipe
       if (_classDefinition.IsAbstract)
       {
         throw new NonInterceptableTypeException (
-            string.Format ("Cannot instantiate type {0} as it is abstract and not instantiable.", _baseType.FullName),
+            string.Format ("Cannot instantiate type {0} as it is abstract and not instantiable.", _baseType.GetFullNameSafe()),
             _baseType);
       }
 
@@ -138,7 +138,7 @@ namespace Remotion.Data.DomainObjects.Infrastructure.TypePipe
         var message = string.Format (
             "Cannot instantiate type '{0}' because the mixin member '{1}.{2}' is an automatic property. "
             + "Mixins must implement their persistent members by using 'Properties' to get and set property values.",
-            _baseType.FullName,
+            _baseType.GetFullNameSafe(),
             property.DeclaringType.Name,
             property.Name);
         throw new NonInterceptableTypeException (message, _baseType);
@@ -150,7 +150,7 @@ namespace Remotion.Data.DomainObjects.Infrastructure.TypePipe
       if (IsAutomaticPropertyAccessor (accessor) && !IsOverridable (accessor))
       {
         string message = string.Format ("Cannot instantiate type '{0}' as its member '{1}' has a non-virtual {2}.",
-            _baseType.FullName, property.Name, accessorDescription);
+            _baseType.GetFullNameSafe(), property.Name, accessorDescription);
         throw new NonInterceptableTypeException (message, _baseType);
       }
     }
@@ -158,7 +158,7 @@ namespace Remotion.Data.DomainObjects.Infrastructure.TypePipe
     private void ValidateBaseType ()
     {
       if (_baseType.IsSealed)
-        throw new NonInterceptableTypeException (string.Format ("Cannot instantiate type {0} as it is sealed.", _baseType.FullName), _baseType);
+        throw new NonInterceptableTypeException (string.Format ("Cannot instantiate type {0} as it is sealed.", _baseType.GetFullNameSafe()), _baseType);
     }
 
     private void ValidateRemainingMethods (Type currentType)
@@ -169,7 +169,7 @@ namespace Remotion.Data.DomainObjects.Infrastructure.TypePipe
           throw new NonInterceptableTypeException (
               string.Format (
                   "Cannot instantiate type {0} as its member {1} (on type {2}) is abstract (and not an automatic property).",
-                  _baseType.FullName,
+                  _baseType.GetFullNameSafe(),
                   method.Name,
                   currentType.Name),
               _baseType);

--- a/Remotion/Data/DomainObjects/Linq/DomainObjectQueryGenerator.cs
+++ b/Remotion/Data/DomainObjects/Linq/DomainObjectQueryGenerator.cs
@@ -283,7 +283,7 @@ namespace Remotion.Data.DomainObjects.Linq
         Assertion.IsNotNull (propertyInfo.DeclaringType);
         var message = string.Format (
             "The property '{0}.{1}' is not a relation end point. Fetching it is not supported by this LINQ provider.",
-            propertyInfo.DeclaringType.FullName,
+            propertyInfo.DeclaringType.GetFullNameSafe(),
             propertyInfo.Name);
         throw new NotSupportedException (message);
       }

--- a/Remotion/Data/DomainObjects/Mapping/ClassDefinition.cs
+++ b/Remotion/Data/DomainObjects/Mapping/ClassDefinition.cs
@@ -29,7 +29,7 @@ using Remotion.Utilities;
 
 namespace Remotion.Data.DomainObjects.Mapping
 {
-  [DebuggerDisplay ("{GetType().Name} for {ClassType.FullName}")]
+  [DebuggerDisplay ("{GetType().Name} for {ClassType.GetFullNameSafe()}")]
   public class ClassDefinition
   {
     private readonly string _id;
@@ -420,7 +420,7 @@ namespace Remotion.Data.DomainObjects.Mapping
 
     public override string ToString ()
     {
-      return GetType().FullName + ": " + _id;
+      return GetType().GetFullNameChecked() + ": " + _id;
     }
 
     private MappingException CreateMappingException (string message, params object[] args)

--- a/Remotion/Data/DomainObjects/Mapping/MappingConfigurationValidationHelper.cs
+++ b/Remotion/Data/DomainObjects/Mapping/MappingConfigurationValidationHelper.cs
@@ -21,6 +21,7 @@ using System.Text;
 using Remotion.Data.DomainObjects.ConfigurationLoader;
 using Remotion.Data.DomainObjects.Mapping.Validation;
 using Remotion.Data.DomainObjects.Persistence.Model;
+using Remotion.Reflection;
 using Remotion.Utilities;
 
 namespace Remotion.Data.DomainObjects.Mapping
@@ -138,8 +139,8 @@ namespace Remotion.Data.DomainObjects.Mapping
             duplicates[0].ClassType.FullName,
             duplicates[1].ClassType.FullName,
             duplicates[0].ID,
-            duplicates[0].ClassType.Assembly.FullName,
-            duplicates[1].ClassType.Assembly.FullName);
+            duplicates[0].ClassType.Assembly.GetFullNameSafe(),
+            duplicates[1].ClassType.Assembly.GetFullNameSafe());
       }
     }
 

--- a/Remotion/Data/DomainObjects/Mapping/MappingConfigurationValidationHelper.cs
+++ b/Remotion/Data/DomainObjects/Mapping/MappingConfigurationValidationHelper.cs
@@ -136,8 +136,8 @@ namespace Remotion.Data.DomainObjects.Mapping
         throw CreateMappingException (
             "Class '{0}' and '{1}' both have the same class ID '{2}'. Use the ClassIDAttribute to define unique IDs for these "
             + "classes. The assemblies involved are '{3}' and '{4}'.",
-            duplicates[0].ClassType.FullName,
-            duplicates[1].ClassType.FullName,
+            duplicates[0].ClassType.GetFullNameSafe(),
+            duplicates[1].ClassType.GetFullNameSafe(),
             duplicates[0].ID,
             duplicates[0].ClassType.Assembly.GetFullNameSafe(),
             duplicates[1].ClassType.Assembly.GetFullNameSafe());

--- a/Remotion/Data/DomainObjects/Mapping/PersistentMixinFinder.cs
+++ b/Remotion/Data/DomainObjects/Mapping/PersistentMixinFinder.cs
@@ -142,7 +142,7 @@ namespace Remotion.Data.DomainObjects.Mapping
       if (suppressedMixin != null)
       {
         string message = string.Format ("Class '{0}' suppresses mixin '{1}' inherited from its base class '{2}'. This is not allowed because "
-            + "the mixin adds persistence information to the base class which must also be present in the derived class.", Type.FullName,
+            + "the mixin adds persistence information to the base class which must also be present in the derived class.", Type.GetFullNameSafe(),
             suppressedMixin.MixinType.Name, ParentClassContext.Type.Name);
         throw new MappingException (message);
       }
@@ -153,7 +153,7 @@ namespace Remotion.Data.DomainObjects.Mapping
       if (mixin.MixinType.ContainsGenericParameters)
       {
         string message = string.Format ("The persistence-relevant mixin {0} applied to class {1} has open generic type parameters. All type "
-            + "parameters of the mixin must be specified when it is applied to a DomainObject.", mixin.MixinType.FullName, Type.FullName);
+            + "parameters of the mixin must be specified when it is applied to a DomainObject.", mixin.MixinType.GetFullNameSafe(), Type.GetFullNameSafe());
         throw new MappingException (message);
       }
       else

--- a/Remotion/Data/DomainObjects/Mapping/PropertyAccessorDataCache.cs
+++ b/Remotion/Data/DomainObjects/Mapping/PropertyAccessorDataCache.cs
@@ -178,7 +178,7 @@ namespace Remotion.Data.DomainObjects.Mapping
     [NotNull]
     private string GetIdentifierFromTypeAndShortName ([NotNull] Type domainObjectType, [NotNull] string shortPropertyName)
     {
-      return domainObjectType.FullName + "." + shortPropertyName;
+      return domainObjectType.GetFullNameChecked() + "." + shortPropertyName;
     }
 
     private Dictionary<string, PropertyAccessorData> BuildAccessorDataDictionary ()

--- a/Remotion/Data/DomainObjects/Mapping/PropertyDefinition.cs
+++ b/Remotion/Data/DomainObjects/Mapping/PropertyDefinition.cs
@@ -114,7 +114,7 @@ namespace Remotion.Data.DomainObjects.Mapping
             throw new InvalidOperationException (
                 string.Format (
                     ".NET enum type '{0}' does not define any values. Properties based on this type must be declared as nullable.",
-                    _propertyType.FullName));
+                    _propertyType.GetFullNameSafe()));
           }
 
           return firstValueOrNull;
@@ -128,7 +128,7 @@ namespace Remotion.Data.DomainObjects.Mapping
             throw new InvalidOperationException (
                 string.Format (
                     "Extensible enum type '{0}' does not define any values. Properties based on this type must be declared as nullable.",
-                    _propertyType.FullName));
+                    _propertyType.GetFullNameSafe()));
           }
 
           return firstValueOrNull.Value;
@@ -181,7 +181,7 @@ namespace Remotion.Data.DomainObjects.Mapping
 
     public override string ToString ()
     {
-      return GetType ().FullName + ": " + _propertyName;
+      return GetType ().GetFullNameSafe() + ": " + _propertyName;
     }
   }
 }

--- a/Remotion/Data/DomainObjects/Mapping/Validation/Reflection/InheritanceHierarchyFollowsClassHierarchyValidationRule.cs
+++ b/Remotion/Data/DomainObjects/Mapping/Validation/Reflection/InheritanceHierarchyFollowsClassHierarchyValidationRule.cs
@@ -15,6 +15,7 @@
 // along with re-motion; if not, see http://www.gnu.org/licenses.
 // 
 using System;
+using Remotion.Reflection;
 
 namespace Remotion.Data.DomainObjects.Mapping.Validation.Reflection
 {
@@ -35,9 +36,9 @@ namespace Remotion.Data.DomainObjects.Mapping.Validation.Reflection
         return MappingValidationResult.CreateInvalidResultForType (
             classDefinition.BaseClass.ClassType,
             "Type '{0}' of class '{1}' is not derived from type '{2}' of base class '{3}'.",
-            classDefinition.ClassType.AssemblyQualifiedName,
+            classDefinition.ClassType.GetAssemblyQualifiedNameSafe(),
             classDefinition.ID,
-            classDefinition.BaseClass.ClassType.AssemblyQualifiedName,
+            classDefinition.BaseClass.ClassType.GetAssemblyQualifiedNameSafe(),
             classDefinition.BaseClass.ID);
       }
       return MappingValidationResult.CreateValidResult();

--- a/Remotion/Data/DomainObjects/ObjectID.cs
+++ b/Remotion/Data/DomainObjects/ObjectID.cs
@@ -19,6 +19,7 @@ using System.Runtime.Serialization;
 using Remotion.Data.DomainObjects.Infrastructure.ObjectIDStringSerialization;
 using Remotion.Data.DomainObjects.Mapping;
 using Remotion.Data.DomainObjects.Persistence.Configuration;
+using Remotion.Reflection;
 using Remotion.Utilities;
 
 namespace Remotion.Data.DomainObjects
@@ -195,7 +196,7 @@ namespace Remotion.Data.DomainObjects
         throw CreateArgumentException (
             "classDefinition",
             "An ObjectID cannot be constructed for abstract type '{0}' of class '{1}'.",
-            classDefinition.ClassType.AssemblyQualifiedName,
+            classDefinition.ClassType.GetAssemblyQualifiedNameSafe(),
             classDefinition.ID);
       }
 

--- a/Remotion/Data/DomainObjects/Persistence/NonPersistent/Validation/RelationPropertyStorageClassMatchesReferencedClassDefinitionStorageClassValidationRule.cs
+++ b/Remotion/Data/DomainObjects/Persistence/NonPersistent/Validation/RelationPropertyStorageClassMatchesReferencedClassDefinitionStorageClassValidationRule.cs
@@ -20,6 +20,7 @@ using System.Linq;
 using Remotion.Data.DomainObjects.Mapping;
 using Remotion.Data.DomainObjects.Mapping.Validation;
 using Remotion.Data.DomainObjects.Persistence.NonPersistent.Model;
+using Remotion.Reflection;
 using Remotion.Utilities;
 
 namespace Remotion.Data.DomainObjects.Persistence.NonPersistent.Validation
@@ -54,7 +55,7 @@ namespace Remotion.Data.DomainObjects.Persistence.NonPersistent.Validation
               relationEndPointDefinition.PropertyInfo,
               "The relation property is defined as persistent but the referenced type '{0}' is non-persistent. "
               + "Persistent relation properties may only reference persistent types.",
-              oppositeEndPointDefinition.ClassDefinition.ClassType.FullName);
+              oppositeEndPointDefinition.ClassDefinition.ClassType.GetFullNameSafe());
         }
       }
 

--- a/Remotion/Data/DomainObjects/Persistence/Rdbms/MappingExport/PropertySerializer.cs
+++ b/Remotion/Data/DomainObjects/Persistence/Rdbms/MappingExport/PropertySerializer.cs
@@ -17,6 +17,7 @@
 using System;
 using System.Xml.Linq;
 using Remotion.Data.DomainObjects.Mapping;
+using Remotion.Reflection;
 using Remotion.Utilities;
 
 namespace Remotion.Data.DomainObjects.Persistence.Rdbms.MappingExport
@@ -61,7 +62,7 @@ namespace Remotion.Data.DomainObjects.Persistence.Rdbms.MappingExport
     private string GetTypeName (Type propertyType)
     {
       if (propertyType.Assembly == typeof (int).Assembly)
-        return propertyType.FullName;
+        return propertyType.GetFullNameChecked();
 
       return TypeUtility.GetPartialAssemblyQualifiedName (propertyType);
     }

--- a/Remotion/Data/DomainObjects/Validation/CommitValidationClientTransactionExtension.cs
+++ b/Remotion/Data/DomainObjects/Validation/CommitValidationClientTransactionExtension.cs
@@ -18,6 +18,7 @@ using System;
 using System.Collections.Generic;
 using System.Runtime.Serialization;
 using Remotion.Data.DomainObjects.Infrastructure.ObjectPersistence;
+using Remotion.Reflection;
 using Remotion.ServiceLocation;
 using Remotion.Utilities;
 
@@ -34,7 +35,7 @@ namespace Remotion.Data.DomainObjects.Validation
   {
     public static string DefaultKey
     {
-      get { return typeof (CommitValidationClientTransactionExtension).FullName; }
+      get { return typeof (CommitValidationClientTransactionExtension).GetFullNameChecked(); }
     }
     
     [NonSerialized]

--- a/Remotion/Development/Web/UnitTesting/AspNetFramework/HttpContextHelper.cs
+++ b/Remotion/Development/Web/UnitTesting/AspNetFramework/HttpContextHelper.cs
@@ -21,6 +21,7 @@ using System.Web;
 using System.Web.Hosting;
 using System.Web.SessionState;
 using Remotion.Development.UnitTesting;
+using Remotion.Reflection;
 using Remotion.Utilities;
 
 namespace Remotion.Development.Web.UnitTesting.AspNetFramework
@@ -51,7 +52,7 @@ namespace Remotion.Development.Web.UnitTesting.AspNetFramework
 
       object httpRuntime = PrivateInvoke.GetNonPublicStaticField (typeof (HttpRuntime), "_theRuntime");
       PrivateInvoke.SetNonPublicField (httpRuntime, "_appDomainAppPath", s_appPhysicalDir);
-      string assemblyName = typeof (HttpApplication).Assembly.FullName;
+      string assemblyName = typeof (HttpApplication).Assembly.GetFullNameChecked();
       Type virtualPathType = Type.GetType ("System.Web.VirtualPath, " + assemblyName, true);
       object virtualPath = PrivateInvoke.InvokePublicStaticMethod (virtualPathType, "Create", s_appVirtualDir);
       PrivateInvoke.SetNonPublicField (httpRuntime, "_appDomainAppVPath", virtualPath);

--- a/Remotion/Globalization/Core/EnumerationGlobalizationServiceExtensions.cs
+++ b/Remotion/Globalization/Core/EnumerationGlobalizationServiceExtensions.cs
@@ -17,6 +17,7 @@
 using System;
 using JetBrains.Annotations;
 using Remotion.Globalization.Implementation;
+using Remotion.Reflection;
 using Remotion.Utilities;
 
 namespace Remotion.Globalization
@@ -55,7 +56,7 @@ namespace Remotion.Globalization
 
       if (ResourceLogger.IsEnabled)
       {
-        ResourceLogger.LogResourceEntryNotFound ("Enum value: '{0}' (Type: '{1}')", value, value.GetType().FullName);
+        ResourceLogger.LogResourceEntryNotFound ("Enum value: '{0}' (Type: '{1}')", value, value.GetType().GetFullNameSafe());
       }
 
       return value.ToString();

--- a/Remotion/Globalization/Core/Implementation/ResourceAttributeBasedResourceManagerFactory.cs
+++ b/Remotion/Globalization/Core/Implementation/ResourceAttributeBasedResourceManagerFactory.cs
@@ -22,6 +22,7 @@ using System.Linq;
 using System.Reflection;
 using System.Resources;
 using Remotion.FunctionalProgramming;
+using Remotion.Reflection;
 using Remotion.ServiceLocation;
 using Remotion.Utilities;
 
@@ -71,7 +72,7 @@ namespace Remotion.Globalization.Implementation
         throw new MissingManifestResourceException (
             string.Format (
                 "Could not find any resources appropriate for the neutral culture. Make sure '{1}.resources' was correctly embedded into assembly '{0}' at compile time.",
-                key.Item1.GetName().Name,
+                key.Item1.GetName().GetNameSafe(),
                 key.Item2));
       }
 

--- a/Remotion/Globalization/Core/ResourceIdentifiersAttribute.cs
+++ b/Remotion/Globalization/Core/ResourceIdentifiersAttribute.cs
@@ -15,6 +15,7 @@
 // along with re-motion; if not, see http://www.gnu.org/licenses.
 // 
 using System;
+using Remotion.Reflection;
 using Remotion.Utilities;
 
 namespace Remotion.Globalization
@@ -29,7 +30,7 @@ public class ResourceIdentifiersAttribute: Attribute
     Type type = enumValue.GetType();
     if (type.DeclaringType != null && IsEnumTypeNameSuppressed (type)) // if the enum is a nested type, suppress enum name
       type = type.DeclaringType;
-    return type.FullName + "." + enumValue.ToString();
+    return type.GetFullNameChecked() + "." + enumValue.ToString();
 
 //    string typePath = type.FullName.Substring (0, type.FullName.Length - type.Name.Length);
 //    if (typePath.EndsWith ("+"))

--- a/Remotion/Globalization/ExtensibleEnums/ExtensibleEnumGlobalizationServiceExtensions.cs
+++ b/Remotion/Globalization/ExtensibleEnums/ExtensibleEnumGlobalizationServiceExtensions.cs
@@ -18,6 +18,7 @@ using System;
 using JetBrains.Annotations;
 using Remotion.ExtensibleEnums;
 using Remotion.Globalization.Implementation;
+using Remotion.Reflection;
 using Remotion.Utilities;
 
 namespace Remotion.Globalization.ExtensibleEnums
@@ -61,7 +62,7 @@ namespace Remotion.Globalization.ExtensibleEnums
             "Extensible enum value: '{0}' (Method: '{1}', Type: '{2}')",
             value.ValueName,
             definingMethod.Name,
-            definingMethod.DeclaringType == null ? "" : definingMethod.DeclaringType.FullName);
+            definingMethod.DeclaringType == null ? "" : definingMethod.DeclaringType.GetFullNameSafe());
       }
 
       return value.ValueName;

--- a/Remotion/Mixins/Core/CodeGeneration/ConcreteMixinType.cs
+++ b/Remotion/Mixins/Core/CodeGeneration/ConcreteMixinType.cs
@@ -19,6 +19,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using Remotion.Mixins.CodeGeneration.TypePipe;
+using Remotion.Reflection;
 using Remotion.TypePipe.MutableReflection;
 using Remotion.TypePipe.TypeAssembly;
 using Remotion.Utilities;
@@ -96,7 +97,7 @@ namespace Remotion.Mixins.CodeGeneration
       if (!_methodWrappers.TryGetValue (methodToBeCalled, out wrapper))
       {
         string message =
-            string.Format ("No public wrapper was generated for method '{0}.{1}'.", methodToBeCalled.DeclaringType!.FullName, methodToBeCalled.Name);
+            string.Format ("No public wrapper was generated for method '{0}.{1}'.", methodToBeCalled.DeclaringType!.GetFullNameSafe(), methodToBeCalled.Name);
         throw new KeyNotFoundException (message);
       }
       else
@@ -113,7 +114,7 @@ namespace Remotion.Mixins.CodeGeneration
       if (!_overrideInterfaceMethodsByMixinMethod.TryGetValue (mixinMethod, out interfaceMethod))
       {
         string message =
-            string.Format ("No override interface method was generated for method '{0}.{1}'.", mixinMethod.DeclaringType!.FullName, mixinMethod.Name);
+            string.Format ("No override interface method was generated for method '{0}.{1}'.", mixinMethod.DeclaringType!.GetFullNameSafe(), mixinMethod.Name);
         throw new KeyNotFoundException (message);
       }
       else

--- a/Remotion/Mixins/Core/CodeGeneration/ObjectFactoryImplementation.cs
+++ b/Remotion/Mixins/Core/CodeGeneration/ObjectFactoryImplementation.cs
@@ -16,6 +16,7 @@
 // 
 using System;
 using Remotion.Mixins.Utilities;
+using Remotion.Reflection;
 using Remotion.ServiceLocation;
 using Remotion.TypePipe;
 using Remotion.Utilities;
@@ -53,7 +54,7 @@ namespace Remotion.Mixins.CodeGeneration
       if (classContext == null && preparedMixins.Length > 0)
       {
           throw new ArgumentException (string.Format ("There is no mixin configuration for type {0}, so no mixin instances must be specified.",
-              targetOrConcreteType.FullName), "preparedMixins");
+              targetOrConcreteType.GetFullNameSafe()), "preparedMixins");
       }
 
       using (new MixedObjectInstantiationScope(preparedMixins))

--- a/Remotion/Mixins/Core/CodeGeneration/Serialization/SerializationInfoConcreteMixinTypeIdentifierSerializer.cs
+++ b/Remotion/Mixins/Core/CodeGeneration/Serialization/SerializationInfoConcreteMixinTypeIdentifierSerializer.cs
@@ -18,6 +18,7 @@ using System;
 using System.Collections.Generic;
 using System.Reflection;
 using System.Runtime.Serialization;
+using Remotion.Reflection;
 using Remotion.Utilities;
 
 namespace Remotion.Mixins.CodeGeneration.Serialization
@@ -43,7 +44,7 @@ namespace Remotion.Mixins.CodeGeneration.Serialization
 
     public void AddMixinType (Type mixinType)
     {
-      _serializationInfo.AddValue (_key + ".MixinType", mixinType.AssemblyQualifiedName);
+      _serializationInfo.AddValue (_key + ".MixinType", mixinType.GetAssemblyQualifiedNameChecked());
     }
 
     public void AddOverriders (HashSet<MethodInfo> overriders)
@@ -66,7 +67,7 @@ namespace Remotion.Mixins.CodeGeneration.Serialization
         if (methodInfo.IsGenericMethod && !methodInfo.IsGenericMethodDefinition)
           throw new NotSupportedException ("Cannot serialize closed generic methods. This is not supported.");
 
-        _serializationInfo.AddValue (collectionKey + "[" + index + "].DeclaringType", methodInfo.DeclaringType!.AssemblyQualifiedName);
+        _serializationInfo.AddValue (collectionKey + "[" + index + "].DeclaringType", methodInfo.DeclaringType!.GetAssemblyQualifiedNameChecked());
 
         _serializationInfo.AddValue (collectionKey + "[" + index + "].Name", methodInfo.Name);
         _serializationInfo.AddValue (collectionKey + "[" + index + "].Signature", methodInfo.ToString());

--- a/Remotion/Mixins/Core/CodeGeneration/TypePipe/CodeGenerationMixinContextOriginSerializer.cs
+++ b/Remotion/Mixins/Core/CodeGeneration/TypePipe/CodeGenerationMixinContextOriginSerializer.cs
@@ -18,6 +18,7 @@ using System;
 using System.Reflection;
 using Remotion.Mixins.Context;
 using Remotion.Mixins.Context.Serialization;
+using Remotion.Reflection;
 using Remotion.TypePipe.Dlr.Ast;
 using Remotion.Utilities;
 
@@ -52,7 +53,7 @@ namespace Remotion.Mixins.CodeGeneration.TypePipe
       ArgumentUtility.CheckNotNull ("assembly", assembly);
 
       Assertion.IsNotNull (s_assemblyLoadMethod);
-      _constructorArguments[1] = Expression.Call (null, s_assemblyLoadMethod, new[] { Expression.Constant (assembly.FullName) });
+      _constructorArguments[1] = Expression.Call (null, s_assemblyLoadMethod, new[] { Expression.Constant (assembly.GetFullNameChecked()) });
     }
 
     public void AddLocation (string location)

--- a/Remotion/Mixins/Core/CodeGeneration/TypePipe/ExpressionMixinContextOriginSerializer.cs
+++ b/Remotion/Mixins/Core/CodeGeneration/TypePipe/ExpressionMixinContextOriginSerializer.cs
@@ -18,6 +18,7 @@ using System;
 using System.Reflection;
 using Remotion.Mixins.Context;
 using Remotion.Mixins.Context.Serialization;
+using Remotion.Reflection;
 using Remotion.TypePipe.Dlr.Ast;
 using Remotion.Utilities;
 
@@ -43,7 +44,7 @@ namespace Remotion.Mixins.CodeGeneration.TypePipe
       return Expression.New (
           s_constructor,
           Expression.Constant (Kind),
-          Expression.Call (s_assemblyLoadMethod, Expression.Constant (Assembly!.FullName)), // TODO RM-7691 Change serializer properties to non-nullable return values
+          Expression.Call (s_assemblyLoadMethod, Expression.Constant (Assembly!.GetFullNameChecked())), // TODO RM-7691 Change serializer properties to non-nullable return values
           Expression.Constant (Locaction));
     }
   }

--- a/Remotion/Mixins/Core/CodeGeneration/TypePipe/SerializationImplementer.cs
+++ b/Remotion/Mixins/Core/CodeGeneration/TypePipe/SerializationImplementer.cs
@@ -17,6 +17,7 @@
 using System;
 using System.Reflection;
 using System.Runtime.Serialization;
+using Remotion.Reflection;
 using Remotion.TypePipe.Dlr.Ast;
 using Remotion.TypePipe.MutableReflection;
 using Remotion.TypePipe.MutableReflection.BodyBuilding;
@@ -75,7 +76,7 @@ namespace Remotion.Mixins.CodeGeneration.TypePipe
       {
         string message = string.Format (
             "No public or protected deserialization constructor in type {0} - serialization is not supported.",
-            ctx.DeclaringType.BaseType.FullName);
+            ctx.DeclaringType.BaseType.GetFullNameSafe());
         return Expression.Throw (Expression.New (s_invalidOperationExceptionConstructor, Expression.Constant (message)));
       }
 
@@ -84,7 +85,7 @@ namespace Remotion.Mixins.CodeGeneration.TypePipe
       if (baseGetObjectDataMethod == null || !IsPublicOrProtected (baseGetObjectDataMethod))
       {
         string message = string.Format ("No public or protected GetObjectData in type {0} - serialization is not supported.",
-            ctx.DeclaringType.BaseType.FullName);
+            ctx.DeclaringType.BaseType.GetFullNameSafe());
         return Expression.Throw (Expression.New (s_invalidOperationExceptionConstructor, Expression.Constant (message)));
       }
 

--- a/Remotion/Mixins/Core/CodeGeneration/TypePipe/TargetTypeForNextCall.cs
+++ b/Remotion/Mixins/Core/CodeGeneration/TypePipe/TargetTypeForNextCall.cs
@@ -17,6 +17,7 @@
 using System;
 using System.Collections.Generic;
 using System.Reflection;
+using Remotion.Reflection;
 using Remotion.TypePipe.MutableReflection;
 using Remotion.Utilities;
 using ReflectionUtility = Remotion.Mixins.Utilities.ReflectionUtility;
@@ -52,7 +53,7 @@ namespace Remotion.Mixins.CodeGeneration.TypePipe
       {
         string message = string.Format (
             "Cannot create base call method for a method defined on a different type than the base type: {0}.{1}.",
-            overriddenMethod.DeclaringType.FullName,
+            overriddenMethod.DeclaringType.GetFullNameSafe(),
             overriddenMethod.Name);
         throw new ArgumentException (message, "overriddenMethod");
       }
@@ -68,7 +69,7 @@ namespace Remotion.Mixins.CodeGeneration.TypePipe
       Assertion.IsTrue (ReflectionUtility.IsPublicOrProtected (baseMethod));
       if (baseMethod.IsAbstract)
       {
-        var message = string.Format ("The given method {0}.{1} is abstract.", baseMethod.DeclaringType!.FullName, baseMethod.Name);
+        var message = string.Format ("The given method {0}.{1} is abstract.", baseMethod.DeclaringType!.GetFullNameSafe(), baseMethod.Name);
         throw new ArgumentException (message, "baseMethod");
       }
 

--- a/Remotion/Mixins/Core/CodeGeneration/TypePipe/TargetTypeGenerator.cs
+++ b/Remotion/Mixins/Core/CodeGeneration/TypePipe/TargetTypeGenerator.cs
@@ -23,6 +23,7 @@ using System.Reflection;
 using Remotion.Mixins.Context;
 using Remotion.Mixins.Definitions;
 using Remotion.Mixins.Utilities;
+using Remotion.Reflection;
 using Remotion.TypePipe.Dlr.Ast;
 using Remotion.TypePipe.Expressions;
 using Remotion.TypePipe.Implementation;
@@ -467,7 +468,7 @@ namespace Remotion.Mixins.CodeGeneration.TypePipe
             $"Property {implementingProperty.DeclaringClass.FullName}.{implementingProperty.Name} has no getter");
         var interfaceGetMethod = Assertion.IsNotNull (
             interfaceProperty.GetGetMethod(),
-            $"Property {interfaceProperty.DeclaringType!.FullName}.{interfaceProperty.Name} has no getter");
+            $"Property {interfaceProperty.DeclaringType!.GetFullNameSafe()}.{interfaceProperty.Name} has no getter");
         getMethod = ImplementIntroducedMethod (implementer, interfaceGetMethod, implementedGetMethod, visibility);
       }
       if (introducedProperty.IntroducesSetMethod)
@@ -477,7 +478,7 @@ namespace Remotion.Mixins.CodeGeneration.TypePipe
             $"Property {implementingProperty.DeclaringClass.FullName}.{implementingProperty.Name} has no setter");
         var interfaceSetMethod = Assertion.IsNotNull (
             interfaceProperty.GetSetMethod(),
-            $"Property {interfaceProperty.DeclaringType!.FullName}.{interfaceProperty.Name} has no setter");
+            $"Property {interfaceProperty.DeclaringType!.GetFullNameSafe()}.{interfaceProperty.Name} has no setter");
         setMethod = ImplementIntroducedMethod (implementer, interfaceSetMethod, implementedSetMethod, visibility);
       }
 

--- a/Remotion/Mixins/Core/Context/ClassContextDeriver.cs
+++ b/Remotion/Mixins/Core/Context/ClassContextDeriver.cs
@@ -16,6 +16,7 @@
 // 
 using System;
 using System.Collections.Generic;
+using Remotion.Reflection;
 using Remotion.Utilities;
 
 namespace Remotion.Mixins.Context
@@ -46,9 +47,9 @@ namespace Remotion.Mixins.Context
         string message = string.Format (
             "The class {0} inherits the mixin {1} from class {2}, but it is explicitly "
                 + "configured for the less specific mixin {3}.",
-            targetClass.FullName,
-            overridden_override.Item2.MixinType.FullName,
-            baseContext.Type.FullName,
+            targetClass.GetFullNameSafe(),
+            overridden_override.Item2.MixinType.GetFullNameSafe(),
+            baseContext.Type.GetFullNameSafe(),
             overridden_override.Item1.MixinType);
         throw new ConfigurationException (message);
       }

--- a/Remotion/Mixins/Core/Context/FluentBuilders/ClassContextBuilder.cs
+++ b/Remotion/Mixins/Core/Context/FluentBuilders/ClassContextBuilder.cs
@@ -148,7 +148,7 @@ namespace Remotion.Mixins.Context.FluentBuilders
         Type mixinTypeForException = mixinType.IsGenericType ? mixinType.GetGenericTypeDefinition() : mixinType;
         Assertion.IsNotNull (mixinTypeForException);
         throw new ArgumentException (
-            string.Format ("{0} is already configured as a mixin for type {1}.", mixinTypeForException.FullName, TargetType.FullName), "mixinType");
+            string.Format ("{0} is already configured as a mixin for type {1}.", mixinTypeForException.GetFullNameSafe(), TargetType.GetFullNameSafe()), "mixinType");
       }
 
       var mixinContextBuilder = new MixinContextBuilder (this, mixinType, origin);
@@ -550,7 +550,7 @@ namespace Remotion.Mixins.Context.FluentBuilders
       if (_composedInterfaces.Contains (interfaceType))
       {
         string message = string.Format ("{0} is already configured as a composed interface for type {1}.",
-            interfaceType.FullName, TargetType.FullName);
+            interfaceType.GetFullNameSafe(), TargetType.GetFullNameSafe());
         throw new ArgumentException (message, "interfaceType");
       }
       _composedInterfaces.Add (interfaceType);

--- a/Remotion/Mixins/Core/Context/FluentBuilders/MixinConfigurationBuilder.cs
+++ b/Remotion/Mixins/Core/Context/FluentBuilders/MixinConfigurationBuilder.cs
@@ -20,6 +20,7 @@ using System.Diagnostics;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using Remotion.Logging;
+using Remotion.Reflection;
 using Remotion.Utilities;
 
 namespace Remotion.Mixins.Context.FluentBuilders
@@ -166,8 +167,8 @@ namespace Remotion.Mixins.Context.FluentBuilders
         Assertion.IsNotNull (typeForMessage);
         string message = string.Format (
             "Two instances of mixin {0} are configured for target type {1}.",
-            typeForMessage.FullName,
-            targetType.FullName);
+            typeForMessage.GetFullNameSafe(),
+            targetType.GetFullNameSafe());
         throw new ConfigurationException (message, ex);
       }
       return mixinContextBuilder;

--- a/Remotion/Mixins/Core/Context/FluentBuilders/MixinContextBuilder.cs
+++ b/Remotion/Mixins/Core/Context/FluentBuilders/MixinContextBuilder.cs
@@ -130,7 +130,7 @@ namespace Remotion.Mixins.Context.FluentBuilders
       ArgumentUtility.CheckNotNull ("requiredMixin", requiredMixin);
       if (_dependencies.Contains (requiredMixin))
       {
-        string message = string.Format ("The mixin {0} already has a dependency on type {1}.", MixinType.FullName, requiredMixin.FullName);
+        string message = string.Format ("The mixin {0} already has a dependency on type {1}.", MixinType.GetFullNameSafe(), requiredMixin.GetFullNameSafe());
         throw new ArgumentException (message, "requiredMixin");
       }
       _dependencies.Add (requiredMixin);

--- a/Remotion/Mixins/Core/Context/MixinContextOrigin.cs
+++ b/Remotion/Mixins/Core/Context/MixinContextOrigin.cs
@@ -18,6 +18,7 @@ using System;
 using System.Diagnostics;
 using System.Reflection;
 using Remotion.Mixins.Context.Serialization;
+using Remotion.Reflection;
 using Remotion.Utilities;
 
 namespace Remotion.Mixins.Context
@@ -97,7 +98,7 @@ namespace Remotion.Mixins.Context
     public override string ToString ()
     {
       var assemblyName = Assembly.GetName (false);
-      return String.Format ("{0}, Location: '{1}' (Assembly: '{2}', code base: {3})", Kind, Location, assemblyName.Name, assemblyName.CodeBase);
+      return String.Format ("{0}, Location: '{1}' (Assembly: '{2}', code base: {3})", Kind, Location, assemblyName.GetNameSafe(), assemblyName.CodeBase);
     }
 
     public void Serialize (IMixinContextOriginSerializer serializer)

--- a/Remotion/Mixins/Core/Context/Serialization/ArrayContextDeserializerBase.cs
+++ b/Remotion/Mixins/Core/Context/Serialization/ArrayContextDeserializerBase.cs
@@ -16,6 +16,7 @@
 // 
 using System;
 using System.Runtime.Serialization;
+using Remotion.Reflection;
 using Remotion.Utilities;
 
 namespace Remotion.Mixins.Context.Serialization
@@ -50,9 +51,9 @@ namespace Remotion.Mixins.Context.Serialization
       {
         var message = string.Format (
             "Expected value of type '{0}' at index {1} in the values array, but found '{2}'.",
-            typeof (T).FullName,
+            typeof (T).GetFullNameSafe(),
             index,
-            value != null ? value.GetType().FullName : "null");
+            value != null ? value.GetType().GetFullNameSafe() : "null");
         throw new SerializationException (message);
       }
 

--- a/Remotion/Mixins/Core/Context/Serialization/ArrayContextSerializerBase.cs
+++ b/Remotion/Mixins/Core/Context/Serialization/ArrayContextSerializerBase.cs
@@ -1,4 +1,4 @@
-// This file is part of the re-motion Core Framework (www.re-motion.org)
+﻿// This file is part of the re-motion Core Framework (www.re-motion.org)
 // Copyright (c) rubicon IT GmbH, www.rubicon.eu
 // 
 // The re-motion Core Framework is free software; you can redistribute it 
@@ -16,6 +16,7 @@
 // 
 using System;
 using System.Reflection;
+using Remotion.Reflection;
 
 namespace Remotion.Mixins.Context.Serialization
 {
@@ -46,7 +47,7 @@ namespace Remotion.Mixins.Context.Serialization
         where T : notnull
     {
       if (typeof (T) == typeof (Assembly))
-        return ConvertToStorageFormat (((Assembly) (object) value).FullName!);
+        return ConvertToStorageFormat (((Assembly) (object) value).GetFullNameChecked());
 
       return value;
     }

--- a/Remotion/Mixins/Core/Context/Serialization/AttributeMixinContextOriginSerializer.cs
+++ b/Remotion/Mixins/Core/Context/Serialization/AttributeMixinContextOriginSerializer.cs
@@ -16,6 +16,7 @@
 // 
 using System;
 using System.Reflection;
+using Remotion.Reflection;
 
 namespace Remotion.Mixins.Context.Serialization
 {
@@ -27,7 +28,7 @@ namespace Remotion.Mixins.Context.Serialization
     protected override object ConvertToStorageFormat<T> (T value)
     {
       if (typeof (T) == typeof (Assembly))
-        return ((Assembly) (object) value).FullName!;
+        return ((Assembly) (object) value).GetFullNameChecked();
 
       return base.ConvertToStorageFormat (value);
     }

--- a/Remotion/Mixins/Core/Context/Serialization/FlatClassContextSerializer.cs
+++ b/Remotion/Mixins/Core/Context/Serialization/FlatClassContextSerializer.cs
@@ -16,6 +16,7 @@
 // 
 using System;
 using System.Linq;
+using Remotion.Reflection;
 
 namespace Remotion.Mixins.Context.Serialization
 {
@@ -34,7 +35,7 @@ namespace Remotion.Mixins.Context.Serialization
       }
 
       if (typeof (T) == typeof (Type))
-        return ConvertToStorageFormat (((Type) (object) value).AssemblyQualifiedName!);
+        return ConvertToStorageFormat (((Type) (object) value).GetAssemblyQualifiedNameChecked());
 
       return base.ConvertToStorageFormat (value);
     }

--- a/Remotion/Mixins/Core/Context/Serialization/FlatMixinContextOriginSerializer.cs
+++ b/Remotion/Mixins/Core/Context/Serialization/FlatMixinContextOriginSerializer.cs
@@ -16,6 +16,7 @@
 // 
 using System;
 using System.Reflection;
+using Remotion.Reflection;
 
 namespace Remotion.Mixins.Context.Serialization
 {
@@ -28,7 +29,7 @@ namespace Remotion.Mixins.Context.Serialization
     protected override object ConvertToStorageFormat<T> (T value)
     {
       if (typeof (T) == typeof (Assembly))
-        return ((Assembly) (object) value).FullName!;
+        return ((Assembly) (object) value).GetFullNameChecked();
 
       return base.ConvertToStorageFormat (value);
     }

--- a/Remotion/Mixins/Core/Context/Serialization/FlatMixinContextSerializer.cs
+++ b/Remotion/Mixins/Core/Context/Serialization/FlatMixinContextSerializer.cs
@@ -16,6 +16,7 @@
 // 
 using System;
 using System.Linq;
+using Remotion.Reflection;
 
 namespace Remotion.Mixins.Context.Serialization
 {
@@ -34,7 +35,7 @@ namespace Remotion.Mixins.Context.Serialization
       }
 
       if (typeof (T) == typeof (Type))
-        return ConvertToStorageFormat (((Type) (object) value).AssemblyQualifiedName!);
+        return ConvertToStorageFormat (((Type) (object) value).GetAssemblyQualifiedNameChecked());
 
       return base.ConvertToStorageFormat (value);
     }

--- a/Remotion/Mixins/Core/CopyCustomAttributesAttribute.cs
+++ b/Remotion/Mixins/Core/CopyCustomAttributesAttribute.cs
@@ -17,6 +17,7 @@
 using System;
 using System.Collections;
 using System.Reflection;
+using Remotion.Reflection;
 using Remotion.Utilities;
 
 namespace Remotion.Mixins
@@ -73,7 +74,7 @@ namespace Remotion.Mixins
     {
       get
       {
-        return AttributeSourceMemberName != null ? AttributeSourceType.FullName + "." + AttributeSourceMemberName : AttributeSourceType.FullName!;
+        return AttributeSourceMemberName != null ? AttributeSourceType.GetFullNameChecked() + "." + AttributeSourceMemberName : AttributeSourceType.GetFullNameChecked();
       }
     }
 
@@ -102,7 +103,7 @@ namespace Remotion.Mixins
               string.Format (
                   "The source member string {0} matches several members on type {1}.",
                   AttributeSourceMemberName,
-                  AttributeSourceType.FullName));
+                  AttributeSourceType.GetFullNameSafe()));
         }
       }
     }

--- a/Remotion/Mixins/Core/Definitions/Building/AttributeDefinitionBuilder.cs
+++ b/Remotion/Mixins/Core/Definitions/Building/AttributeDefinitionBuilder.cs
@@ -66,7 +66,7 @@ namespace Remotion.Mixins.Definitions.Building
     private void ApplyViaCopyAttribute (MemberInfo copyAttributeSource, ICustomAttributeData copyAttributeData)
     {
       Assertion.IsTrue (copyAttributeData.Constructor.DeclaringType == typeof (CopyCustomAttributesAttribute));
-      string sourceName = GetFullMemberName (copyAttributeSource);
+      string sourceName = GetFullMemberNameSafe (copyAttributeSource);
 
       var copyAttribute = (CopyCustomAttributesAttribute) copyAttributeData.CreateInstance();
 
@@ -145,9 +145,9 @@ namespace Remotion.Mixins.Definitions.Building
         return memberType;
     }
 
-    private string GetFullMemberName (MemberInfo attributeSource)
+    private string GetFullMemberNameSafe (MemberInfo attributeSource)
     {
-      return attributeSource.DeclaringType != null ? attributeSource.DeclaringType.FullName + "." + attributeSource.Name : attributeSource.Name;
+      return attributeSource.DeclaringType != null ? attributeSource.DeclaringType.GetFullNameSafe() + "." + attributeSource.Name : attributeSource.Name;
     }
   }
 }

--- a/Remotion/Mixins/Core/Definitions/Building/AttributeDefinitionBuilder.cs
+++ b/Remotion/Mixins/Core/Definitions/Building/AttributeDefinitionBuilder.cs
@@ -17,6 +17,7 @@
 using System;
 using System.Collections.Generic;
 using System.Reflection;
+using Remotion.Reflection;
 using Remotion.TypePipe.MutableReflection;
 using Remotion.Utilities;
 
@@ -58,9 +59,8 @@ namespace Remotion.Mixins.Definitions.Building
 
     private bool IsIgnoredAttributeType (Type type)
     {
-      Assertion.IsNotNull (type.Namespace);
       return type == typeof (SerializableAttribute)
-          || (typeof (ExtendsAttribute).Assembly.Equals (type.Assembly) && type.Namespace.StartsWith ("Remotion.Mixins"));
+          || (typeof (ExtendsAttribute).Assembly.Equals (type.Assembly) && type.GetNamespaceChecked().StartsWith ("Remotion.Mixins"));
     }
 
     private void ApplyViaCopyAttribute (MemberInfo copyAttributeSource, ICustomAttributeData copyAttributeData)

--- a/Remotion/Mixins/Core/Definitions/Building/InterfaceIntroductionDefinitionBuilder.cs
+++ b/Remotion/Mixins/Core/Definitions/Building/InterfaceIntroductionDefinitionBuilder.cs
@@ -19,6 +19,7 @@ using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using System.Runtime.Serialization;
+using Remotion.Reflection;
 using Remotion.Utilities;
 
 namespace Remotion.Mixins.Definitions.Building
@@ -63,7 +64,7 @@ namespace Remotion.Mixins.Definitions.Building
         MixinDefinition otherIntroducer = _mixin.TargetClass.ReceivedInterfaces[implementedInterface].Implementer;
         string message = string.Format (
             "Two mixins introduce the same interface {0} to base class {1}: {2} and {3}.",
-            implementedInterface.FullName,
+            implementedInterface.GetFullNameSafe(),
             _mixin.TargetClass.FullName,
             otherIntroducer.FullName,
             _mixin.FullName);

--- a/Remotion/Mixins/Core/Definitions/Building/NextDependencyDefinitionBuilder.cs
+++ b/Remotion/Mixins/Core/Definitions/Building/NextDependencyDefinitionBuilder.cs
@@ -15,6 +15,7 @@
 // along with re-motion; if not, see http://www.gnu.org/licenses.
 // 
 using System;
+using Remotion.Reflection;
 using Remotion.Utilities;
 
 namespace Remotion.Mixins.Definitions.Building
@@ -49,7 +50,7 @@ namespace Remotion.Mixins.Definitions.Building
       if (!type.IsInterface)
       {
         string message = string.Format ("Next call dependencies must be interfaces (or System.Object), but mixin {0} (on class {1} has a dependency "
-            + "on a class: {2}.", _mixin.FullName, _mixin.TargetClass.FullName, type.FullName);
+            + "on a class: {2}.", _mixin.FullName, _mixin.TargetClass.FullName, type.GetFullNameSafe());
         throw new ConfigurationException (message);
       }
 

--- a/Remotion/Mixins/Core/Definitions/Building/TargetClassDefinitionBuilder.cs
+++ b/Remotion/Mixins/Core/Definitions/Building/TargetClassDefinitionBuilder.cs
@@ -20,6 +20,7 @@ using System.Linq;
 using Remotion.FunctionalProgramming;
 using Remotion.Mixins.Context;
 using Remotion.Mixins.Definitions.Building.DependencySorting;
+using Remotion.Reflection;
 using Remotion.ServiceLocation;
 using Remotion.Utilities;
 using ReflectionUtility = Remotion.Mixins.Utilities.ReflectionUtility;
@@ -51,7 +52,7 @@ namespace Remotion.Mixins.Definitions.Building
 
       if (classContext.Type.ContainsGenericParameters)
       {
-        string message = string.Format ("The base class {0} contains generic parameters. This is not supported.", classContext.Type.FullName);
+        string message = string.Format ("The base class {0} contains generic parameters. This is not supported.", classContext.Type.GetFullNameSafe());
         throw new ConfigurationException (message);
       }
 

--- a/Remotion/Mixins/Core/Definitions/MemberDefinitionBase.cs
+++ b/Remotion/Mixins/Core/Definitions/MemberDefinitionBase.cs
@@ -17,6 +17,7 @@
 using System;
 using System.Diagnostics;
 using System.Reflection;
+using Remotion.Reflection;
 using Remotion.Utilities;
 
 namespace Remotion.Mixins.Definitions
@@ -85,7 +86,7 @@ namespace Remotion.Mixins.Definitions
 
     public string FullName
     {
-      get { return MemberInfo.DeclaringType!.FullName + "." + Name; }
+      get { return MemberInfo.DeclaringType!.GetFullNameChecked() + "." + Name; }
     }
 
     public abstract MemberDefinitionBase? BaseAsMember { get; protected internal set; }

--- a/Remotion/Mixins/Core/ExtendsAttribute.cs
+++ b/Remotion/Mixins/Core/ExtendsAttribute.cs
@@ -18,6 +18,7 @@ using System;
 using JetBrains.Annotations;
 using Remotion.Mixins.Context;
 using Remotion.Mixins.Context.FluentBuilders;
+using Remotion.Reflection;
 using Remotion.Utilities;
 
 namespace Remotion.Mixins
@@ -141,8 +142,8 @@ namespace Remotion.Mixins
       {
         string message = string.Format (
             "The ExtendsAttribute for target class {0} applied to mixin type {1} specified {2} generic type argument(s) when {3} argument(s) were expected.",
-            TargetType.FullName,
-            mixinType.FullName,
+            TargetType.GetFullNameSafe(),
+            mixinType.GetFullNameSafe(),
             MixinTypeArguments.Length,
             expectedTypeArgumentLength);
         throw new ConfigurationException (message);

--- a/Remotion/Mixins/Core/Mixin.cs
+++ b/Remotion/Mixins/Core/Mixin.cs
@@ -17,6 +17,7 @@
 using System;
 using System.Diagnostics;
 using System.Reflection;
+using Remotion.Reflection;
 using Remotion.Utilities;
 
 namespace Remotion.Mixins
@@ -81,8 +82,8 @@ namespace Remotion.Mixins
           {
             string message = string.Format (
                 "Both mixins '{0}' and '{1}' match the given type '{2}'.",
-                mixin.GetType ().FullName,
-                potentialMixin.GetType ().FullName,
+                mixin.GetType ().GetFullNameSafe(),
+                potentialMixin.GetType ().GetFullNameSafe(),
                 mixinType.Name);
             throw new AmbiguousMatchException (message);
           }

--- a/Remotion/Mixins/Core/Utilities/MixinReflector.cs
+++ b/Remotion/Mixins/Core/Utilities/MixinReflector.cs
@@ -18,6 +18,7 @@ using System;
 using System.Reflection;
 using Remotion.Mixins.CodeGeneration;
 using Remotion.Mixins.Definitions;
+using Remotion.Reflection;
 using Remotion.Utilities;
 
 namespace Remotion.Mixins.Utilities
@@ -73,7 +74,7 @@ namespace Remotion.Mixins.Utilities
       var castTarget = mixinTargetInstance as IMixinTarget;
       if (castTarget == null)
       {
-        string message = string.Format ("The given object of type {0} is not a mixin target.", mixinTargetInstance.GetType().FullName);
+        string message = string.Format ("The given object of type {0} is not a mixin target.", mixinTargetInstance.GetType().GetFullNameSafe());
         throw new ArgumentException (message, "mixinTargetInstance");
       }
 

--- a/Remotion/Mixins/Core/Utilities/ReflectionUtility.cs
+++ b/Remotion/Mixins/Core/Utilities/ReflectionUtility.cs
@@ -19,6 +19,7 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
+using Remotion.Reflection;
 using Remotion.Utilities;
 
 namespace Remotion.Mixins.Utilities
@@ -92,7 +93,7 @@ namespace Remotion.Mixins.Utilities
 
       string message = String.Format (
           "The given member {0}.{1} is neither property, method, nor event.",
-          member.DeclaringType!.FullName,
+          member.DeclaringType!.GetFullNameSafe(),
           member.Name);
       throw new ArgumentException (message, "member");
     }

--- a/Remotion/Mixins/Core/Validation/DelegateValidationRule.cs
+++ b/Remotion/Mixins/Core/Validation/DelegateValidationRule.cs
@@ -18,6 +18,7 @@ using System;
 using System.Reflection;
 using System.Text;
 using Remotion.Mixins.Definitions;
+using Remotion.Reflection;
 using Remotion.Utilities;
 
 namespace Remotion.Mixins.Validation
@@ -70,7 +71,7 @@ namespace Remotion.Mixins.Validation
       MethodInfo method = rule.Method;
       var attribute = AttributeUtility.GetCustomAttribute<DelegateRuleDescriptionAttribute> (method, true);
       if (attribute == null || attribute.RuleName == null)
-        return method.DeclaringType!.FullName + "." + rule.Method.Name;
+        return method.DeclaringType!.GetFullNameChecked() + "." + rule.Method.Name;
       else
         return attribute.RuleName;
     }

--- a/Remotion/Mixins/Core/Validation/Rules/ContextStoreMemberIntroductionLookupUtility.cs
+++ b/Remotion/Mixins/Core/Validation/Rules/ContextStoreMemberIntroductionLookupUtility.cs
@@ -18,6 +18,7 @@ using System;
 using System.Collections.Generic;
 using Remotion.Collections;
 using Remotion.Mixins.Definitions;
+using Remotion.Reflection;
 
 namespace Remotion.Mixins.Validation.Rules
 {
@@ -30,7 +31,7 @@ namespace Remotion.Mixins.Validation.Rules
     public IEnumerable<TMemberIntroductionDefinition> GetCachedPublicIntroductionsByName (IDictionary<object, object> contextStore, TargetClassDefinition targetClass, string name)
     {
       Tuple<string, TargetClassDefinition> cacheKey = Tuple.Create (
-          typeof (ContextStoreMemberIntroductionLookupUtility<TMemberIntroductionDefinition>).FullName + ".GetCachedPublicIntroductionsByName",
+          typeof (ContextStoreMemberIntroductionLookupUtility<TMemberIntroductionDefinition>).GetFullNameChecked() + ".GetCachedPublicIntroductionsByName",
           targetClass);
 
       // Optimized for memory allocations

--- a/Remotion/Mixins/Core/Validation/Rules/ContextStoreMemberLookupUtility.cs
+++ b/Remotion/Mixins/Core/Validation/Rules/ContextStoreMemberLookupUtility.cs
@@ -18,6 +18,7 @@ using System;
 using System.Collections.Generic;
 using Remotion.Collections;
 using Remotion.Mixins.Definitions;
+using Remotion.Reflection;
 
 namespace Remotion.Mixins.Validation.Rules
 {
@@ -29,7 +30,7 @@ namespace Remotion.Mixins.Validation.Rules
     public IEnumerable<TMemberDefinition> GetCachedMembersByName (IDictionary<object, object> contextStore, TargetClassDefinition targetClass, string name)
     {
       Tuple<string, TargetClassDefinition> cacheKey =
-          Tuple.Create (typeof (ContextStoreMemberLookupUtility<TMemberDefinition>).FullName + ".GetCachedMembersByName", targetClass);
+          Tuple.Create (typeof (ContextStoreMemberLookupUtility<TMemberDefinition>).GetFullNameChecked() + ".GetCachedMembersByName", targetClass);
 
       // Optimized for memory allocations
       if (_contextStoreValueFactory == null)

--- a/Remotion/Mixins/Core/Validation/Validator.cs
+++ b/Remotion/Mixins/Core/Validation/Validator.cs
@@ -80,7 +80,7 @@ namespace Remotion.Mixins.Validation
     {
       foreach (Type t in AssemblyTypeCache.GetTypes (Assembly.GetExecutingAssembly()))
       {
-        if (!t.IsAbstract && typeof (IRuleSet).IsAssignableFrom (t) && t.Namespace == typeof (IRuleSet).Namespace)
+        if (!t.IsAbstract && typeof (IRuleSet).IsAssignableFrom (t) && t.Namespace == typeof (IRuleSet).GetNamespaceChecked())
         {
           IRuleSet ruleSet = (IRuleSet) Activator.CreateInstance (t)!;
           ruleSet.Install (visitor);

--- a/Remotion/Mixins/MixerTools/MixerRunner.cs
+++ b/Remotion/Mixins/MixerTools/MixerRunner.cs
@@ -90,7 +90,7 @@ namespace Remotion.Mixins.MixerTools
       else
       {
         var mixerLoggers = from t in AssemblyTypeCache.GetTypes (typeof (Mixer).Assembly)
-                           where t.Namespace == typeof (Mixer).Namespace
+                           where t.Namespace == typeof (Mixer).GetNamespaceChecked()
                            select LogManager.GetLogger (t);
         var logThresholds = from l in mixerLoggers
                             select new LogThreshold (l, LogLevel.Info);

--- a/Remotion/Mixins/MixerTools/Program.cs
+++ b/Remotion/Mixins/MixerTools/Program.cs
@@ -15,6 +15,7 @@
 // along with re-motion; if not, see http://www.gnu.org/licenses.
 // 
 using System;
+using Remotion.Reflection;
 using Remotion.Tools.Console;
 using Remotion.Tools.Console.CommandLine;
 
@@ -49,7 +50,7 @@ namespace Remotion.Mixins.MixerTools
         {
           System.Console.Error.WriteLine ("Execution aborted. Exception stack:");
           for (; e != null; e = e.InnerException)
-            System.Console.Error.WriteLine ("{0}: {1}\n{2}", e.GetType().FullName, e.Message, e.StackTrace);
+            System.Console.Error.WriteLine ("{0}: {1}\n{2}", e.GetType().GetFullNameSafe(), e.Message, e.StackTrace);
         }
         return 1;
       }

--- a/Remotion/ObjectBinding/Core/BindableObject/BindableObjectClassWithIdentity.cs
+++ b/Remotion/ObjectBinding/Core/BindableObject/BindableObjectClassWithIdentity.cs
@@ -17,6 +17,7 @@
 using System;
 using System.Collections.Generic;
 using Remotion.ObjectBinding.BindableObject.Properties;
+using Remotion.Reflection;
 using Remotion.ServiceLocation;
 using Remotion.Utilities;
 
@@ -59,9 +60,9 @@ namespace Remotion.ObjectBinding.BindableObject
         throw new InvalidOperationException (
             string.Format (
                 "The '{0}' required for loading objectes of type '{1}' is not registered with the '{2}' associated with this type.",
-                _getObjectServiceType.FullName,
-                TargetType.FullName,
-                typeof (BusinessObjectProvider).FullName));
+                _getObjectServiceType.GetFullNameSafe(),
+                TargetType.GetFullNameSafe(),
+                typeof (BusinessObjectProvider).GetFullNameSafe()));
       }
       return service;
     }

--- a/Remotion/ObjectBinding/Core/BindableObject/BindableObjectProvider.cs
+++ b/Remotion/ObjectBinding/Core/BindableObject/BindableObjectProvider.cs
@@ -20,6 +20,7 @@ using System.Collections.Concurrent;
 using Remotion.Collections;
 using Remotion.Collections.DataStore;
 using Remotion.Mixins;
+using Remotion.Reflection;
 using Remotion.Utilities;
 using TypeExtensions = Remotion.Reflection.TypeExtensions;
 
@@ -49,7 +50,7 @@ namespace Remotion.ObjectBinding.BindableObject
       var providerAttributeType = s_providerAttributeTypeCache.GetOrAdd (type, s_findProviderAttributeTypeFunc);
 
       var provider = (BindableObjectProvider) GetProvider (providerAttributeType);
-      Assertion.IsNotNull (provider, "GetProvider cannot return null (type '{0}').", type.FullName);
+      Assertion.IsNotNull (provider, "GetProvider cannot return null (type '{0}').", type.GetFullNameSafe());
       return provider;
     }
 
@@ -112,8 +113,8 @@ namespace Remotion.ObjectBinding.BindableObject
       {
         var message = string.Format (
             "The type '{0}' does not have the '{1}' applied.",
-            type.FullName,
-            typeof (BusinessObjectProviderAttribute).FullName);
+            type.GetFullNameSafe(),
+            typeof (BusinessObjectProviderAttribute).GetFullNameSafe());
         throw new ArgumentException (message, "type");
       }
 
@@ -121,8 +122,8 @@ namespace Remotion.ObjectBinding.BindableObject
       {
         var message = string.Format (
             "The business object provider associated with the type '{0}' is not of type '{1}'.",
-            type.FullName,
-            typeof (BindableObjectProvider).FullName);
+            type.GetFullNameSafe(),
+            typeof (BindableObjectProvider).GetFullNameSafe());
         throw new ArgumentException (message, "type");
       }
 
@@ -197,7 +198,7 @@ namespace Remotion.ObjectBinding.BindableObject
           throw new ArgumentException (
               string.Format (
                   "The type '{0}' is not a bindable object implementation. Open generic types are not supported.",
-                  type.FullName),
+                  type.GetFullNameSafe()),
               "type");
         }
 
@@ -205,7 +206,7 @@ namespace Remotion.ObjectBinding.BindableObject
             string.Format (
                 "The type '{0}' is not a bindable object implementation. It must either have a mixin derived from BindableObjectMixinBase<T> applied "
                 + "or implement the IBusinessObject interface and apply the BindableObjectBaseClassAttribute.",
-                type.FullName),
+                type.GetFullNameSafe()),
             "type");
       }
 

--- a/Remotion/ObjectBinding/Core/BindableObject/ClassReflector.cs
+++ b/Remotion/ObjectBinding/Core/BindableObject/ClassReflector.cs
@@ -79,7 +79,7 @@ namespace Remotion.ObjectBinding.BindableObject
         return new BindableObjectClass (_concreteType, _businessObjectProvider, _bindableObjectGlobalizationService, GetProperties());
 
       throw new NotSupportedException (
-          string.Format ("Type '{0}' does not implement the required IBusinessObject interface.", _concreteType.FullName));
+          string.Format ("Type '{0}' does not implement the required IBusinessObject interface.", _concreteType.GetFullNameSafe()));
     }
 
     protected IEnumerable<PropertyBase> GetProperties ()
@@ -95,7 +95,7 @@ namespace Remotion.ObjectBinding.BindableObject
         {
           string message = string.Format (
               "Type '{0}' has two properties called '{1}', this is currently not supported.",
-              TargetType.FullName,
+              TargetType.GetFullNameSafe(),
               property.Identifier);
           throw new NotSupportedException (message);
         }

--- a/Remotion/ObjectBinding/Core/BindableObject/Properties/PropertyBase.cs
+++ b/Remotion/ObjectBinding/Core/BindableObject/Properties/PropertyBase.cs
@@ -102,8 +102,8 @@ namespace Remotion.ObjectBinding.BindableObject.Properties
                 throw new InvalidOperationException (
                     string.Format (
                         "The concrete type must be assignable to the underlying type '{0}'.\r\nConcrete type: {1}",
-                        underlyingType.FullName,
-                        actualConcreteType.FullName));
+                        underlyingType.GetFullNameSafe(),
+                        actualConcreteType.GetFullNameSafe()));
               }
               return actualConcreteType;
             },

--- a/Remotion/ObjectBinding/Core/BindableObject/Properties/ReferenceProperty.cs
+++ b/Remotion/ObjectBinding/Core/BindableObject/Properties/ReferenceProperty.cs
@@ -17,6 +17,7 @@
 using System;
 using System.Threading;
 using JetBrains.Annotations;
+using Remotion.Reflection;
 using Remotion.Utilities;
 
 namespace Remotion.ObjectBinding.BindableObject.Properties
@@ -471,7 +472,7 @@ namespace Remotion.ObjectBinding.BindableObject.Properties
             string.Format (
                 "The '{0}' type does not use the '{1}' implementation of '{2}' and there is no '{3}' registered with the '{4}' associated with this type.",
                 UnderlyingType.FullName,
-                typeof (BindableObjectMixin).Namespace,
+                typeof (BindableObjectMixin).GetNamespaceSafe(),
                 typeof (IBusinessObject).FullName,
                 typeof (IBusinessObjectClassService).FullName,
                 typeof (BusinessObjectProvider).FullName));

--- a/Remotion/ObjectBinding/Core/BindableObject/Properties/ReferenceProperty.cs
+++ b/Remotion/ObjectBinding/Core/BindableObject/Properties/ReferenceProperty.cs
@@ -420,7 +420,7 @@ namespace Remotion.ObjectBinding.BindableObject.Properties
             if (!typeof (IBusinessObject).IsAssignableFrom (actualConcreteType))
             {
               throw new InvalidOperationException (
-                  string.Format ("The concrete type must implement the IBusinessObject interface.\r\nConcrete type: {0}", actualConcreteType.FullName));
+                  string.Format ("The concrete type must implement the IBusinessObject interface.\r\nConcrete type: {0}", actualConcreteType.GetFullNameSafe()));
             }
             return actualConcreteType;
           },
@@ -453,10 +453,10 @@ namespace Remotion.ObjectBinding.BindableObject.Properties
         throw new InvalidOperationException (
             string.Format (
                 "The GetBusinessObjectClass method of '{0}', registered with the '{1}', failed to return an '{2}' for type '{3}'.",
-                service.GetType().FullName,
-                BusinessObjectProvider.GetType().FullName,
-                typeof (IBusinessObjectClass).FullName,
-                UnderlyingType.FullName));
+                service.GetType().GetFullNameSafe(),
+                BusinessObjectProvider.GetType().GetFullNameSafe(),
+                typeof (IBusinessObjectClass).GetFullNameSafe(),
+                UnderlyingType.GetFullNameSafe()));
       }
 
       return businessObjectClass;
@@ -471,11 +471,11 @@ namespace Remotion.ObjectBinding.BindableObject.Properties
         throw new InvalidOperationException (
             string.Format (
                 "The '{0}' type does not use the '{1}' implementation of '{2}' and there is no '{3}' registered with the '{4}' associated with this type.",
-                UnderlyingType.FullName,
+                UnderlyingType.GetFullNameSafe(),
                 typeof (BindableObjectMixin).GetNamespaceSafe(),
-                typeof (IBusinessObject).FullName,
-                typeof (IBusinessObjectClassService).FullName,
-                typeof (BusinessObjectProvider).FullName));
+                typeof (IBusinessObject).GetFullNameSafe(),
+                typeof (IBusinessObjectClassService).GetFullNameSafe(),
+                typeof (BusinessObjectProvider).GetFullNameSafe()));
       }
       return service;
     }
@@ -485,7 +485,7 @@ namespace Remotion.ObjectBinding.BindableObject.Properties
         where TService: IBusinessObjectService
     {
       var service = GetServiceOrNull<TService> (serviceDefinition);
-      Assertion.IsNotNull (service, "The BusinessObjectProvider did not return a service for '{0}'.", serviceDefinition.Item2.FullName);
+      Assertion.IsNotNull (service, "The BusinessObjectProvider did not return a service for '{0}'.", serviceDefinition.Item2.GetFullNameSafe());
       return service;
     }
 

--- a/Remotion/ObjectBinding/Core/Design/BindableObject/ControllerBase.cs
+++ b/Remotion/ObjectBinding/Core/Design/BindableObject/ControllerBase.cs
@@ -18,6 +18,7 @@ using System;
 using System.Drawing;
 using System.IO;
 using System.Windows.Forms;
+using Remotion.Reflection;
 using Remotion.Utilities;
 
 namespace Remotion.ObjectBinding.Design.BindableObject
@@ -33,7 +34,7 @@ namespace Remotion.ObjectBinding.Design.BindableObject
       Type type = GetType();
       string resourceID = treeViewIcon.Item2;
       Stream stream = type.Assembly.GetManifestResourceStream (type, resourceID);
-      Assertion.IsNotNull (stream, string.Format ("Resource '{0}' was not found in namespace '{1}'.", resourceID, type.Namespace));
+      Assertion.IsNotNull (stream, string.Format ("Resource '{0}' was not found in namespace '{1}'.", resourceID, type.GetNamespaceSafe()));
       try
       {
         imageList.Images.Add (treeViewIcon.Item1.ToString(), Image.FromStream (stream));

--- a/Remotion/ObjectBinding/Core/Design/BindableObject/TypeTreeViewController.cs
+++ b/Remotion/ObjectBinding/Core/Design/BindableObject/TypeTreeViewController.cs
@@ -111,7 +111,7 @@ namespace Remotion.ObjectBinding.Design.BindableObject
 
     private TreeNode GetTypeNode (Type type, TreeNodeCollection typeNodes)
     {
-      TreeNode typeNode = typeNodes[type.FullName];
+      TreeNode typeNode = typeNodes[type.GetFullNameChecked()];
       if (typeNode == null)
       {
         typeNode = new TreeNode();
@@ -131,7 +131,7 @@ namespace Remotion.ObjectBinding.Design.BindableObject
     {
       if (node.Tag is Type
           && selectedType != null
-          && ((Type) node.Tag).FullName.Equals (selectedType.FullName, StringComparison.CurrentCultureIgnoreCase))
+          && ((Type) node.Tag).GetFullNameChecked().Equals (selectedType.GetFullNameChecked(), StringComparison.CurrentCultureIgnoreCase))
       {
         _treeView.SelectedNode = node;
         node.EnsureVisible();

--- a/Remotion/ObjectBinding/Core/Design/BindableObject/TypeTreeViewController.cs
+++ b/Remotion/ObjectBinding/Core/Design/BindableObject/TypeTreeViewController.cs
@@ -93,12 +93,12 @@ namespace Remotion.ObjectBinding.Design.BindableObject
 
     private TreeNode GetNamespaceNode (Type type, TreeNodeCollection namespaceNodes)
     {
-      TreeNode namespaceNode = namespaceNodes[type.Namespace];
+      TreeNode namespaceNode = namespaceNodes[type.GetNamespaceChecked()];
       if (namespaceNode == null)
       {
         namespaceNode = new TreeNode();
-        namespaceNode.Name = type.Namespace;
-        namespaceNode.Text = type.Namespace;
+        namespaceNode.Name = type.GetNamespaceChecked();
+        namespaceNode.Text = type.GetNamespaceChecked();
         namespaceNode.ImageKey = TreeViewIcons.Namespace.ToString();
         namespaceNode.SelectedImageKey = TreeViewIcons.Namespace.ToString();
 

--- a/Remotion/ObjectBinding/Core/Design/BindableObject/TypeTreeViewController.cs
+++ b/Remotion/ObjectBinding/Core/Design/BindableObject/TypeTreeViewController.cs
@@ -18,6 +18,7 @@ using System;
 using System.Collections.Generic;
 using System.Reflection;
 using System.Windows.Forms;
+using Remotion.Reflection;
 using Remotion.Utilities;
 
 namespace Remotion.ObjectBinding.Design.BindableObject
@@ -79,7 +80,7 @@ namespace Remotion.ObjectBinding.Design.BindableObject
       {
         assemblyNode = new TreeNode();
         assemblyNode.Name = assemblyName.FullName;
-        assemblyNode.Text = assemblyName.Name;
+        assemblyNode.Text = assemblyName.GetNameChecked();
         assemblyNode.ToolTipText = assemblyName.FullName;
         assemblyNode.ImageKey = TreeViewIcons.Assembly.ToString();
         assemblyNode.SelectedImageKey = TreeViewIcons.Assembly.ToString();

--- a/Remotion/ObjectBinding/Sample/BindableXmlObject.cs
+++ b/Remotion/ObjectBinding/Sample/BindableXmlObject.cs
@@ -17,6 +17,7 @@
 using System;
 using System.Xml.Serialization;
 using Remotion.Mixins;
+using Remotion.Reflection;
 
 namespace Remotion.ObjectBinding.Sample
 {
@@ -59,7 +60,7 @@ namespace Remotion.ObjectBinding.Sample
     [OverrideMixin]
     public virtual string DisplayName
     {
-      get { return GetType().FullName; }
+      get { return GetType().GetFullNameChecked(); }
     }
 
     [XmlIgnore]

--- a/Remotion/ObjectBinding/Sample/FileSystemReflectionBusinessObjectStorageProvider.cs
+++ b/Remotion/ObjectBinding/Sample/FileSystemReflectionBusinessObjectStorageProvider.cs
@@ -17,6 +17,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using Remotion.Reflection;
 using Remotion.Utilities;
 
 namespace Remotion.ObjectBinding.Sample
@@ -92,7 +93,7 @@ namespace Remotion.ObjectBinding.Sample
 
     private string GetDirectoryForType (Type type)
     {
-      return Path.Combine (_rootPath, type.FullName);
+      return Path.Combine (_rootPath, type.GetFullNameChecked());
     }
   }
 }

--- a/Remotion/ObjectBinding/Sample/ReflectionBusinessObjectWebUIService.cs
+++ b/Remotion/ObjectBinding/Sample/ReflectionBusinessObjectWebUIService.cs
@@ -19,6 +19,7 @@ using System.Web.UI.WebControls;
 using Remotion.ObjectBinding.BindableObject;
 using Remotion.ObjectBinding.Web;
 using Remotion.ObjectBinding.Web.UI.Controls;
+using Remotion.Reflection;
 using Remotion.Utilities;
 using Remotion.Web.UI.Controls;
 
@@ -42,7 +43,7 @@ namespace Remotion.ObjectBinding.Sample
       }
       else
       {
-        string url = "~/Images/" + ((BindableObjectClass) obj.BusinessObjectClass).TargetType.FullName + ".gif";
+        string url = "~/Images/" + ((BindableObjectClass) obj.BusinessObjectClass).TargetType.GetFullNameChecked() + ".gif";
         return new IconInfo (url, Unit.Pixel (16), Unit.Pixel (16));
       }
     }
@@ -52,7 +53,7 @@ namespace Remotion.ObjectBinding.Sample
       if (obj == null)
         return "No ToolTip";
       else
-        return "ToolTip: " + ((BindableObjectClass) obj.BusinessObjectClass).TargetType.FullName;
+        return "ToolTip: " + ((BindableObjectClass) obj.BusinessObjectClass).TargetType.GetFullNameChecked();
     }
 
     public HelpInfo GetHelpInfo (

--- a/Remotion/ObjectBinding/Sample/SessionStateReflectionBusinessObjectStorageProvider.cs
+++ b/Remotion/ObjectBinding/Sample/SessionStateReflectionBusinessObjectStorageProvider.cs
@@ -17,6 +17,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using Remotion.Reflection;
 using Remotion.Utilities;
 using Remotion.Web.Infrastructure;
 
@@ -24,7 +25,7 @@ namespace Remotion.ObjectBinding.Sample
 {
   public class SessionStateReflectionBusinessObjectStorageProvider : IReflectionBusinessObjectStorageProvider
   {
-    private static readonly string s_sessionKeyForStorageProvider = typeof (SessionStateReflectionBusinessObjectStorageProvider).FullName;
+    private static readonly string s_sessionKeyForStorageProvider = typeof (SessionStateReflectionBusinessObjectStorageProvider).GetFullNameChecked();
 
     private readonly IHttpContextProvider _httpContextProvider;
     private readonly IReflectionBusinessObjectStorageProviderFactory _reflectionBusinessObjectStorageProviderFactory;

--- a/Remotion/ObjectBinding/Web/UI/Controls/BocBooleanValueImplementation/Rendering/BocBooleanValueRenderer.cs
+++ b/Remotion/ObjectBinding/Web/UI/Controls/BocBooleanValueImplementation/Rendering/BocBooleanValueRenderer.cs
@@ -23,6 +23,7 @@ using System.Web.UI.WebControls;
 using Remotion.FunctionalProgramming;
 using Remotion.Globalization;
 using Remotion.ObjectBinding.Web.Contracts.DiagnosticMetadata;
+using Remotion.Reflection;
 using Remotion.ServiceLocation;
 using Remotion.Utilities;
 using Remotion.Web;
@@ -57,7 +58,7 @@ namespace Remotion.ObjectBinding.Web.UI.Controls.BocBooleanValueImplementation.R
 
     private const string c_nullString = "null";
 
-    private static readonly string s_startUpScriptKeyPrefix = typeof (BocBooleanValueRenderer).FullName + "_Startup_";
+    private static readonly string s_startUpScriptKeyPrefix = typeof (BocBooleanValueRenderer).GetFullNameChecked() + "_Startup_";
 
     private readonly IBocBooleanValueResourceSetFactory _resourceSetFactory;
     private readonly ILabelReferenceRenderer _labelReferenceRenderer;
@@ -85,11 +86,11 @@ namespace Remotion.ObjectBinding.Web.UI.Controls.BocBooleanValueImplementation.R
     {
       ArgumentUtility.CheckNotNull ("htmlHeadAppender", htmlHeadAppender);
 
-      string scriptFileKey = typeof (BocBooleanValueRenderer).FullName + "_Script";
+      string scriptFileKey = typeof (BocBooleanValueRenderer).GetFullNameChecked() + "_Script";
       var scriptUrl = ResourceUrlFactory.CreateResourceUrl (typeof (BocBooleanValueRenderer), ResourceType.Html, "BocBooleanValue.js");
       htmlHeadAppender.RegisterJavaScriptInclude (scriptFileKey, scriptUrl);
 
-      string styleFileKey = typeof (BocBooleanValueRenderer).FullName + "_Style";
+      string styleFileKey = typeof (BocBooleanValueRenderer).GetFullNameChecked() + "_Style";
       var styleUrl = ResourceUrlFactory.CreateThemedResourceUrl (typeof (BocBooleanValueRenderer), ResourceType.Html, "BocBooleanValue.css");
       htmlHeadAppender.RegisterStylesheetLink (styleFileKey, styleUrl, HtmlHeadAppender.Priority.Library);
     }

--- a/Remotion/ObjectBinding/Web/UI/Controls/BocBooleanValueImplementation/Rendering/BocCheckBoxRenderer.cs
+++ b/Remotion/ObjectBinding/Web/UI/Controls/BocBooleanValueImplementation/Rendering/BocCheckBoxRenderer.cs
@@ -21,6 +21,7 @@ using System.Web.UI;
 using System.Web.UI.HtmlControls;
 using System.Web.UI.WebControls;
 using Remotion.Globalization;
+using Remotion.Reflection;
 using Remotion.ServiceLocation;
 using Remotion.Utilities;
 using Remotion.Web;
@@ -44,7 +45,7 @@ namespace Remotion.ObjectBinding.Web.UI.Controls.BocBooleanValueImplementation.R
     private const string c_trueIcon = "CheckBoxTrue.gif";
     private const string c_falseIcon = "CheckBoxFalse.gif";
 
-    private static readonly string s_startUpScriptKey = typeof (BocCheckBoxRenderer).FullName + "_Startup";
+    private static readonly string s_startUpScriptKey = typeof (BocCheckBoxRenderer).GetFullNameChecked() + "_Startup";
 
     public BocCheckBoxRenderer (
         IResourceUrlFactory resourceUrlFactory,
@@ -65,11 +66,11 @@ namespace Remotion.ObjectBinding.Web.UI.Controls.BocBooleanValueImplementation.R
     {
       ArgumentUtility.CheckNotNull ("htmlHeadAppender", htmlHeadAppender);
 
-      string scriptFileKey = typeof (BocCheckBoxRenderer).FullName + "_Script";
+      string scriptFileKey = typeof (BocCheckBoxRenderer).GetFullNameChecked() + "_Script";
       var scriptUrl = ResourceUrlFactory.CreateResourceUrl (typeof (BocCheckBoxRenderer), ResourceType.Html, "BocCheckbox.js");
       htmlHeadAppender.RegisterJavaScriptInclude (scriptFileKey, scriptUrl);
 
-      string styleFileKey = typeof (BocCheckBoxRenderer).FullName + "_Style";
+      string styleFileKey = typeof (BocCheckBoxRenderer).GetFullNameChecked() + "_Style";
       var styleUrl = ResourceUrlFactory.CreateThemedResourceUrl (typeof (BocCheckBoxRenderer), ResourceType.Html, "BocCheckbox.css");
       htmlHeadAppender.RegisterStylesheetLink (styleFileKey, styleUrl, HtmlHeadAppender.Priority.Library);
     }

--- a/Remotion/ObjectBinding/Web/UI/Controls/BocDateTimeValue.cs
+++ b/Remotion/ObjectBinding/Web/UI/Controls/BocDateTimeValue.cs
@@ -27,6 +27,7 @@ using Remotion.ObjectBinding.BusinessObjectPropertyConstraints;
 using Remotion.ObjectBinding.Web.UI.Controls.BocDateTimeValueImplementation;
 using Remotion.ObjectBinding.Web.UI.Controls.BocDateTimeValueImplementation.Rendering;
 using Remotion.ObjectBinding.Web.UI.Controls.BocDateTimeValueImplementation.Validation;
+using Remotion.Reflection;
 using Remotion.Utilities;
 using Remotion.Web.UI;
 using Remotion.Web.UI.Controls;
@@ -601,7 +602,7 @@ namespace Remotion.ObjectBinding.Web.UI.Controls
       }
       catch (InvalidCastException e)
       {
-        throw new ArgumentException ("Expected type '" + _actualValueType + "', but was '" + value.GetType().FullName + "'.", "value", e);
+        throw new ArgumentException ("Expected type '" + _actualValueType + "', but was '" + value.GetType().GetFullNameSafe() + "'.", "value", e);
       }
 
       if (ActualValueType == BocDateTimeValueType.DateTime
@@ -614,7 +615,7 @@ namespace Remotion.ObjectBinding.Web.UI.Controls
         catch (InvalidCastException e)
         {
           throw new ArgumentException (
-              "Expected type '" + _actualValueType + "', but was '" + value.GetType().FullName + "'.",
+              "Expected type '" + _actualValueType + "', but was '" + value.GetType().GetFullNameSafe() + "'.",
               "value",
               e);
         }

--- a/Remotion/ObjectBinding/Web/UI/Controls/BocDateTimeValueImplementation/Rendering/BocDateTimeValueRenderer.cs
+++ b/Remotion/ObjectBinding/Web/UI/Controls/BocDateTimeValueImplementation/Rendering/BocDateTimeValueRenderer.cs
@@ -22,6 +22,7 @@ using System.Web.UI.WebControls;
 using Remotion.FunctionalProgramming;
 using Remotion.Globalization;
 using Remotion.ObjectBinding.Web.Contracts.DiagnosticMetadata;
+using Remotion.Reflection;
 using Remotion.ServiceLocation;
 using Remotion.Utilities;
 using Remotion.Web;
@@ -96,7 +97,7 @@ namespace Remotion.ObjectBinding.Web.UI.Controls.BocDateTimeValueImplementation.
 
       RegisterBrowserCompatibilityScript (htmlHeadAppender);
 
-      string styleKey = typeof (BocDateTimeValueRenderer).FullName + "_Style";
+      string styleKey = typeof (BocDateTimeValueRenderer).GetFullNameChecked() + "_Style";
       var styleFile = ResourceUrlFactory.CreateThemedResourceUrl (typeof (BocDateTimeValueRenderer), ResourceType.Html, "BocDateTimeValue.css");
       htmlHeadAppender.RegisterStylesheetLink (styleKey, styleFile, HtmlHeadAppender.Priority.Library);
     }

--- a/Remotion/ObjectBinding/Web/UI/Controls/BocEnumValueImplementation/Rendering/BocEnumValueRenderer.cs
+++ b/Remotion/ObjectBinding/Web/UI/Controls/BocEnumValueImplementation/Rendering/BocEnumValueRenderer.cs
@@ -22,6 +22,7 @@ using System.Web.UI.WebControls;
 using Remotion.FunctionalProgramming;
 using Remotion.Globalization;
 using Remotion.ObjectBinding.Web.Contracts.DiagnosticMetadata;
+using Remotion.Reflection;
 using Remotion.ServiceLocation;
 using Remotion.Utilities;
 using Remotion.Web;
@@ -69,7 +70,7 @@ namespace Remotion.ObjectBinding.Web.UI.Controls.BocEnumValueImplementation.Rend
     {
       ArgumentUtility.CheckNotNull ("htmlHeadAppender", htmlHeadAppender);
 
-      string key = typeof (BocEnumValueRenderer).FullName + "_Style";
+      string key = typeof (BocEnumValueRenderer).GetFullNameChecked() + "_Style";
       var url = ResourceUrlFactory.CreateThemedResourceUrl (typeof (BocEnumValueRenderer), ResourceType.Html, "BocEnumValue.css");
       htmlHeadAppender.RegisterStylesheetLink (key, url, HtmlHeadAppender.Priority.Library);
     }

--- a/Remotion/ObjectBinding/Web/UI/Controls/BocList.cs
+++ b/Remotion/ObjectBinding/Web/UI/Controls/BocList.cs
@@ -40,6 +40,7 @@ using Remotion.ObjectBinding.Web.UI.Controls.BocListImplementation.Rendering;
 using Remotion.ObjectBinding.Web.UI.Controls.BocListImplementation.Sorting;
 using Remotion.ObjectBinding.Web.UI.Controls.BocListImplementation.Validation;
 using Remotion.ObjectBinding.Web.UI.Design;
+using Remotion.Reflection;
 using Remotion.ServiceLocation;
 using Remotion.Utilities;
 using Remotion.Web;
@@ -1997,7 +1998,7 @@ namespace Remotion.ObjectBinding.Web.UI.Controls
             {
               //  Invalid collection property
               s_log.Debug (
-                  "BocList '" + ID + "' in naming container '" + NamingContainer.GetType().FullName + "' on page '" + Page
+                  "BocList '" + ID + "' in naming container '" + NamingContainer.GetType().GetFullNameSafe() + "' on page '" + Page
                   + "' does not contain a collection property named '" + collectionID + "'.");
               break;
             }
@@ -2024,7 +2025,7 @@ namespace Remotion.ObjectBinding.Web.UI.Controls
         {
           //  Not supported format or invalid property
           s_log.Debug (
-              "BocList '" + ID + "' in naming container '" + NamingContainer.GetType().FullName + "' on page '" + Page
+              "BocList '" + ID + "' in naming container '" + NamingContainer.GetType().GetFullNameSafe() + "' on page '" + Page
               + "' received a resource with an invalid or unknown key '" + key
               + "'. Required format: 'property' or 'collectionID:elementID:property'.");
         }

--- a/Remotion/ObjectBinding/Web/UI/Controls/BocListImplementation/Rendering/BocListRenderer.cs
+++ b/Remotion/ObjectBinding/Web/UI/Controls/BocListImplementation/Rendering/BocListRenderer.cs
@@ -21,6 +21,7 @@ using System.Web.UI;
 using Remotion.Globalization;
 using Remotion.ObjectBinding.Web.Contracts.DiagnosticMetadata;
 using Remotion.ObjectBinding.Web.UI.Controls.BocListImplementation.EditableRowSupport;
+using Remotion.Reflection;
 using Remotion.ServiceLocation;
 using Remotion.Utilities;
 using Remotion.Web;
@@ -121,11 +122,11 @@ namespace Remotion.ObjectBinding.Web.UI.Controls.BocListImplementation.Rendering
 
       htmlHeadAppender.RegisterUtilitiesJavaScriptInclude();
 
-      string styleFileKey = typeof (BocListRenderer).FullName + "_Style";
+      string styleFileKey = typeof (BocListRenderer).GetFullNameChecked() + "_Style";
       var styleUrl = ResourceUrlFactory.CreateThemedResourceUrl (typeof (BocListRenderer), ResourceType.Html, "BocList.css");
       htmlHeadAppender.RegisterStylesheetLink (styleFileKey, styleUrl, HtmlHeadAppender.Priority.Library);
 
-      string scriptFileKey = typeof (BocListRenderer).FullName + "_Script";
+      string scriptFileKey = typeof (BocListRenderer).GetFullNameChecked() + "_Script";
       var scriptUrl = ResourceUrlFactory.CreateResourceUrl (typeof (BocListRenderer), ResourceType.Html, "BocList.js");
       htmlHeadAppender.RegisterJavaScriptInclude (scriptFileKey, scriptUrl);
 
@@ -245,7 +246,7 @@ namespace Remotion.ObjectBinding.Web.UI.Controls.BocListImplementation.Rendering
       if (!renderingContext.Control.HasClientScript)
         return;
 
-      string startUpScriptKey = typeof (BocListRenderer).FullName + "_Startup";
+      string startUpScriptKey = typeof (BocListRenderer).GetFullNameChecked() + "_Startup";
       if (!renderingContext.Control.Page.ClientScript.IsStartupScriptRegistered (typeof (BocListRenderer), startUpScriptKey))
       {
         string script = "BocList.InitializeGlobals ();";
@@ -276,7 +277,7 @@ namespace Remotion.ObjectBinding.Web.UI.Controls.BocListImplementation.Rendering
         renderingContext.Control.Page.ClientScript.RegisterStartupScriptBlock (
             renderingContext.Control,
             typeof (BocListTableBlockRenderer),
-            typeof (BocList).FullName + "_" + renderingContext.Control.ClientID + "_InitializeListScript",
+            typeof (BocList).GetFullNameChecked() + "_" + renderingContext.Control.ClientID + "_InitializeListScript",
             script);
       }
     }

--- a/Remotion/ObjectBinding/Web/UI/Controls/BocReferenceValueImplementation/BocReferenceValueBase.cs
+++ b/Remotion/ObjectBinding/Web/UI/Controls/BocReferenceValueImplementation/BocReferenceValueBase.cs
@@ -30,6 +30,7 @@ using Remotion.Globalization;
 using Remotion.Logging;
 using Remotion.ObjectBinding.Web.Services;
 using Remotion.ObjectBinding.Web.UI.Design;
+using Remotion.Reflection;
 using Remotion.ServiceLocation;
 using Remotion.Utilities;
 using Remotion.Web.ExecutionEngine;
@@ -813,7 +814,7 @@ namespace Remotion.ObjectBinding.Web.UI.Controls.BocReferenceValueImplementation
             {
               //  Invalid collection property
               s_log.Debug (
-                  GetType().Name + " '" + ID + "' in naming container '" + NamingContainer.GetType().FullName + "' on page '" + Page
+                  GetType().Name + " '" + ID + "' in naming container '" + NamingContainer.GetType().GetFullNameSafe() + "' on page '" + Page
                   + "' does not contain an element named '" + elementID + "'.");
               break;
             }
@@ -841,7 +842,7 @@ namespace Remotion.ObjectBinding.Web.UI.Controls.BocReferenceValueImplementation
             {
               //  Invalid collection property
               s_log.Debug (
-                  GetType().Name + " '" + ID + "' in naming container '" + NamingContainer.GetType().FullName + "' on page '" + Page
+                  GetType().Name + " '" + ID + "' in naming container '" + NamingContainer.GetType().GetFullNameSafe() + "' on page '" + Page
                   + "' does not contain a collection property named '" + collectionID + "'.");
               break;
             }
@@ -868,7 +869,7 @@ namespace Remotion.ObjectBinding.Web.UI.Controls.BocReferenceValueImplementation
         {
           //  Not supported format or invalid property
           s_log.Debug (
-              GetType().Name + " '" + ID + "' in naming container '" + NamingContainer.GetType().FullName + "' on page '" + Page
+              GetType().Name + " '" + ID + "' in naming container '" + NamingContainer.GetType().GetFullNameSafe() + "' on page '" + Page
               + "' received a resource with an invalid or unknown key '" + key
               + "'. Required format: 'property' or 'collectionID:elementID:property'.");
         }

--- a/Remotion/ObjectBinding/Web/UI/Controls/BocReferenceValueImplementation/Rendering/BocAutoCompleteReferenceValueRenderer.cs
+++ b/Remotion/ObjectBinding/Web/UI/Controls/BocReferenceValueImplementation/Rendering/BocAutoCompleteReferenceValueRenderer.cs
@@ -22,6 +22,7 @@ using System.Web.UI.WebControls;
 using Remotion.Globalization;
 using Remotion.ObjectBinding.Web.Contracts.DiagnosticMetadata;
 using Remotion.ObjectBinding.Web.Services;
+using Remotion.Reflection;
 using Remotion.ServiceLocation;
 using Remotion.Utilities;
 using Remotion.Web;
@@ -130,7 +131,7 @@ namespace Remotion.ObjectBinding.Web.UI.Controls.BocReferenceValueImplementation
 
       htmlHeadAppender.RegisterUtilitiesJavaScriptInclude();
 
-      string jqueryAutocompleteScriptKey = typeof (BocAutoCompleteReferenceValueRenderer).FullName + "_JQueryAutoCompleteScript";
+      string jqueryAutocompleteScriptKey = typeof (BocAutoCompleteReferenceValueRenderer).GetFullNameChecked() + "_JQueryAutoCompleteScript";
       htmlHeadAppender.RegisterJavaScriptInclude (
           jqueryAutocompleteScriptKey,
           ResourceUrlFactory.CreateResourceUrl (
@@ -138,7 +139,7 @@ namespace Remotion.ObjectBinding.Web.UI.Controls.BocReferenceValueImplementation
               ResourceType.Html,
               "BocAutoCompleteReferenceValue.jquery.js"));
 
-      string scriptKey = typeof (BocAutoCompleteReferenceValueRenderer).FullName + "_Script";
+      string scriptKey = typeof (BocAutoCompleteReferenceValueRenderer).GetFullNameChecked() + "_Script";
       htmlHeadAppender.RegisterJavaScriptInclude (
           scriptKey,
           ResourceUrlFactory.CreateResourceUrl (typeof (BocAutoCompleteReferenceValueRenderer), ResourceType.Html, "BocAutoCompleteReferenceValue.js"));
@@ -146,7 +147,7 @@ namespace Remotion.ObjectBinding.Web.UI.Controls.BocReferenceValueImplementation
 
     private void RegisterStylesheets (HtmlHeadAppender htmlHeadAppender)
     {
-      string styleKey = typeof (BocAutoCompleteReferenceValueRenderer).FullName + "_Style";
+      string styleKey = typeof (BocAutoCompleteReferenceValueRenderer).GetFullNameChecked() + "_Style";
       htmlHeadAppender.RegisterStylesheetLink (
           styleKey,
           ResourceUrlFactory.CreateThemedResourceUrl (
@@ -155,7 +156,7 @@ namespace Remotion.ObjectBinding.Web.UI.Controls.BocReferenceValueImplementation
               "BocAutoCompleteReferenceValue.css"),
           HtmlHeadAppender.Priority.Library);
 
-      string jqueryAutocompleteStyleKey = typeof (BocAutoCompleteReferenceValueRenderer).FullName + "_JQueryAutoCompleteStyle";
+      string jqueryAutocompleteStyleKey = typeof (BocAutoCompleteReferenceValueRenderer).GetFullNameChecked() + "_JQueryAutoCompleteStyle";
       htmlHeadAppender.RegisterStylesheetLink (
           jqueryAutocompleteStyleKey,
           ResourceUrlFactory.CreateThemedResourceUrl (

--- a/Remotion/ObjectBinding/Web/UI/Controls/BocReferenceValueImplementation/Rendering/BocReferenceValueRenderer.cs
+++ b/Remotion/ObjectBinding/Web/UI/Controls/BocReferenceValueImplementation/Rendering/BocReferenceValueRenderer.cs
@@ -22,6 +22,7 @@ using System.Web.UI;
 using System.Web.UI.WebControls;
 using Remotion.Globalization;
 using Remotion.ObjectBinding.Web.Contracts.DiagnosticMetadata;
+using Remotion.Reflection;
 using Remotion.ServiceLocation;
 using Remotion.Utilities;
 using Remotion.Web;
@@ -116,14 +117,14 @@ namespace Remotion.ObjectBinding.Web.UI.Controls.BocReferenceValueImplementation
 
       base.RegisterJavaScriptFiles (htmlHeadAppender);
 
-      string scriptFileKey = typeof (BocReferenceValueRenderer).FullName + "_Script";
+      string scriptFileKey = typeof (BocReferenceValueRenderer).GetFullNameChecked() + "_Script";
       var scriptUrl = ResourceUrlFactory.CreateResourceUrl (typeof (BocReferenceValueRenderer), ResourceType.Html, "BocReferenceValue.js");
       htmlHeadAppender.RegisterJavaScriptInclude (scriptFileKey, scriptUrl);
     }
 
     private void RegisterStylesheets (HtmlHeadAppender htmlHeadAppender)
     {
-      string styleFileKey = typeof (BocReferenceValueRenderer).FullName + "_Style";
+      string styleFileKey = typeof (BocReferenceValueRenderer).GetFullNameChecked() + "_Style";
       var styleUrl = ResourceUrlFactory.CreateThemedResourceUrl (typeof (BocReferenceValueRenderer), ResourceType.Html, "BocReferenceValue.css");
       htmlHeadAppender.RegisterStylesheetLink (styleFileKey, styleUrl, HtmlHeadAppender.Priority.Library);
     }

--- a/Remotion/ObjectBinding/Web/UI/Controls/BocReferenceValueImplementation/Rendering/BocReferenceValueRendererBase.cs
+++ b/Remotion/ObjectBinding/Web/UI/Controls/BocReferenceValueImplementation/Rendering/BocReferenceValueRendererBase.cs
@@ -25,6 +25,7 @@ using System.Web.UI.WebControls;
 using Remotion.Globalization;
 using Remotion.ObjectBinding.Web.Services;
 using Remotion.Mixins;
+using Remotion.Reflection;
 using Remotion.Utilities;
 using Remotion.Web;
 using Remotion.Web.UI;
@@ -77,7 +78,7 @@ namespace Remotion.ObjectBinding.Web.UI.Controls.BocReferenceValueImplementation
 
       htmlHeadAppender.RegisterUtilitiesJavaScriptInclude();
 
-      string scriptKey = typeof (BocReferenceValueRendererBase<>).FullName + "_Script";
+      string scriptKey = typeof (BocReferenceValueRendererBase<>).GetFullNameChecked() + "_Script";
       htmlHeadAppender.RegisterJavaScriptInclude (
           scriptKey,
           ResourceUrlFactory.CreateResourceUrl (typeof (BocReferenceValueRendererBase<>), ResourceType.Html, "BocReferenceValueBase.js"));
@@ -114,7 +115,7 @@ namespace Remotion.ObjectBinding.Web.UI.Controls.BocReferenceValueImplementation
 
     private void RegisterInitializationScript (BocRenderingContext<TControl> renderingContext)
     {
-      string key = typeof (BocReferenceValueRendererBase<>).FullName + "_InitializeGlobals";
+      string key = typeof (BocReferenceValueRendererBase<>).GetFullNameChecked() + "_InitializeGlobals";
 
       if (renderingContext.Control.Page.ClientScript.IsClientScriptBlockRegistered (typeof (BocReferenceValueRendererBase<>), key))
         return;

--- a/Remotion/ObjectBinding/Web/UI/Controls/BocTextValueImplementation/Rendering/BocMultilineTextValueRenderer.cs
+++ b/Remotion/ObjectBinding/Web/UI/Controls/BocTextValueImplementation/Rendering/BocMultilineTextValueRenderer.cs
@@ -22,6 +22,7 @@ using System.Web.UI.WebControls;
 using Remotion.FunctionalProgramming;
 using Remotion.Globalization;
 using Remotion.ObjectBinding.Web.Contracts.DiagnosticMetadata;
+using Remotion.Reflection;
 using Remotion.ServiceLocation;
 using Remotion.Utilities;
 using Remotion.Web;
@@ -55,7 +56,7 @@ namespace Remotion.ObjectBinding.Web.UI.Controls.BocTextValueImplementation.Rend
 
       textBoxStyle.RegisterJavaScriptInclude (ResourceUrlFactory, htmlHeadAppender);
 
-      string key = typeof (BocMultilineTextValueRenderer).FullName + "_Style";
+      string key = typeof (BocMultilineTextValueRenderer).GetFullNameChecked() + "_Style";
       var url = ResourceUrlFactory.CreateThemedResourceUrl (typeof (BocMultilineTextValueRenderer), ResourceType.Html, "BocMultilineTextValue.css");
       htmlHeadAppender.RegisterStylesheetLink (key, url, HtmlHeadAppender.Priority.Library);
     }

--- a/Remotion/ObjectBinding/Web/UI/Controls/BocTextValueImplementation/Rendering/BocTextValueRenderer.cs
+++ b/Remotion/ObjectBinding/Web/UI/Controls/BocTextValueImplementation/Rendering/BocTextValueRenderer.cs
@@ -20,6 +20,7 @@ using System.Web;
 using System.Web.UI;
 using System.Web.UI.WebControls;
 using Remotion.Globalization;
+using Remotion.Reflection;
 using Remotion.ServiceLocation;
 using Remotion.Utilities;
 using Remotion.Web;
@@ -52,7 +53,7 @@ namespace Remotion.ObjectBinding.Web.UI.Controls.BocTextValueImplementation.Rend
 
       textBoxStyle.RegisterJavaScriptInclude (ResourceUrlFactory, htmlHeadAppender);
 
-      string styleKey = typeof (BocTextValueRenderer).FullName + "_Style";
+      string styleKey = typeof (BocTextValueRenderer).GetFullNameChecked() + "_Style";
       var styleFile = ResourceUrlFactory.CreateThemedResourceUrl (typeof (BocTextValueRenderer), ResourceType.Html, "BocTextValue.css");
       htmlHeadAppender.RegisterStylesheetLink (styleKey, styleFile, HtmlHeadAppender.Priority.Library);
     }

--- a/Remotion/ObjectBinding/Web/UI/Controls/BocTextValueImplementation/Validation/BocTextValueValidatorFactory.cs
+++ b/Remotion/ObjectBinding/Web/UI/Controls/BocTextValueImplementation/Validation/BocTextValueValidatorFactory.cs
@@ -20,6 +20,7 @@ using System.Globalization;
 using System.Web.UI.WebControls;
 using JetBrains.Annotations;
 using Remotion.Globalization;
+using Remotion.Reflection;
 using Remotion.ServiceLocation;
 using Remotion.Utilities;
 using Remotion.Web.UI.Controls;
@@ -132,7 +133,7 @@ namespace Remotion.ObjectBinding.Web.UI.Controls.BocTextValueImplementation.Vali
         default:
         {
           throw new InvalidOperationException (
-              "BocTextValue '" + control.ID + "': Cannot convert " + valueType + " to type " + typeof (ValidationDataType).FullName + ".");
+              "BocTextValue '" + control.ID + "': Cannot convert " + valueType + " to type " + typeof (ValidationDataType).GetFullNameSafe() + ".");
         }
       }
     }

--- a/Remotion/ObjectBinding/Web/UI/Controls/BocTextValueValidator.cs
+++ b/Remotion/ObjectBinding/Web/UI/Controls/BocTextValueValidator.cs
@@ -18,6 +18,7 @@ using System;
 using System.Collections;
 using System.ComponentModel;
 using System.Web.UI.WebControls;
+using Remotion.Reflection;
 using Remotion.Web.UI.Controls;
 using Remotion.Web.UI.Design;
 
@@ -167,7 +168,7 @@ public class BocTextValueValidator: CompoundValidator
       case BocTextValueType.Double:
         return ValidationDataType.Double;
       default:
-        throw new ArgumentException ("Cannot convert " + valueType.ToString() + " to type " + typeof (ValidationDataType).FullName + ".");
+        throw new ArgumentException ("Cannot convert " + valueType.ToString() + " to type " + typeof (ValidationDataType).GetFullNameSafe() + ".");
     }
   }
 }

--- a/Remotion/ObjectBinding/Web/UI/Controls/Styles.cs
+++ b/Remotion/ObjectBinding/Web/UI/Controls/Styles.cs
@@ -17,6 +17,7 @@
 using System;
 using System.ComponentModel;
 using System.Web.UI.WebControls;
+using Remotion.Reflection;
 using Remotion.Utilities;
 using Remotion.Web;
 using Remotion.Web.UI;
@@ -391,7 +392,7 @@ namespace Remotion.ObjectBinding.Web.UI.Controls
   public class TextBoxStyle : SingleRowTextBoxStyle
   {
     private const string c_scriptFileUrl = "TextBoxStyle.js";
-    private static readonly string s_scriptFileKey = typeof (TextBoxStyle).FullName + "_Script";
+    private static readonly string s_scriptFileKey = typeof (TextBoxStyle).GetFullNameChecked() + "_Script";
 
     private int? _rows;
     private BocTextBoxMode _textMode;

--- a/Remotion/Security/Core/AccessType.cs
+++ b/Remotion/Security/Core/AccessType.cs
@@ -16,6 +16,7 @@
 // 
 using System;
 using System.Collections.Concurrent;
+using Remotion.Reflection;
 using Remotion.Utilities;
 
 namespace Remotion.Security
@@ -53,8 +54,8 @@ namespace Remotion.Security
         throw new ArgumentException (
             string.Format (
                 "Enumerated type '{0}' cannot be used as an access type. Valid access types must have the {1} applied.",
-                type.FullName,
-                typeof (AccessTypeAttribute).FullName),
+                type.GetFullNameSafe(),
+                typeof (AccessTypeAttribute).GetFullNameSafe()),
             "accessType");
       }
 

--- a/Remotion/Security/Core/DemandPermissionAttribute.cs
+++ b/Remotion/Security/Core/DemandPermissionAttribute.cs
@@ -15,6 +15,7 @@
 // along with re-motion; if not, see http://www.gnu.org/licenses.
 // 
 using System;
+using Remotion.Reflection;
 using Remotion.Utilities;
 
 namespace Remotion.Security
@@ -76,7 +77,7 @@ namespace Remotion.Security
       if (!permissionType.IsDefined (typeof (AccessTypeAttribute), false))
       {
         string message = string.Format (string.Format ("Enumerated Type '{0}' cannot be used as an access type. Valid access types must have the "
-                + "Remotion.Security.AccessTypeAttribute applied.", permissionType.FullName));
+                + "Remotion.Security.AccessTypeAttribute applied.", permissionType.GetFullNameSafe()));
 
         throw new ArgumentException (message, "accessType");
       }

--- a/Remotion/Security/Core/EnumWrapper.cs
+++ b/Remotion/Security/Core/EnumWrapper.cs
@@ -16,6 +16,7 @@
 // 
 using System;
 using System.Collections.Concurrent;
+using Remotion.Reflection;
 using Remotion.Utilities;
 
 namespace Remotion.Security
@@ -78,8 +79,8 @@ namespace Remotion.Security
         throw new ArgumentException (
             string.Format (
                 "Enumerated type '{0}' cannot be wrapped. Only enumerated types without the {1} can be wrapped.",
-                type.FullName,
-                typeof (FlagsAttribute).FullName),
+                type.GetFullNameSafe(),
+                typeof (FlagsAttribute).GetFullNameSafe()),
             "enumValue");
       }
 

--- a/Remotion/Security/Core/Metadata/EnumerationReflector.cs
+++ b/Remotion/Security/Core/Metadata/EnumerationReflector.cs
@@ -18,6 +18,7 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Reflection;
+using Remotion.Reflection;
 using Remotion.Utilities;
 
 namespace Remotion.Security.Metadata
@@ -43,7 +44,7 @@ namespace Remotion.Security.Metadata
     {
       ArgumentUtility.CheckNotNull ("type", type);
       if (!type.IsEnum)
-        throw new ArgumentException (string.Format ("The type '{0}' is not an enumerated type.", type.FullName), "type");
+        throw new ArgumentException (string.Format ("The type '{0}' is not an enumerated type.", type.GetFullNameSafe()), "type");
       ArgumentUtility.CheckNotNull ("cache", cache);
 
       IList values = Enum.GetValues (type);

--- a/Remotion/Security/Core/Metadata/ReflectionBasedMemberResolver.cs
+++ b/Remotion/Security/Core/Metadata/ReflectionBasedMemberResolver.cs
@@ -131,7 +131,7 @@ namespace Remotion.Security.Metadata
                 "The DemandPermissionAttribute must not be defined on methods overriden or redefined in derived classes. "
                 + "A method '{0}' exists in class '{1}' and its base class.",
                 methodName,
-                type.FullName),
+                type.GetFullNameSafe()),
             "methodName");
       }
 

--- a/Remotion/Security/Core/Metadata/StatePropertyReflector.cs
+++ b/Remotion/Security/Core/Metadata/StatePropertyReflector.cs
@@ -17,6 +17,7 @@
 using System;
 using System.Collections.Generic;
 using System.Reflection;
+using Remotion.Reflection;
 using Remotion.Utilities;
 
 namespace Remotion.Security.Metadata
@@ -57,14 +58,14 @@ namespace Remotion.Security.Metadata
       if (!property.PropertyType.IsEnum)
       {
         throw new ArgumentException (
-            string.Format ("The type of the property '{0}' in type '{1}' is not an enumerated type.", property.Name, property.DeclaringType.FullName),
+            string.Format ("The type of the property '{0}' in type '{1}' is not an enumerated type.", property.Name, property.DeclaringType.GetFullNameSafe()),
             "property");
       }
 
       if (!Attribute.IsDefined (property.PropertyType, typeof (SecurityStateAttribute), false))
       {
         throw new ArgumentException (string.Format ("The type of the property '{0}' in type '{1}' does not have the {2} applied.", 
-                property.Name, property.DeclaringType.FullName, typeof (SecurityStateAttribute).FullName),
+                property.Name, property.DeclaringType.GetFullNameSafe(), typeof (SecurityStateAttribute).GetFullNameSafe()),
             "property");
       }
 

--- a/Remotion/Security/Core/SecurityClient.cs
+++ b/Remotion/Security/Core/SecurityClient.cs
@@ -284,7 +284,7 @@ namespace Remotion.Security
         ArgumentUtility.CheckNotNull ("securableObject", securableObject);
 
         throw CreatePermissionDeniedException (
-            "Access to method '{0}' on type '{1}' has been denied.", methodName, securableObject.GetSecurableType().FullName);
+            "Access to method '{0}' on type '{1}' has been denied.", methodName, securableObject.GetSecurableType().GetFullNameSafe());
       }
     }
 
@@ -305,7 +305,7 @@ namespace Remotion.Security
         ArgumentUtility.CheckNotNull ("methodInfo", methodInfo);
 
         throw CreatePermissionDeniedException (
-            "Access to method '{0}' on type '{1}' has been denied.", methodInfo.Name, securableObject.GetSecurableType ().FullName);
+            "Access to method '{0}' on type '{1}' has been denied.", methodInfo.Name, securableObject.GetSecurableType ().GetFullNameSafe());
       }
     }
 
@@ -328,7 +328,7 @@ namespace Remotion.Security
         throw CreatePermissionDeniedException (
             "Access to method '{0}' on type '{1}' has been denied.",
             methodInformation.Name,
-            securableObject.GetSecurableType().FullName);
+            securableObject.GetSecurableType().GetFullNameSafe());
       }
     }
 
@@ -402,7 +402,7 @@ namespace Remotion.Security
         throw CreatePermissionDeniedException (
             "Access to method '{0}' on type '{1}' has been denied.",
             propertyName,
-            securableObject.GetSecurableType().FullName);
+            securableObject.GetSecurableType().GetFullNameSafe());
       }
     }
 
@@ -425,7 +425,7 @@ namespace Remotion.Security
         throw CreatePermissionDeniedException (
             "Access to get-accessor of property '{0}' on type '{1}' has been denied.",
             methodInfo.Name,
-            securableObject.GetSecurableType().FullName);
+            securableObject.GetSecurableType().GetFullNameSafe());
       }
     }
 
@@ -448,7 +448,7 @@ namespace Remotion.Security
         throw CreatePermissionDeniedException (
             "Access to method '{0}' on type '{1}' has been denied.",
             methodInformation.Name,
-            securableObject.GetSecurableType().FullName);
+            securableObject.GetSecurableType().GetFullNameSafe());
       }
     }
 
@@ -522,7 +522,7 @@ namespace Remotion.Security
         throw CreatePermissionDeniedException (
             "Access to set-accessor of property '{0}' on type '{1}' has been denied.",
             propertyName,
-            securableObject.GetSecurableType().FullName);
+            securableObject.GetSecurableType().GetFullNameSafe());
       }
     }
 
@@ -545,7 +545,7 @@ namespace Remotion.Security
         throw CreatePermissionDeniedException (
             "Access to set-accessor of property '{0}' on type '{1}' has been denied.",
             methodInfo.Name,
-            securableObject.GetSecurableType().FullName);
+            securableObject.GetSecurableType().GetFullNameSafe());
       }
     }
 
@@ -568,7 +568,7 @@ namespace Remotion.Security
         throw CreatePermissionDeniedException (
             "Access to set-accessor of property '{0}' on type '{1}' has been denied.",
             methodInformation.Name,
-            securableObject.GetSecurableType().FullName);
+            securableObject.GetSecurableType().GetFullNameSafe());
       }
     }
 
@@ -600,7 +600,7 @@ namespace Remotion.Security
       {
         ArgumentUtility.CheckNotNull ("securableClass", securableClass);
 
-        throw CreatePermissionDeniedException ("Access to constructor of type '{0}' has been denied.", securableClass.FullName);
+        throw CreatePermissionDeniedException ("Access to constructor of type '{0}' has been denied.", securableClass.GetFullNameSafe());
       }
     }
 
@@ -668,7 +668,7 @@ namespace Remotion.Security
         ArgumentUtility.CheckNotNull ("securableClass", securableClass);
         ArgumentUtility.CheckNotNullOrEmpty ("methodName", methodName);
 
-        throw CreatePermissionDeniedException ("Access to static method '{0}' on type '{1}' has been denied.", methodName, securableClass.FullName);
+        throw CreatePermissionDeniedException ("Access to static method '{0}' on type '{1}' has been denied.", methodName, securableClass.GetFullNameSafe());
       }
     }
 
@@ -691,7 +691,7 @@ namespace Remotion.Security
         throw CreatePermissionDeniedException (
             "Access to static method '{0}' on type '{1}' has been denied.",
             methodInfo.Name,
-            securableClass.FullName);
+            securableClass.GetFullNameSafe());
       }
     }
 
@@ -714,7 +714,7 @@ namespace Remotion.Security
         throw CreatePermissionDeniedException (
             "Access to static method '{0}' on type '{1}' has been denied.",
             methodInformation.Name,
-            securableClass.FullName);
+            securableClass.GetFullNameSafe());
       }
     }
 

--- a/Remotion/Security/Core/SecurityContext.cs
+++ b/Remotion/Security/Core/SecurityContext.cs
@@ -18,6 +18,7 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
+using Remotion.Reflection;
 using Remotion.Utilities;
 
 namespace Remotion.Security
@@ -128,7 +129,7 @@ namespace Remotion.Security
           string message = string.Format (
               "Enumerated Type '{0}' cannot be used as an abstract role. Valid abstract roles must have the {1} applied.",
               roleType,
-              typeof (AbstractRoleAttribute).FullName);
+              typeof (AbstractRoleAttribute).GetFullNameSafe());
 
           throw new ArgumentException (message, "abstractRoles");
         }
@@ -151,7 +152,7 @@ namespace Remotion.Security
           string message = string.Format (
               "Enumerated Type '{0}' cannot be used as a security state. Valid security states must have the {1} applied.",
               stateType,
-              typeof (SecurityStateAttribute).FullName);
+              typeof (SecurityStateAttribute).GetFullNameSafe());
 
           throw new ArgumentException (message, "states");
         }

--- a/Remotion/Security/Metadata.Extractor/Program.cs
+++ b/Remotion/Security/Metadata.Extractor/Program.cs
@@ -16,6 +16,7 @@
 // 
 using System;
 using System.Globalization;
+using Remotion.Reflection;
 using Remotion.Tools.Console.CommandLine;
 
 namespace Remotion.Security.Metadata.Extractor
@@ -82,7 +83,7 @@ namespace Remotion.Security.Metadata.Extractor
 
         for (; exception != null; exception = exception.InnerException)
         {
-          Console.Error.WriteLine ("{0}: {1}\n{2}", exception.GetType ().FullName, exception.Message, exception.StackTrace);
+          Console.Error.WriteLine ("{0}: {1}\n{2}", exception.GetType ().GetFullNameSafe(), exception.Message, exception.StackTrace);
         }
       }
       else

--- a/Remotion/Validation/Core/Implementation/ClassTypeAwareValidatedTypeResolverDecorator.cs
+++ b/Remotion/Validation/Core/Implementation/ClassTypeAwareValidatedTypeResolverDecorator.cs
@@ -15,6 +15,7 @@
 // along with re-motion; if not, see http://www.gnu.org/licenses.
 // 
 using System;
+using Remotion.Reflection;
 using Remotion.ServiceLocation;
 using Remotion.Utilities;
 using Remotion.Validation.Attributes;
@@ -66,9 +67,9 @@ namespace Remotion.Validation.Implementation
             string.Format (
                 "Invalid '{0}'-definition for collector '{1}': type '{2}' is not assignable from '{3}'.",
                 typeof (ApplyWithClassAttribute).Name,
-                collectorType.FullName,
-                validatedType.FullName,
-                classOrMixinType.FullName));
+                collectorType.GetFullNameSafe(),
+                validatedType.GetFullNameSafe(),
+                classOrMixinType.GetFullNameSafe()));
       }
     }
   }

--- a/Remotion/Validation/Core/Implementation/DiscoveryServiceBasedValidationRuleCollectorReflector.cs
+++ b/Remotion/Validation/Core/Implementation/DiscoveryServiceBasedValidationRuleCollectorReflector.cs
@@ -86,7 +86,7 @@ namespace Remotion.Validation.Implementation
     {
       var type = _validatedTypeResolver.GetValidatedType (collectorType);
       if (type == null)
-        throw new InvalidOperationException (string.Format ("No validated type could be resolved for collector '{0}'.", collectorType.FullName));
+        throw new InvalidOperationException (string.Format ("No validated type could be resolved for collector '{0}'.", collectorType.GetFullNameSafe()));
       return type;
     }
 

--- a/Remotion/Validation/Core/Merging/DiagnosticOutputValidationRuleMergeDecorator.cs
+++ b/Remotion/Validation/Core/Merging/DiagnosticOutputValidationRuleMergeDecorator.cs
@@ -100,7 +100,7 @@ namespace Remotion.Validation.Merging
 
     protected virtual string GetDomainTypeName (Type domainType)
     {
-      return domainType.FullName;
+      return domainType.GetFullNameChecked();
     }
 
     private string GetLogBefore (IEnumerable<IEnumerable<ValidationRuleCollectorInfo>> validationCollectorInfos)

--- a/Remotion/Validation/Core/Merging/NamespaceAwareDiagnosticOutputValidationRuleMergeDecorator.cs
+++ b/Remotion/Validation/Core/Merging/NamespaceAwareDiagnosticOutputValidationRuleMergeDecorator.cs
@@ -16,6 +16,7 @@
 // 
 using System;
 using Remotion.Logging;
+using Remotion.Reflection;
 using Remotion.Validation.Implementation;
 
 namespace Remotion.Validation.Merging
@@ -35,7 +36,7 @@ namespace Remotion.Validation.Merging
 
     protected override string GetTypeName (Type type)
     {
-      return type.FullName;
+      return type.GetFullNameChecked();
     }
   }
 }

--- a/Remotion/Validation/Core/MetaValidation/Rules/Custom/AnyRuleAppliedPropertyMetaValidationRule.cs
+++ b/Remotion/Validation/Core/MetaValidation/Rules/Custom/AnyRuleAppliedPropertyMetaValidationRule.cs
@@ -18,6 +18,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
+using Remotion.Reflection;
 using Remotion.Utilities;
 using Remotion.Validation.Attributes.MetaValidation;
 using Remotion.Validation.Validators;
@@ -48,7 +49,7 @@ namespace Remotion.Validation.MetaValidation.Rules.Custom
             MetaValidationRuleValidationResult.CreateInvalidResult (
                 "'{0}' failed for property '{1}.{2}': No validation rules defined.",
                 GetType ().Name,
-                _property.ReflectedType.FullName,
+                _property.ReflectedType.GetFullNameSafe(),
                 _property.Name);
       }
       else

--- a/Remotion/Validation/Core/MetaValidation/Rules/Custom/RemotionMaxLengthPropertyMetaValidationRule.cs
+++ b/Remotion/Validation/Core/MetaValidation/Rules/Custom/RemotionMaxLengthPropertyMetaValidationRule.cs
@@ -18,6 +18,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
+using Remotion.Reflection;
 using Remotion.Utilities;
 using Remotion.Validation.Validators;
 
@@ -51,7 +52,7 @@ namespace Remotion.Validation.MetaValidation.Rules.Custom
             MetaValidationRuleValidationResult.CreateInvalidResult (
                 "'{0}' failed for property '{1}.{2}': No max-length validation rules defined.",
                 GetType().Name,
-                _propertyInfo.ReflectedType.FullName,
+                _propertyInfo.ReflectedType.GetFullNameSafe(),
                 _propertyInfo.Name);
       }
       else if (rules.Where (r => r.Max > _maxLength).Any())
@@ -60,7 +61,7 @@ namespace Remotion.Validation.MetaValidation.Rules.Custom
             MetaValidationRuleValidationResult.CreateInvalidResult (
                 "'{0}' failed for property '{1}.{2}': Max-length validation rule value '{3}' exceeds meta validation rule max-length value of '{4}'.",
                 GetType().Name,
-                _propertyInfo.ReflectedType.FullName,
+                _propertyInfo.ReflectedType.GetFullNameSafe(),
                 _propertyInfo.Name,
                 rules.Max(r=>r.Max),
                 _maxLength);

--- a/Remotion/Validation/Core/RuleBuilders/AddingObjectValidationRuleBuilder.cs
+++ b/Remotion/Validation/Core/RuleBuilders/AddingObjectValidationRuleBuilder.cs
@@ -17,6 +17,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq.Expressions;
+using Remotion.Reflection;
 using Remotion.Utilities;
 using Remotion.Validation.MetaValidation;
 using Remotion.Validation.RuleCollectors;
@@ -104,7 +105,7 @@ namespace Remotion.Validation.RuleBuilders
             return MetaValidationRuleValidationResult.CreateInvalidResult (
                 "Meta validation rule '{0}' failed for validator '{1}' on type '{2}'.",
                 metaValidationRuleExpression,
-                typeof (TValidator).FullName,
+                typeof (TValidator).GetFullNameSafe(),
                 _addingObjectValidationRuleCollector.ValidatedType.FullName);
           });
 

--- a/Remotion/Validation/Core/RuleBuilders/AddingPropertyValidationRuleBuilder.cs
+++ b/Remotion/Validation/Core/RuleBuilders/AddingPropertyValidationRuleBuilder.cs
@@ -17,6 +17,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq.Expressions;
+using Remotion.Reflection;
 using Remotion.Utilities;
 using Remotion.Validation.MetaValidation;
 using Remotion.Validation.RuleCollectors;
@@ -104,7 +105,7 @@ namespace Remotion.Validation.RuleBuilders
             return MetaValidationRuleValidationResult.CreateInvalidResult (
                 "Meta validation rule '{0}' failed for validator '{1}' on property '{2}.{3}'.",
                 metaValidationRuleExpression,
-                typeof (TValidator).FullName,
+                typeof (TValidator).GetFullNameSafe(),
                 _addingPropertyValidationRuleCollector.Property.DeclaringType.FullName,
                 _addingPropertyValidationRuleCollector.Property.Name);
           });

--- a/Remotion/Validation/Core/RuleCollectors/AddingObjectValidationRuleCollector1.cs
+++ b/Remotion/Validation/Core/RuleCollectors/AddingObjectValidationRuleCollector1.cs
@@ -93,7 +93,7 @@ namespace Remotion.Validation.RuleCollectors
 
       if (typeof (TValidatedTypeForCondition) != typeof (TValidatedType))
         throw new ArgumentException (
-            $"The type '{typeof (TValidatedTypeForCondition).FullName}' of the predicate does not match the type '{typeof (TValidatedType).FullName}' of the validation rule.");
+            $"The type '{typeof (TValidatedTypeForCondition).GetFullNameSafe()}' of the predicate does not match the type '{typeof (TValidatedType).GetFullNameSafe()}' of the validation rule.");
 
       Condition = (Func<TValidatedType, bool>) (object) predicate;
     }

--- a/Remotion/Validation/Core/RuleCollectors/AddingPropertyValidationRuleCollector1.cs
+++ b/Remotion/Validation/Core/RuleCollectors/AddingPropertyValidationRuleCollector1.cs
@@ -92,7 +92,7 @@ namespace Remotion.Validation.RuleCollectors
 
       if (typeof (TValidatedTypeForCondition) != typeof (TValidatedType))
         throw new ArgumentException (
-            $"The type '{typeof (TValidatedTypeForCondition).FullName}' of the predicate does not match the type '{typeof (TValidatedType).FullName}' of the validation rule.");
+            $"The type '{typeof (TValidatedTypeForCondition).GetFullNameSafe()}' of the predicate does not match the type '{typeof (TValidatedType).GetFullNameSafe()}' of the validation rule.");
 
       Condition = (Func<TValidatedType, bool>) (object) predicate;
     }

--- a/Remotion/Validation/Mixins/Implementation/CheckNoMixinValidationRuleCollectorValidator.cs
+++ b/Remotion/Validation/Mixins/Implementation/CheckNoMixinValidationRuleCollectorValidator.cs
@@ -16,6 +16,7 @@
 // 
 using System;
 using Remotion.Mixins;
+using Remotion.Reflection;
 using Remotion.ServiceLocation;
 using Remotion.Utilities;
 using Remotion.Validation.Implementation;
@@ -45,7 +46,7 @@ namespace Remotion.Validation.Mixins.Implementation
               string.Format (
                   "Validation rules for type '{0}' are not supported. If validation rules should be defined for mixins, "
                   +"please ensure to apply the rules to 'ITargetInterface' or 'IIntroducedInterface' instead.",
-                  collector.ValidatedType.FullName));
+                  collector.ValidatedType.GetFullNameSafe()));
       }
     }
   }

--- a/Remotion/Web/Core/ExecutionEngine/Infrastructure/ResourceObjectWithVarRef.cs
+++ b/Remotion/Web/Core/ExecutionEngine/Infrastructure/ResourceObjectWithVarRef.cs
@@ -18,6 +18,7 @@ using System;
 using System.Reflection;
 using System.Web;
 using Remotion.Collections;
+using Remotion.Reflection;
 using Remotion.Utilities;
 using Remotion.Web.Resources;
 
@@ -51,7 +52,7 @@ namespace Remotion.Web.ExecutionEngine.Infrastructure
       
       string page = pageObject as string;
       if (page == null)
-        throw new InvalidCastException (string.Format ("The variable '{0}' was of type '{1}'. Expected type is '{2}'.", _pathReference.Name, pageObject.GetType().FullName, typeof (string).FullName));
+        throw new InvalidCastException (string.Format ("The variable '{0}' was of type '{1}'. Expected type is '{2}'.", _pathReference.Name, pageObject.GetType().GetFullNameSafe(), typeof (string).GetFullNameSafe()));
 
       return VirtualPathUtility.Combine (
           VirtualPathUtility.AppendTrailingSlash (ResourceRoot),

--- a/Remotion/Web/Core/ExecutionEngine/Infrastructure/WxeVariablesContainer.cs
+++ b/Remotion/Web/Core/ExecutionEngine/Infrastructure/WxeVariablesContainer.cs
@@ -23,6 +23,7 @@ using System.Linq;
 using System.Reflection;
 using Remotion.Collections;
 using Remotion.FunctionalProgramming;
+using Remotion.Reflection;
 using Remotion.ServiceLocation;
 using Remotion.Utilities;
 using Remotion.Web.UI.Controls;
@@ -43,7 +44,7 @@ namespace Remotion.Web.ExecutionEngine.Infrastructure
     {
       ArgumentUtility.CheckNotNull ("type", type);
       if (!typeof (WxeFunction).IsAssignableFrom (type))
-        throw new ArgumentException ("Type " + type.FullName + " is not derived from WxeFunction.", "type");
+        throw new ArgumentException ("Type " + type.GetFullNameSafe() + " is not derived from WxeFunction.", "type");
 
       return s_parameterDeclarations.GetOrAdd (type, s_getParameterDeclarationsUncheckedFunc);
     }

--- a/Remotion/Web/Core/ExecutionEngine/UrlMapping/UrlMappingConfiguration.cs
+++ b/Remotion/Web/Core/ExecutionEngine/UrlMapping/UrlMappingConfiguration.cs
@@ -17,6 +17,7 @@
 using System;
 using System.Collections;
 using System.Xml.Serialization;
+using Remotion.Reflection;
 using Remotion.Utilities;
 using Remotion.Web.Configuration;
 using Remotion.Web.Utilities;
@@ -173,7 +174,7 @@ public class UrlMappingEntry
       if (! typeof (WxeFunction).IsAssignableFrom (value))
         throw new ArgumentException (string.Format ("The FunctionType '{0}' must be derived from WxeFunction.", value), "FunctionType");
       _functionType = value;
-      _functionTypeName = _functionType.AssemblyQualifiedName;
+      _functionTypeName = _functionType.GetAssemblyQualifiedNameChecked();
     }
   }
 

--- a/Remotion/Web/Core/ExecutionEngine/WxeContext.cs
+++ b/Remotion/Web/Core/ExecutionEngine/WxeContext.cs
@@ -20,6 +20,7 @@ using System.ComponentModel;
 using System.Web;
 using System.Web.UI;
 using Remotion.Context;
+using Remotion.Reflection;
 using Remotion.Utilities;
 using Remotion.Web.ExecutionEngine.UrlMapping;
 using Remotion.Web.Utilities;
@@ -99,7 +100,7 @@ namespace Remotion.Web.ExecutionEngine
             throw new WxeException (
                 string.Format (
                     "No URL mapping has been defined for WXE Function '{0}', nor has a default WxeHandler URL been specified in the application configuration (web.config).",
-                    functionType.FullName));
+                    functionType.GetFullNameSafe()));
         }
         else
         {

--- a/Remotion/Web/Core/ExecutionEngine/WxeFunction.cs
+++ b/Remotion/Web/Core/ExecutionEngine/WxeFunction.cs
@@ -21,6 +21,7 @@ using System.Threading;
 using JetBrains.Annotations;
 using Remotion.Collections;
 using Remotion.FunctionalProgramming;
+using Remotion.Reflection;
 using Remotion.ServiceLocation;
 using Remotion.Utilities;
 using Remotion.Web.ExecutionEngine.Infrastructure;
@@ -121,7 +122,7 @@ namespace Remotion.Web.ExecutionEngine
         if (!_exceptionHandler.Catch (unwrappedException))
         {
           throw new WxeUnhandledException (
-              string.Format ("An exception ocured while executing WxeFunction '{0}'.", GetType().FullName),
+              string.Format ("An exception ocured while executing WxeFunction '{0}'.", GetType().GetFullNameSafe()),
               stepException);
         }
       }

--- a/Remotion/Web/Core/ExecutionEngine/WxeFunctionStateManager.cs
+++ b/Remotion/Web/Core/ExecutionEngine/WxeFunctionStateManager.cs
@@ -22,6 +22,7 @@ using System.Web;
 using System.Web.SessionState;
 using Remotion.Context;
 using Remotion.Logging;
+using Remotion.Reflection;
 using Remotion.Utilities;
 
 namespace Remotion.Web.ExecutionEngine
@@ -68,7 +69,7 @@ namespace Remotion.Web.ExecutionEngine
 
     private static readonly ILog s_log = LogManager.GetLogger (typeof (WxeFunctionStateManager));
 
-    private static readonly string s_key = typeof (WxeFunctionStateManager).AssemblyQualifiedName;
+    private static readonly string s_key = typeof (WxeFunctionStateManager).GetAssemblyQualifiedNameChecked();
     private static readonly string s_sessionKeyForFunctionStates = s_key + "|WxeFunctionStates";
 
     private static readonly SafeContextSingleton<WxeFunctionStateManager> s_functionStateManager =

--- a/Remotion/Web/Core/ExecutionEngine/WxeHandler.cs
+++ b/Remotion/Web/Core/ExecutionEngine/WxeHandler.cs
@@ -20,6 +20,7 @@ using System.IO;
 using System.Web;
 using System.Web.SessionState;
 using Remotion.Logging;
+using Remotion.Reflection;
 using Remotion.Utilities;
 using Remotion.Web.Configuration;
 using Remotion.Web.Utilities;
@@ -214,7 +215,7 @@ namespace Remotion.Web.ExecutionEngine
         if (!typeof (WxeFunction).IsAssignableFrom (type))
         {
           throw new WxeException (
-              string.Format ("The function type '{0}' is invalid. Wxe functions must be derived from '{1}'.", typeName, typeof (WxeFunction).FullName));
+              string.Format ("The function type '{0}' is invalid. Wxe functions must be derived from '{1}'.", typeName, typeof (WxeFunction).GetFullNameSafe()));
         }
         return type;
       }
@@ -405,7 +406,7 @@ namespace Remotion.Web.ExecutionEngine
       ArgumentUtility.CheckNotNull ("function", function);
       ArgumentUtility.CheckNotNull ("context", context);
       if (function.IsAborted)
-        throw new ArgumentException ("The function " + function.GetType().FullName + " is aborted.");
+        throw new ArgumentException ("The function " + function.GetType().GetFullNameSafe() + " is aborted.");
 
       function.ExceptionHandler.AppendCatchExceptionTypes (typeof (WxeUserCancelException));
       function.Execute (context);

--- a/Remotion/Web/Core/ExecutionEngine/WxeMethodStep.cs
+++ b/Remotion/Web/Core/ExecutionEngine/WxeMethodStep.cs
@@ -16,6 +16,7 @@
 // 
 using System;
 using System.Reflection;
+using Remotion.Reflection;
 using Remotion.Utilities;
 
 namespace Remotion.Web.ExecutionEngine
@@ -82,13 +83,13 @@ public class WxeMethodStep: WxeStep
     
     bool isAssignable = declaringType.IsAssignableFrom (targetType);
     if (! isAssignable || method.IsStatic)
-      throw new WxeException ("Method step '" + method.Name + "' is not an instance method of the type '" + targetType.FullName + "'.");
+      throw new WxeException ("Method step '" + method.Name + "' is not an instance method of the type '" + targetType.GetFullNameSafe() + "'.");
     
     ParameterInfo[] parameters = method.GetParameters();
     if (parameters.Length > 1)
-      throw new WxeException ("Method step '" + method.Name + "', declared in type '" + declaringType.FullName + "', does not support more than one parameter.");
+      throw new WxeException ("Method step '" + method.Name + "', declared in type '" + declaringType.GetFullNameSafe() + "', does not support more than one parameter.");
     if (parameters.Length == 1 && ! typeof (WxeContext).IsAssignableFrom (parameters[0].ParameterType))
-      throw new WxeException ("Method step '" + method.Name + "', declared in type '" + declaringType.FullName + "', may only have a parameter of type WxeContext.");
+      throw new WxeException ("Method step '" + method.Name + "', declared in type '" + declaringType.GetFullNameSafe() + "', may only have a parameter of type WxeContext.");
 
     _target = target;
     _methodName = method.Name;

--- a/Remotion/Web/Core/ExecutionEngine/WxePageInfo.cs
+++ b/Remotion/Web/Core/ExecutionEngine/WxePageInfo.cs
@@ -24,6 +24,7 @@ using System.Web.UI.HtmlControls;
 using JetBrains.Annotations;
 using Remotion.Collections;
 using Remotion.Globalization;
+using Remotion.Reflection;
 using Remotion.ServiceLocation;
 using Remotion.Utilities;
 using Remotion.Web.ExecutionEngine.Infrastructure;
@@ -64,9 +65,9 @@ namespace Remotion.Web.ExecutionEngine
     private const string c_styleFileUrl = "ExecutionEngine.css";
     private const string c_styleFileUrlForIE = "ExecutionEngineIE.css";
 
-    private static readonly string s_scriptFileKey = typeof (WxePageInfo).FullName + "_Script";
-    private static readonly string s_styleFileKey = typeof (WxePageInfo).FullName + "_Style";
-    private static readonly string s_styleFileKeyForIE = typeof (WxePageInfo).FullName + "_StyleIE";
+    private static readonly string s_scriptFileKey = typeof (WxePageInfo).GetFullNameChecked() + "_Script";
+    private static readonly string s_styleFileKey = typeof (WxePageInfo).GetFullNameChecked() + "_Style";
+    private static readonly string s_styleFileKeyForIE = typeof (WxePageInfo).GetFullNameChecked() + "_StyleIE";
 
     private readonly IWxePage _page;
     private WxeForm _wxeForm;
@@ -206,12 +207,12 @@ namespace Remotion.Web.ExecutionEngine
       if (fields.Length == 0 && !isDesignMode)
       {
         throw new ApplicationException (
-            "Page class " + _page.GetType().FullName + " has no field of type HtmlForm. Please add a field or override property IWxePage.HtmlForm.");
+            message: "Page class " + _page.GetType().GetFullNameSafe() + " has no field of type HtmlForm. Please add a field or override property IWxePage.HtmlForm.");
       }
       else if (fields.Length > 1)
       {
         throw new ApplicationException (
-            "Page class " + _page.GetType().FullName
+            "Page class " + _page.GetType().GetFullNameSafe()
             + " has more than one field of type HtmlForm. Please remove excessive fields or override property IWxePage.HtmlForm.");
       }
 

--- a/Remotion/Web/Core/ExecutionEngine/WxeParameterDeclaration.cs
+++ b/Remotion/Web/Core/ExecutionEngine/WxeParameterDeclaration.cs
@@ -16,6 +16,7 @@
 // 
 using System;
 using Remotion.Collections;
+using Remotion.Reflection;
 using Remotion.Utilities;
 
 namespace Remotion.Web.ExecutionEngine
@@ -107,7 +108,7 @@ public class WxeParameterDeclaration
   private void SetParameter (string parameterName, object value, NameObjectCollection variables)
   {
     if (value != null && _type != null && ! _type.IsAssignableFrom (value.GetType()))
-      throw new ApplicationException ("Parameter '" + parameterName + "' has unexpected type " + value.GetType().FullName + " (" + _type.FullName + " was expected).");
+      throw new ApplicationException ("Parameter '" + parameterName + "' has unexpected type " + value.GetType().GetFullNameSafe() + " (" + _type.GetFullNameSafe() + " was expected).");
     variables[parameterName] = value;
   }
 

--- a/Remotion/Web/Core/ExecutionEngine/WxeStepList.cs
+++ b/Remotion/Web/Core/ExecutionEngine/WxeStepList.cs
@@ -17,6 +17,7 @@
 using System;
 using System.Collections.Generic;
 using System.Reflection;
+using Remotion.Reflection;
 using Remotion.Utilities;
 using Remotion.Web.ExecutionEngine.Infrastructure;
 
@@ -73,7 +74,7 @@ namespace Remotion.Web.ExecutionEngine
       {
         var currentStep = _steps[_executingStep];
         if (currentStep.IsAborted)
-          throw new InvalidOperationException ("Step " + _executingStep + " of " + this.GetType ().FullName + " is aborted.");
+          throw new InvalidOperationException ("Step " + _executingStep + " of " + this.GetType ().GetFullNameSafe() + " is aborted.");
         currentStep.Execute (context);
         _executingStep++;
       }

--- a/Remotion/Web/Core/ExecutionEngine/WxeTemplateControlInfo.cs
+++ b/Remotion/Web/Core/ExecutionEngine/WxeTemplateControlInfo.cs
@@ -19,6 +19,7 @@ using System.Web;
 using System.Web.UI;
 using Remotion.Collections;
 using Remotion.Globalization;
+using Remotion.Reflection;
 using Remotion.ServiceLocation;
 using Remotion.Utilities;
 using Remotion.Web.UI.Globalization;
@@ -60,7 +61,7 @@ namespace Remotion.Web.ExecutionEngine
       {
         IWxePage wxePage = _control.Page as IWxePage;
         if (wxePage == null)
-          throw new InvalidOperationException (string.Format ("'{0}' can only be added to a Page implementing the IWxePage interface.", _control.GetType ().FullName));
+          throw new InvalidOperationException (string.Format ("'{0}' can only be added to a Page implementing the IWxePage interface.", _control.GetType ().GetFullNameSafe()));
         _wxeHandler = wxePage.WxeHandler;
       }
       if (_wxeHandler == null)

--- a/Remotion/Web/Core/Resources/ResourcePathBuilderBase.cs
+++ b/Remotion/Web/Core/Resources/ResourcePathBuilderBase.cs
@@ -17,6 +17,7 @@
 using System;
 using System.Collections.Concurrent;
 using System.Reflection;
+using Remotion.Reflection;
 using Remotion.Utilities;
 
 namespace Remotion.Web.Resources
@@ -39,7 +40,7 @@ namespace Remotion.Web.Resources
 
       string root = GetResourceRoot();
       // C# compiler 7.2 already provides caching for anonymous method.
-      string assemblyName = s_assemblyNameCache.GetOrAdd (assembly, key => key.GetName()).Name;
+      string assemblyName = s_assemblyNameCache.GetOrAdd (assembly, key => key.GetName()).GetNameChecked();
 
       string[] completePath = ArrayUtility.Combine (new[] { root, assemblyName }, assemblyRelativePathParts);
       return BuildPath (completePath);

--- a/Remotion/Web/Core/Services/WebServiceFactory.cs
+++ b/Remotion/Web/Core/Services/WebServiceFactory.cs
@@ -18,6 +18,7 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
+using Remotion.Reflection;
 using Remotion.ServiceLocation;
 using Remotion.Utilities;
 using Remotion.Web.Infrastructure;
@@ -88,7 +89,7 @@ namespace Remotion.Web.Services
                           ? "Web service '{0}' does not implement mandatory interface '{1}'."
                           : "Web service '{0}' is not based on type '{1}'.";
 
-        throw new ArgumentException (string.Format (message, virtualPath, typeof (T).FullName));
+        throw new ArgumentException (string.Format (message, virtualPath, typeof (T).GetFullNameSafe()));
       }
       return compiledType;
     }

--- a/Remotion/Web/Core/Services/WebServiceUtility.cs
+++ b/Remotion/Web/Core/Services/WebServiceUtility.cs
@@ -21,6 +21,7 @@ using System.Linq;
 using System.Reflection;
 using System.Web.Script.Services;
 using System.Web.Services;
+using Remotion.Reflection;
 using Remotion.Utilities;
 
 namespace Remotion.Web.Services
@@ -99,7 +100,7 @@ namespace Remotion.Web.Services
         throw CreateArgumentException (
             "Web method '{0}' on web service type '{1}' does not have the ResponseFormat property of the {2} set to Json.",
             method,
-            type.FullName,
+            type.GetFullNameSafe(),
             typeof (ScriptMethodAttribute).Name);
       }
       CheckParameters (type, methodInfo, parameters);
@@ -108,7 +109,7 @@ namespace Remotion.Web.Services
     private static void CheckType (Type type)
     {
       if (!typeof (WebService).IsAssignableFrom (type))
-        throw CreateArgumentException ("Web service type '{0}' does not derive from '{1}'.", type.FullName, typeof (WebService).FullName);
+        throw CreateArgumentException ("Web service type '{0}' does not derive from '{1}'.", type.GetFullNameSafe(), typeof (WebService).GetFullNameSafe());
     }
 
     private static MethodInfo GetCheckedMethodInfo (Type type, string method)
@@ -123,7 +124,7 @@ namespace Remotion.Web.Services
         throw CreateArgumentException (
             "Web method '{0}' was not found on the public API of web service type '{1}'.",
             method,
-            type.FullName);
+            type.GetFullNameSafe());
       }
       return methodInfo;
     }
@@ -136,8 +137,8 @@ namespace Remotion.Web.Services
       {
         throw CreateArgumentException (
             "Web service type '{0}' does not have the '{1}' applied.",
-            type.FullName,
-            typeof (T).FullName);
+            type.GetFullNameSafe(),
+            typeof (T).GetFullNameSafe());
       }
       return attribute;
     }
@@ -151,8 +152,8 @@ namespace Remotion.Web.Services
         throw CreateArgumentException (
             "Web method '{0}' on web service type '{1}' does not have the '{2}' applied.",
             methodInfo.Name,
-            type.FullName,
-            typeof (T).FullName);
+            type.GetFullNameSafe(),
+            typeof (T).GetFullNameSafe());
       }
       return attribute;
     }
@@ -169,7 +170,7 @@ namespace Remotion.Web.Services
         throw CreateArgumentException (
             "Web method '{0}' on web service type '{1}' does not declare the required parameter '{2}'. Parameters are matched by name and case.",
             methodInfo.Name,
-            type.FullName,
+            type.GetFullNameSafe(),
             firstMissingParameter);
       }
 
@@ -179,7 +180,7 @@ namespace Remotion.Web.Services
         throw CreateArgumentException (
             "Web method '{0}' on web service type '{1}' has unexpected parameter '{2}'.",
             methodInfo.Name,
-            type.FullName,
+            type.GetFullNameSafe(),
             firstUnexpectedParameter);
       }
     }

--- a/Remotion/Web/Core/UI/Controls/Command.cs
+++ b/Remotion/Web/Core/UI/Controls/Command.cs
@@ -25,6 +25,7 @@ using JetBrains.Annotations;
 using Remotion.Collections;
 using Remotion.FunctionalProgramming;
 using Remotion.Globalization;
+using Remotion.Reflection;
 using Remotion.Security;
 using Remotion.ServiceLocation;
 using Remotion.Utilities;
@@ -547,7 +548,7 @@ namespace Remotion.Web.UI.Controls
           return GetCommandInfoForNoneCommand();
         default:
           throw new InvalidOperationException (
-              string.Format ("The CommandType '{0}' is not supported by the '{1}'.", _type, typeof (Command).FullName));
+              string.Format ("The CommandType '{0}' is not supported by the '{1}'.", _type, typeof (Command).GetFullNameSafe()));
       }
     }
 
@@ -1041,7 +1042,7 @@ namespace Remotion.Web.UI.Controls
           return true;
         default:
           throw new InvalidOperationException (
-              string.Format ("The CommandType '{0}' is not supported by the '{1}'.", _type, typeof (Command).FullName));
+              string.Format ("The CommandType '{0}' is not supported by the '{1}'.", _type, typeof (Command).GetFullNameSafe()));
       }
     }
 

--- a/Remotion/Web/Core/UI/Controls/ControlItemCollection.cs
+++ b/Remotion/Web/Core/UI/Controls/ControlItemCollection.cs
@@ -21,6 +21,7 @@ using System.Reflection;
 using System.Web.UI;
 using Remotion.Globalization;
 using Remotion.Logging;
+using Remotion.Reflection;
 using Remotion.Utilities;
 using Remotion.Web.UI.Globalization;
 
@@ -60,7 +61,7 @@ namespace Remotion.Web.UI.Controls
         if (!typeof (IControlItem).IsAssignableFrom (type))
         {
           throw new ArgumentException (
-              string.Format ("Type '{0}' at index {1} does not implement interface 'IControlItem'.", type.FullName, i), "supportedTypes");
+              string.Format ("Type '{0}' at index {1} does not implement interface 'IControlItem'.", type.GetFullNameSafe(), i), "supportedTypes");
         }
       }
 

--- a/Remotion/Web/Core/UI/Controls/DatePickerButtonImplementation/Rendering/DatePickerButtonRenderer.cs
+++ b/Remotion/Web/Core/UI/Controls/DatePickerButtonImplementation/Rendering/DatePickerButtonRenderer.cs
@@ -20,6 +20,7 @@ using System.Threading;
 using System.Web.UI;
 using System.Web.UI.WebControls;
 using Remotion.Globalization;
+using Remotion.Reflection;
 using Remotion.ServiceLocation;
 using Remotion.Utilities;
 using Remotion.Web.UI.Controls.Rendering;
@@ -48,11 +49,11 @@ namespace Remotion.Web.UI.Controls.DatePickerButtonImplementation.Rendering
 
       htmlHeadAppender.RegisterUtilitiesJavaScriptInclude ();
 
-      string scriptFileKey = typeof (DatePickerButtonRenderer).FullName + "_Script";
+      string scriptFileKey = typeof (DatePickerButtonRenderer).GetFullNameChecked() + "_Script";
       var scriptUrl = ResourceUrlFactory.CreateResourceUrl (typeof (DatePickerButtonRenderer), ResourceType.Html, "DatePicker.js");
       htmlHeadAppender.RegisterJavaScriptInclude (scriptFileKey, scriptUrl);
 
-      string styleFileKey = typeof (DatePickerButtonRenderer).FullName + "_Style";
+      string styleFileKey = typeof (DatePickerButtonRenderer).GetFullNameChecked() + "_Style";
       var styleUrl = ResourceUrlFactory.CreateThemedResourceUrl (typeof (DatePickerButtonRenderer), ResourceType.Html, "DatePicker.css");
       htmlHeadAppender.RegisterStylesheetLink (styleFileKey, styleUrl, HtmlHeadAppender.Priority.Library);
     }

--- a/Remotion/Web/Core/UI/Controls/DatePickerButtonImplementation/Rendering/DatePickerPageRenderer.cs
+++ b/Remotion/Web/Core/UI/Controls/DatePickerButtonImplementation/Rendering/DatePickerPageRenderer.cs
@@ -15,6 +15,7 @@
 // along with re-motion; if not, see http://www.gnu.org/licenses.
 // 
 using System;
+using Remotion.Reflection;
 using Remotion.ServiceLocation;
 using Remotion.Utilities;
 
@@ -36,7 +37,7 @@ namespace Remotion.Web.UI.Controls.DatePickerButtonImplementation.Rendering
     {
       ArgumentUtility.CheckNotNull ("htmlHeadAppender", htmlHeadAppender);
 
-      string key = typeof (DatePickerPageRenderer).FullName + "_Script";
+      string key = typeof (DatePickerPageRenderer).GetFullNameChecked() + "_Script";
       var scriptUrl = ResourceUrlFactory.CreateResourceUrl (typeof (DatePickerPageRenderer), ResourceType.Html, "DatePicker.js");
       htmlHeadAppender.RegisterJavaScriptInclude (key, scriptUrl);
 

--- a/Remotion/Web/Core/UI/Controls/DatePickerPage.cs
+++ b/Remotion/Web/Core/UI/Controls/DatePickerPage.cs
@@ -19,6 +19,7 @@ using System.Web;
 using System.Web.UI;
 using System.Web.UI.HtmlControls;
 using System.Web.UI.WebControls;
+using Remotion.Reflection;
 using Remotion.ServiceLocation;
 using Remotion.Web.Infrastructure;
 using Remotion.Web.UI.Controls.DatePickerButtonImplementation.Rendering;
@@ -78,11 +79,11 @@ public class DatePickerPage : Page
   override protected void OnInit(EventArgs e)
 	{
     if (Form == null)
-      throw new HttpException (this.GetType().FullName + " does not initialize field 'Form'.");
+      throw new HttpException (this.GetType().GetFullNameSafe() + " does not initialize field 'Form'.");
     if (HtmlHeadContents == null)
-      throw new HttpException (this.GetType().FullName + " does not initialize field 'HtmlHeadContents'.");
+      throw new HttpException (this.GetType().GetFullNameSafe() + " does not initialize field 'HtmlHeadContents'.");
     if (Calendar == null)
-      throw new HttpException (this.GetType().FullName + " does not initialize field 'Calendar'.");
+      throw new HttpException (this.GetType().GetFullNameSafe() + " does not initialize field 'Calendar'.");
 
     Calendar.SelectionChanged += new EventHandler(Calendar_SelectionChanged);
 

--- a/Remotion/Web/Core/UI/Controls/DropDownMenuImplementation/Rendering/DropDownMenuRenderer.cs
+++ b/Remotion/Web/Core/UI/Controls/DropDownMenuImplementation/Rendering/DropDownMenuRenderer.cs
@@ -19,6 +19,7 @@ using System.Collections.Generic;
 using System.Text;
 using System.Web.UI;
 using Remotion.Globalization;
+using Remotion.Reflection;
 using Remotion.ServiceLocation;
 using Remotion.Utilities;
 using Remotion.Web.Contracts.DiagnosticMetadata;
@@ -72,11 +73,11 @@ namespace Remotion.Web.UI.Controls.DropDownMenuImplementation.Rendering
 
       htmlHeadAppender.RegisterUtilitiesJavaScriptInclude();
 
-      string scriptKey = typeof (DropDownMenuRenderer).FullName + "_Script";
+      string scriptKey = typeof (DropDownMenuRenderer).GetFullNameChecked() + "_Script";
       var scriptUrl = ResourceUrlFactory.CreateResourceUrl (typeof (DropDownMenuRenderer), ResourceType.Html, "DropDownMenu.js");
       htmlHeadAppender.RegisterJavaScriptInclude (scriptKey, scriptUrl);
 
-      string styleSheetKey = typeof (DropDownMenuRenderer).FullName + "_Style";
+      string styleSheetKey = typeof (DropDownMenuRenderer).GetFullNameChecked() + "_Style";
       var styleSheetUrl = ResourceUrlFactory.CreateThemedResourceUrl (typeof (DropDownMenuRenderer), ResourceType.Html, "DropDownMenu.css");
       htmlHeadAppender.RegisterStylesheetLink (styleSheetKey, styleSheetUrl, HtmlHeadAppender.Priority.Library);
     }

--- a/Remotion/Web/Core/UI/Controls/FormGridManager.cs
+++ b/Remotion/Web/Core/UI/Controls/FormGridManager.cs
@@ -27,6 +27,7 @@ using System.Web.UI.WebControls;
 using Microsoft.Practices.ServiceLocation;
 using Remotion.Globalization;
 using Remotion.Logging;
+using Remotion.Reflection;
 using Remotion.ServiceLocation;
 using Remotion.Utilities;
 using Remotion.Web.Contracts.DiagnosticMetadata;
@@ -265,7 +266,7 @@ namespace Remotion.Web.UI.Controls
         //  Not found, append to form grid instead of inserting at position of related form grid row
         if (relatedRow == null)
         {
-          s_log.Warn ("Could not find control '" + relatedRowID + "' inside FormGrid (HtmlTable) '" + _table.ID + "' in naming container '" + _table.NamingContainer.GetType().FullName + "' on page '" + _table.Page.ToString() + "'.");
+          s_log.Warn ("Could not find control '" + relatedRowID + "' inside FormGrid (HtmlTable) '" + _table.ID + "' in naming container '" + _table.NamingContainer.GetType().GetFullNameSafe() + "' on page '" + _table.Page.ToString() + "'.");
 
           //  append html table rows
           for (int i = 0; i < newFormGridRow.HtmlTableRows.Count; i++)
@@ -1220,7 +1221,7 @@ namespace Remotion.Web.UI.Controls
           else
           {
             //  Invalid control
-            s_log.Warn ("FormGrid '" + tableID + "' in naming container '" + NamingContainer.GetType().FullName + "' on page '" + Page.ToString() + "' does not contain a control with UniqueID '" + controlID + "'.");
+            s_log.Warn ("FormGrid '" + tableID + "' in naming container '" + NamingContainer.GetType().GetFullNameSafe() + "' on page '" + Page.ToString() + "' does not contain a control with UniqueID '" + controlID + "'.");
           }
         }
       }
@@ -1232,7 +1233,7 @@ namespace Remotion.Web.UI.Controls
 
       NamingContainer.Load += new EventHandler(NamingContainer_Load);
 
-      string key = typeof (FormGridManager).FullName + "_Style";
+      string key = typeof (FormGridManager).GetFullNameChecked() + "_Style";
       if (!HtmlHeadAppender.Current.IsRegistered (key))
       {
         var url = InfrastructureResourceUrlFactory.CreateThemedResourceUrl (ResourceType.Html, "FormGrid.css");

--- a/Remotion/Web/Core/UI/Controls/ListMenuImplementation/Rendering/ListMenuRenderer.cs
+++ b/Remotion/Web/Core/UI/Controls/ListMenuImplementation/Rendering/ListMenuRenderer.cs
@@ -22,6 +22,7 @@ using System.Text;
 using System.Web.UI;
 using System.Web.UI.WebControls;
 using Remotion.Globalization;
+using Remotion.Reflection;
 using Remotion.ServiceLocation;
 using Remotion.Utilities;
 using Remotion.Web.Contracts.DiagnosticMetadata;
@@ -55,11 +56,11 @@ namespace Remotion.Web.UI.Controls.ListMenuImplementation.Rendering
 
       htmlHeadAppender.RegisterUtilitiesJavaScriptInclude();
 
-      string scriptFileKey = typeof (ListMenuRenderer).FullName + "_Script";
+      string scriptFileKey = typeof (ListMenuRenderer).GetFullNameChecked() + "_Script";
       var scriptFileUrl = ResourceUrlFactory.CreateResourceUrl (typeof (ListMenuRenderer), ResourceType.Html, "ListMenu.js");
       htmlHeadAppender.RegisterJavaScriptInclude (scriptFileKey, scriptFileUrl);
 
-      string styleSheetKey = typeof (ListMenuRenderer).FullName + "_Style";
+      string styleSheetKey = typeof (ListMenuRenderer).GetFullNameChecked() + "_Style";
       var styleSheetUrl = ResourceUrlFactory.CreateThemedResourceUrl (typeof (ListMenuRenderer), ResourceType.Html, "ListMenu.css");
       htmlHeadAppender.RegisterStylesheetLink (styleSheetKey, styleSheetUrl, HtmlHeadAppender.Priority.Library);
     }

--- a/Remotion/Web/Core/UI/Controls/Rendering/ViewLayoutExtensions.cs
+++ b/Remotion/Web/Core/UI/Controls/Rendering/ViewLayoutExtensions.cs
@@ -15,6 +15,7 @@
 // along with re-motion; if not, see http://www.gnu.org/licenses.
 // 
 using System;
+using Remotion.Reflection;
 using Remotion.ServiceLocation;
 using Remotion.Utilities;
 
@@ -29,7 +30,7 @@ namespace Remotion.Web.UI.Controls.Rendering
     {
       ArgumentUtility.CheckNotNull ("htmlHeadAppender", htmlHeadAppender);
       
-      string keyScript = typeof (ViewLayoutExtensions).FullName + "_Script";
+      string keyScript = typeof (ViewLayoutExtensions).GetFullNameChecked() + "_Script";
       var scriptUrl = ResourceUrlFactory.CreateResourceUrl (typeof (ViewLayoutExtensions), ResourceType.Html, "ViewLayout.js");
       htmlHeadAppender.RegisterJavaScriptInclude (keyScript, scriptUrl);
     }

--- a/Remotion/Web/Core/UI/Controls/SingleViewImplementation/Rendering/SingleViewRenderer.cs
+++ b/Remotion/Web/Core/UI/Controls/SingleViewImplementation/Rendering/SingleViewRenderer.cs
@@ -18,6 +18,7 @@ using System;
 using System.Web.UI;
 using System.Web.UI.WebControls;
 using Remotion.Globalization;
+using Remotion.Reflection;
 using Remotion.ServiceLocation;
 using Remotion.Utilities;
 using Remotion.Web.UI.Controls.Rendering;
@@ -47,7 +48,7 @@ namespace Remotion.Web.UI.Controls.SingleViewImplementation.Rendering
 
       htmlHeadAppender.RegisterUtilitiesJavaScriptInclude();
 
-      string keyStyle = typeof (SingleViewRenderer).FullName + "_Style";
+      string keyStyle = typeof (SingleViewRenderer).GetFullNameChecked() + "_Style";
 
       var styleSheetUrl = ResourceUrlFactory.CreateThemedResourceUrl (typeof (SingleViewRenderer), ResourceType.Html, "SingleView.css");
       htmlHeadAppender.RegisterStylesheetLink (keyStyle, styleSheetUrl, HtmlHeadAppender.Priority.Library);

--- a/Remotion/Web/Core/UI/Controls/TabbedMenu.cs
+++ b/Remotion/Web/Core/UI/Controls/TabbedMenu.cs
@@ -23,6 +23,7 @@ using System.Web;
 using System.Web.UI;
 using System.Web.UI.WebControls;
 using Remotion.Globalization;
+using Remotion.Reflection;
 using Remotion.ServiceLocation;
 using Remotion.Utilities;
 using Remotion.Web.ExecutionEngine;
@@ -433,7 +434,7 @@ namespace Remotion.Web.UI.Controls
       else if (subMenuTab != null)
         tabIDs = ConvertTabIDsToArray (subMenuTab.Parent, subMenuTab);
       else
-        throw new NotSupportedException (string.Format ("menuTab is of unsupported type '{0}'.", menuTab.GetType().FullName));
+        throw new NotSupportedException (string.Format ("menuTab is of unsupported type '{0}'.", menuTab.GetType().GetFullNameSafe()));
 
       string value = (string) TypeConversionProvider.Convert (typeof (string[]), typeof (string), tabIDs);
 

--- a/Remotion/Web/Core/UI/Controls/TabbedMenuImplementation/Rendering/TabbedMenuRenderer.cs
+++ b/Remotion/Web/Core/UI/Controls/TabbedMenuImplementation/Rendering/TabbedMenuRenderer.cs
@@ -19,6 +19,7 @@ using System.Drawing;
 using System.Web.UI;
 using System.Web.UI.WebControls;
 using Remotion.Globalization;
+using Remotion.Reflection;
 using Remotion.ServiceLocation;
 using Remotion.Utilities;
 using Remotion.Web.UI.Controls.Rendering;
@@ -43,7 +44,7 @@ namespace Remotion.Web.UI.Controls.TabbedMenuImplementation.Rendering
     public void RegisterHtmlHeadContents (HtmlHeadAppender htmlHeadAppender)
     {
       ArgumentUtility.CheckNotNull ("htmlHeadAppender", htmlHeadAppender);
-      string key = typeof (TabbedMenuRenderer).FullName + "_Style";
+      string key = typeof (TabbedMenuRenderer).GetFullNameChecked() + "_Style";
       var url = ResourceUrlFactory.CreateThemedResourceUrl (typeof (TabbedMenuRenderer), ResourceType.Html, "TabbedMenu.css");
       htmlHeadAppender.RegisterStylesheetLink (key, url, HtmlHeadAppender.Priority.Library);
     }

--- a/Remotion/Web/Core/UI/Controls/TabbedMultiViewImplementation/Rendering/TabbedMultiViewRenderer.cs
+++ b/Remotion/Web/Core/UI/Controls/TabbedMultiViewImplementation/Rendering/TabbedMultiViewRenderer.cs
@@ -19,6 +19,7 @@ using System.Linq;
 using System.Web.UI;
 using System.Web.UI.WebControls;
 using Remotion.Globalization;
+using Remotion.Reflection;
 using Remotion.ServiceLocation;
 using Remotion.Utilities;
 using Remotion.Web.UI.Controls.Rendering;
@@ -62,7 +63,7 @@ namespace Remotion.Web.UI.Controls.TabbedMultiViewImplementation.Rendering
 
       htmlHeadAppender.RegisterUtilitiesJavaScriptInclude();
 
-      string keyStyle = typeof (TabbedMultiViewRenderer).FullName + "_Style";
+      string keyStyle = typeof (TabbedMultiViewRenderer).GetFullNameChecked() + "_Style";
       var styleSheetUrl = ResourceUrlFactory.CreateThemedResourceUrl (typeof (TabbedMultiViewRenderer), ResourceType.Html, "TabbedMultiView.css");
       htmlHeadAppender.RegisterStylesheetLink (keyStyle, styleSheetUrl, HtmlHeadAppender.Priority.Library);
 

--- a/Remotion/Web/Core/UI/Controls/WebButtonImplementation/Rendering/WebButtonRenderer.cs
+++ b/Remotion/Web/Core/UI/Controls/WebButtonImplementation/Rendering/WebButtonRenderer.cs
@@ -16,6 +16,7 @@
 // 
 using System;
 using Remotion.Globalization;
+using Remotion.Reflection;
 using Remotion.ServiceLocation;
 using Remotion.Utilities;
 using Remotion.Web.UI.Controls.Rendering;
@@ -41,11 +42,11 @@ namespace Remotion.Web.UI.Controls.WebButtonImplementation.Rendering
     {
       ArgumentUtility.CheckNotNull ("htmlHeadAppender", htmlHeadAppender);
 
-      string scriptKey = typeof (WebButtonRenderer).FullName + "_Script";
+      string scriptKey = typeof (WebButtonRenderer).GetFullNameChecked() + "_Script";
       var scriptUrl = ResourceUrlFactory.CreateResourceUrl (typeof (WebButtonRenderer), ResourceType.Html, "WebButton.js");
       htmlHeadAppender.RegisterJavaScriptInclude (scriptKey, scriptUrl);
 
-      string styleKey = typeof (WebButtonRenderer).FullName + "_Style";
+      string styleKey = typeof (WebButtonRenderer).GetFullNameChecked() + "_Style";
       var styleUrl = ResourceUrlFactory.CreateThemedResourceUrl (typeof (WebButtonRenderer), ResourceType.Html, "WebButton.css");
       htmlHeadAppender.RegisterStylesheetLink (styleKey, styleUrl, HtmlHeadAppender.Priority.Library);
     }

--- a/Remotion/Web/Core/UI/Controls/WebTabCollection.cs
+++ b/Remotion/Web/Core/UI/Controls/WebTabCollection.cs
@@ -17,6 +17,7 @@
 using System;
 using System.Collections;
 using System.Web.UI;
+using Remotion.Reflection;
 using Remotion.Utilities;
 using Remotion.Web.Utilities;
 
@@ -42,7 +43,7 @@ namespace Remotion.Web.UI.Controls
         if (!typeof (WebTab).IsAssignableFrom (type))
         {
           throw new ArgumentException (
-              string.Format ("Type '{0}' at index {1} is not compatible with type 'WebTab'.", type.FullName, i), "supportedTypes");
+              string.Format ("Type '{0}' at index {1} is not compatible with type 'WebTab'.", type.GetFullNameSafe(), i), "supportedTypes");
         }
       }
     }

--- a/Remotion/Web/Core/UI/Controls/WebTabStrip.cs
+++ b/Remotion/Web/Core/UI/Controls/WebTabStrip.cs
@@ -25,6 +25,7 @@ using System.Web.UI;
 using System.Web.UI.WebControls;
 using Remotion.Globalization;
 using Remotion.Logging;
+using Remotion.Reflection;
 using Remotion.ServiceLocation;
 using Remotion.Utilities;
 using Remotion.Web.Infrastructure;
@@ -362,7 +363,7 @@ namespace Remotion.Web.UI.Controls
             {
               //  Invalid collection property
               s_log.Warn (
-                  "WebTabStrip '" + ID + "' in naming container '" + NamingContainer.GetType().FullName + "' on page '" + Page
+                  "WebTabStrip '" + ID + "' in naming container '" + NamingContainer.GetType().GetFullNameSafe() + "' on page '" + Page
                   + "' does not contain a collection property named '" + collectionID + "'.");
               break;
             }
@@ -389,7 +390,7 @@ namespace Remotion.Web.UI.Controls
         {
           //  Not supported format or invalid property
           s_log.Warn (
-              "WebTabStrip '" + ID + "' in naming container '" + NamingContainer.GetType().FullName + "' on page '" + Page
+              "WebTabStrip '" + ID + "' in naming container '" + NamingContainer.GetType().GetFullNameSafe() + "' on page '" + Page
               + "' received a resource with an invalid or unknown key '" + key
               + "'. Required format: 'property' or 'collectionID:elementID:property'.");
         }

--- a/Remotion/Web/Core/UI/Controls/WebTabStripImplementation/Rendering/WebTabStripRenderer.cs
+++ b/Remotion/Web/Core/UI/Controls/WebTabStripImplementation/Rendering/WebTabStripRenderer.cs
@@ -18,6 +18,7 @@ using System;
 using System.Web.UI;
 using System.Web.UI.WebControls;
 using Remotion.Globalization;
+using Remotion.Reflection;
 using Remotion.ServiceLocation;
 using Remotion.Utilities;
 using Remotion.Web.UI.Controls.Rendering;
@@ -45,11 +46,11 @@ namespace Remotion.Web.UI.Controls.WebTabStripImplementation.Rendering
       ArgumentUtility.CheckNotNull ("htmlHeadAppender", htmlHeadAppender);
       ArgumentUtility.CheckNotNull ("control", control);
 
-      string key = typeof (WebTabStripRenderer).FullName + "_Style";
+      string key = typeof (WebTabStripRenderer).GetFullNameChecked() + "_Style";
       var styleSheetUrl = ResourceUrlFactory.CreateThemedResourceUrl (typeof (WebTabStripRenderer), ResourceType.Html, "TabStrip.css");
       htmlHeadAppender.RegisterStylesheetLink (key, styleSheetUrl, HtmlHeadAppender.Priority.Library);
 
-      string keyScript = typeof (WebTabStripRenderer).FullName + "_Script";
+      string keyScript = typeof (WebTabStripRenderer).GetFullNameChecked() + "_Script";
       var scriptUrl = ResourceUrlFactory.CreateResourceUrl (typeof (WebTabStripRenderer), ResourceType.Html, "TabStrip.js");
       htmlHeadAppender.RegisterJavaScriptInclude (keyScript, scriptUrl);
 

--- a/Remotion/Web/Core/UI/Controls/WebTreeViewImplementation/Rendering/WebTreeViewRenderer.cs
+++ b/Remotion/Web/Core/UI/Controls/WebTreeViewImplementation/Rendering/WebTreeViewRenderer.cs
@@ -16,6 +16,7 @@
 // 
 using System;
 using Remotion.Globalization;
+using Remotion.Reflection;
 using Remotion.ServiceLocation;
 using Remotion.Utilities;
 using Remotion.Web.UI.Controls.Rendering;
@@ -41,11 +42,11 @@ namespace Remotion.Web.UI.Controls.WebTreeViewImplementation.Rendering
     {
       ArgumentUtility.CheckNotNull ("htmlHeadAppender", htmlHeadAppender);
       
-      string scriptFileKey = typeof (WebTreeViewRenderer).FullName + "_Script";
+      string scriptFileKey = typeof (WebTreeViewRenderer).GetFullNameChecked() + "_Script";
       var scriptFileUrl = ResourceUrlFactory.CreateResourceUrl (typeof (WebTreeViewRenderer), ResourceType.Html, "TreeView.js");
       htmlHeadAppender.RegisterJavaScriptInclude (scriptFileKey, scriptFileUrl);
 
-      string styleKey = typeof (WebTreeViewRenderer).FullName + "_Style";
+      string styleKey = typeof (WebTreeViewRenderer).GetFullNameChecked() + "_Style";
       var styleSheetUrl = ResourceUrlFactory.CreateThemedResourceUrl (typeof (WebTreeViewRenderer), ResourceType.Html, "TreeView.css");
       htmlHeadAppender.RegisterStylesheetLink (styleKey, styleSheetUrl, HtmlHeadAppender.Priority.Library);
     }

--- a/Remotion/Web/Core/UI/Design/CollectionEditorServiceProvider.cs
+++ b/Remotion/Web/Core/UI/Design/CollectionEditorServiceProvider.cs
@@ -19,6 +19,7 @@ using System.Drawing;
 using System.Reflection;
 using System.Windows.Forms;
 using System.Windows.Forms.Design;
+using Remotion.Reflection;
 
 namespace Remotion.Web.UI.Design
 {
@@ -99,7 +100,7 @@ public class CollectionEditorServiceProvider: IServiceProvider, IWindowsFormsEdi
     BindingFlags bindingFlags = BindingFlags.DeclaredOnly | BindingFlags.Instance | BindingFlags.NonPublic;
 
     Type collectionEditorCollectionFormType = editor.GetType();
-    if (collectionEditorCollectionFormType.FullName != collectionEditorCollectionFormTypeName)
+    if (collectionEditorCollectionFormType.GetFullNameChecked() != collectionEditorCollectionFormTypeName)
     {
       throw new ArgumentException (
           string.Format ("Argument {0} has type {2} when type {1} was expected.",
@@ -125,7 +126,7 @@ public class CollectionEditorServiceProvider: IServiceProvider, IWindowsFormsEdi
     BindingFlags bindingFlags = BindingFlags.DeclaredOnly | BindingFlags.Instance | BindingFlags.NonPublic;
 
     Type collectionEditorCollectionFormType = editor.GetType();
-    if (collectionEditorCollectionFormType.FullName != collectionEditorCollectionFormTypeName)
+    if (collectionEditorCollectionFormType.GetFullNameChecked() != collectionEditorCollectionFormTypeName)
     {
       throw new ArgumentException (
           string.Format ("Argument {0} has type {2} when type {1} was expected.",

--- a/Remotion/Web/Core/UI/Design/WebControlDesigner.cs
+++ b/Remotion/Web/Core/UI/Design/WebControlDesigner.cs
@@ -20,6 +20,7 @@ using System.ComponentModel;
 using System.ComponentModel.Design;
 using System.Reflection;
 using System.Web.UI.Design;
+using Remotion.Reflection;
 using Remotion.Utilities;
 using Remotion.Web.UI.Controls;
 
@@ -75,19 +76,19 @@ namespace Remotion.Web.UI.Design
       Assembly[] assemblies = AppDomain.CurrentDomain.GetAssemblies();
       Assembly[] remotionAssemblies = Array.FindAll (
           assemblies,
-          delegate (Assembly assembly) { return assembly.FullName.StartsWith ("Remotion"); });
+          delegate (Assembly assembly) { return assembly.GetFullNameChecked().StartsWith ("Remotion"); });
 
       Dictionary<string, Assembly> assemblyDictionary = new Dictionary<string, Assembly>();
       foreach (Assembly assembly in remotionAssemblies)
       {
-        if (assemblyDictionary.ContainsKey (assembly.FullName))
+        if (assemblyDictionary.ContainsKey (assembly.GetFullNameChecked()))
         {
           throw new NotSupportedException (
               "Duplicate re-motion framework assemblies have been detected. In order to provide a consistent design time experience it is necessary"
               + " to install the re-motion framework in the global assembly cache (GAC). In addition, please ensure that the 'Copy Local' flag"
               + " is set to 'true' for all re-motion framework assemblies referenced by the web project.");
         }
-        assemblyDictionary.Add (assembly.FullName, assembly);
+        assemblyDictionary.Add (assembly.GetFullNameChecked(), assembly);
       }
 
       _hasCheckedForDuplicateAssemblies = true;

--- a/Remotion/Web/Core/UI/Globalization/ResourceDispatcher.cs
+++ b/Remotion/Web/Core/UI/Globalization/ResourceDispatcher.cs
@@ -22,6 +22,7 @@ using System.Web.UI;
 using System.Web.UI.HtmlControls;
 using Remotion.Globalization;
 using Remotion.Logging;
+using Remotion.Reflection;
 using Remotion.Utilities;
 using Remotion.Web.Utilities;
 
@@ -160,7 +161,7 @@ public sealed class ResourceDispatcher
         if (genericHtmlControl != null)
           genericHtmlControl.Attributes[propertyName] = propertyValue;
         else //  Non-HtmlControls require valid property
-          s_log.Warn ("Control '" + control.ID + "' of type '" + control.GetType().FullName + "' does not contain a public property '" + propertyName + "'.");
+          s_log.Warn ("Control '" + control.ID + "' of type '" + control.GetType().GetFullNameSafe() + "' does not contain a public property '" + propertyName + "'.");
       }
     }
   }

--- a/Remotion/Web/Core/UI/Globalization/WebMultiLingualResourcesAttribute.cs
+++ b/Remotion/Web/Core/UI/Globalization/WebMultiLingualResourcesAttribute.cs
@@ -17,6 +17,7 @@
 using System;
 using System.Web.UI;
 using Remotion.Globalization;
+using Remotion.Reflection;
 using Remotion.ServiceLocation;
 using Remotion.Utilities;
 using Remotion.Web.Infrastructure;
@@ -137,7 +138,7 @@ namespace Remotion.Web.UI.Globalization
     }
 
     public WebMultiLingualResourcesAttribute (Type resourceType)
-        : base (resourceType.FullName)
+        : base (resourceType.GetFullNameChecked())
     {
       ArgumentUtility.CheckNotNull ("resourceType", resourceType);
       SetResourceAssembly (resourceType.Assembly);

--- a/Remotion/Web/Core/UI/HtmlHeadAppender.cs
+++ b/Remotion/Web/Core/UI/HtmlHeadAppender.cs
@@ -20,6 +20,7 @@ using System.Linq;
 using System.Web;
 using Remotion.Collections;
 using Remotion.Context;
+using Remotion.Reflection;
 using Remotion.Utilities;
 using Remotion.Web.Resources;
 using Remotion.Web.UI.Controls;
@@ -51,7 +52,7 @@ namespace Remotion.Web.UI
     }
 
     private static readonly SafeContextSingleton<HtmlHeadAppender> s_current =
-        new SafeContextSingleton<HtmlHeadAppender> (typeof (HtmlHeadAppender).AssemblyQualifiedName + "_Current", () => new HtmlHeadAppender());
+        new SafeContextSingleton<HtmlHeadAppender> (typeof (HtmlHeadAppender).GetAssemblyQualifiedNameChecked() + "_Current", () => new HtmlHeadAppender());
 
     /// <summary>
     ///   Gets the <see cref="HtmlHeadAppender"/> instance.

--- a/Remotion/Web/Core/UI/HtmlHeadAppenderExtensions.cs
+++ b/Remotion/Web/Core/UI/HtmlHeadAppenderExtensions.cs
@@ -15,6 +15,7 @@
 // along with re-motion; if not, see http://www.gnu.org/licenses.
 // 
 using System;
+using Remotion.Reflection;
 using Remotion.ServiceLocation;
 using Remotion.Utilities;
 using Remotion.Web.Infrastructure;
@@ -34,15 +35,15 @@ namespace Remotion.Web.UI
     {
       ArgumentUtility.CheckNotNull ("htmlHeadAppender", htmlHeadAppender);
 
-      string jqueryKey = typeof (HtmlHeadContents).FullName + "_JQuery";
+      string jqueryKey = typeof (HtmlHeadContents).GetFullNameChecked() + "_JQuery";
       var jqueryFileUrl = ResourceUrlFactory.CreateResourceUrl (typeof (HtmlHeadContents), ResourceType.Html, "jquery-1.6.4.js");
       htmlHeadAppender.RegisterJavaScriptInclude (jqueryKey, jqueryFileUrl);
 
-      string jQueryIframeShimScriptKey = typeof (HtmlHeadContents).FullName + "_JQueryBgiFrames";
+      string jQueryIframeShimScriptKey = typeof (HtmlHeadContents).GetFullNameChecked() + "_JQueryBgiFrames";
       var href = ResourceUrlFactory.CreateResourceUrl (typeof (HtmlHeadContents), ResourceType.Html, "jquery.IFrameShim.js");
       htmlHeadAppender.RegisterJavaScriptInclude (jQueryIframeShimScriptKey, href);
 
-      string utilitiesKey = typeof (HtmlHeadContents).FullName + "_Utilities";
+      string utilitiesKey = typeof (HtmlHeadContents).GetFullNameChecked() + "_Utilities";
       var utilitiesScripFileUrl = ResourceUrlFactory.CreateResourceUrl (typeof (HtmlHeadContents), ResourceType.Html, "Utilities.js");
       htmlHeadAppender.RegisterJavaScriptInclude (utilitiesKey, utilitiesScripFileUrl);
     }
@@ -65,7 +66,7 @@ namespace Remotion.Web.UI
     {
       ArgumentUtility.CheckNotNull ("htmlHeadAppender", htmlHeadAppender);
 
-      string key = typeof (HtmlHeadContents).FullName + "_Style";
+      string key = typeof (HtmlHeadContents).GetFullNameChecked() + "_Style";
       var url = InfrastructureResourceUrlFactory.CreateThemedResourceUrl (ResourceType.Html, "Style.css");
       htmlHeadAppender.RegisterStylesheetLink (key, url, HtmlHeadAppender.Priority.Page);
     }

--- a/Remotion/Web/Core/UI/SmartPageImplementation/SmartPageInfo.cs
+++ b/Remotion/Web/Core/UI/SmartPageImplementation/SmartPageInfo.cs
@@ -24,6 +24,7 @@ using System.Web.UI;
 using JetBrains.Annotations;
 using Remotion.Collections;
 using Remotion.Globalization;
+using Remotion.Reflection;
 using Remotion.ServiceLocation;
 using Remotion.Utilities;
 using Remotion.Web.Infrastructure;
@@ -58,9 +59,9 @@ namespace Remotion.Web.UI.SmartPageImplementation
     private const string c_styleFileUrl = "SmartPage.css";
     private const string c_smartNavigationScriptFileUrl = "SmartNavigation.js";
 
-    private static readonly string s_scriptFileKey = typeof (SmartPageInfo).FullName + "_Script";
-    private static readonly string s_styleFileKey = typeof (SmartPageInfo).FullName + "_Style";
-    private static readonly string s_smartNavigationScriptKey = typeof (SmartPageInfo).FullName + "_SmartNavigation";
+    private static readonly string s_scriptFileKey = typeof (SmartPageInfo).GetFullNameChecked() + "_Script";
+    private static readonly string s_styleFileKey = typeof (SmartPageInfo).GetFullNameChecked() + "_Style";
+    private static readonly string s_smartNavigationScriptKey = typeof (SmartPageInfo).GetFullNameChecked() + "_SmartNavigation";
 
     private readonly ISmartPage _page;
 

--- a/Remotion/Web/Core/UI/WcagHelper.cs
+++ b/Remotion/Web/Core/UI/WcagHelper.cs
@@ -17,6 +17,7 @@
 using System;
 using System.Web.UI;
 using Remotion.Logging;
+using Remotion.Reflection;
 using Remotion.Utilities;
 using Remotion.Web.Configuration;
 using Remotion.Web.Utilities;
@@ -109,7 +110,7 @@ public class WcagHelper
 
     string message = string.Format (
        "{0} '{1}' on page '{2}' might not comply with a priority {3} checkpoint.", 
-        control.GetType().Name, control.ID, control.Page.GetType().FullName, priority);
+        control.GetType().Name, control.ID, control.Page.GetType().GetFullNameSafe(), priority);
     HandleWarning (message);
   }
 
@@ -121,7 +122,7 @@ public class WcagHelper
 
     string message = string.Format (
         "The value of property '{0}' for {1} '{2}' on page '{3}' might not comply with a priority {4} checkpoint.", 
-        property, control.GetType().Name, control.ID, control.Page.GetType().FullName, priority);
+        property, control.GetType().Name, control.ID, control.Page.GetType().GetFullNameSafe(), priority);
     HandleWarning (message);
   }
 
@@ -146,7 +147,7 @@ public class WcagHelper
 
     string message = string.Format (
        "{0} '{1}' on page '{2}' does not comply with a priority {3} checkpoint.", 
-        control.GetType().Name, control.ID, control.Page.GetType().FullName, priority);
+        control.GetType().Name, control.ID, control.Page.GetType().GetFullNameSafe(), priority);
     HandleError (message);
   }
 
@@ -158,7 +159,7 @@ public class WcagHelper
 
     string message = string.Format (
         "The value of property '{0}' for {1} '{2}' on page '{3}' does not comply with a priority {4} checkpoint.", 
-        property, control.GetType().Name, control.ID, control.Page.GetType().FullName, priority);
+        property, control.GetType().Name, control.ID, control.Page.GetType().GetFullNameSafe(), priority);
     HandleError (message);
   }
 

--- a/Remotion/Web/Core/Utilities/ScriptUtility.cs
+++ b/Remotion/Web/Core/Utilities/ScriptUtility.cs
@@ -16,6 +16,7 @@
 // 
 using System;
 using System.Text;
+using Remotion.Reflection;
 using Remotion.ServiceLocation;
 using Remotion.Utilities;
 using Remotion.Web.Infrastructure;
@@ -124,7 +125,7 @@ namespace Remotion.Web.Utilities
       ArgumentUtility.CheckNotNull ("control", control);
       ArgumentUtility.CheckNotNull ("htmlHeadAppender", htmlHeadAppender);
 
-      string key = typeof (ScriptUtility).FullName + "_StyleUtility";
+      string key = typeof (ScriptUtility).GetFullNameChecked() + "_StyleUtility";
       if (!htmlHeadAppender.IsRegistered (key))
       {
         var url = _infrastructureResourceUrlFactory.CreateThemedResourceUrl (ResourceType.Html, "StyleUtility.js");

--- a/Remotion/Web/Core/Utilities/WebTypeUtility.cs
+++ b/Remotion/Web/Core/Utilities/WebTypeUtility.cs
@@ -18,6 +18,7 @@ using System;
 using System.Collections;
 using System.Reflection;
 using JetBrains.Annotations;
+using Remotion.Reflection;
 using Remotion.ServiceLocation;
 using Remotion.Utilities;
 using Remotion.Web.Infrastructure;
@@ -65,7 +66,7 @@ namespace Remotion.Web.Utilities
     {
       ArgumentUtility.CheckNotNull ("type", type);
       if (IsCompiledType (type))
-        return type.FullName;
+        return type.GetFullNameChecked();
       return TypeUtility.GetPartialAssemblyQualifiedName (type);
     }
 

--- a/Remotion/Web/Security/ExecutionEngine/WxeDemandMethodPermissionAttributeHelper.cs
+++ b/Remotion/Web/Security/ExecutionEngine/WxeDemandMethodPermissionAttributeHelper.cs
@@ -17,6 +17,7 @@
 using System;
 using System.Linq;
 using JetBrains.Annotations;
+using Remotion.Reflection;
 using Remotion.Security;
 using Remotion.Utilities;
 using Remotion.Web.ExecutionEngine;
@@ -92,7 +93,7 @@ namespace Remotion.Web.Security.ExecutionEngine
       {
         throw new WxeException (string.Format (
             "The parameter '{1}' specified by the {0} applied to WxeFunction '{2}' does not implement interface '{3}'.",
-            _attribute.GetType ().Name, parameterDeclaration.Name, _functionType.FullName, typeof (ISecurableObject).FullName));
+            _attribute.GetType ().Name, parameterDeclaration.Name, _functionType.GetFullNameSafe(), typeof (ISecurableObject).GetFullNameSafe()));
       }
 
       if (SecurableClass == null)
@@ -116,7 +117,7 @@ namespace Remotion.Web.Security.ExecutionEngine
       {
         throw new WxeException (string.Format (
            "The parameter '{1}' specified by the {0} applied to WxeFunction '{2}' is null.",
-           _attribute.GetType ().Name, parameterDeclaration.Name, _functionType.FullName));
+           _attribute.GetType ().Name, parameterDeclaration.Name, _functionType.GetFullNameSafe()));
       }
 
       ISecurableObject securableObject = parameterValue as ISecurableObject;
@@ -124,7 +125,7 @@ namespace Remotion.Web.Security.ExecutionEngine
       {
         throw new WxeException (string.Format (
             "The parameter '{1}' specified by the {0} applied to WxeFunction '{2}' does not implement interface '{3}'.",
-            _attribute.GetType ().Name, parameterDeclaration.Name, _functionType.FullName, typeof (ISecurableObject).FullName));
+            _attribute.GetType ().Name, parameterDeclaration.Name, _functionType.GetFullNameSafe(), typeof (ISecurableObject).GetFullNameSafe()));
       }
 
       if (SecurableClass != null)
@@ -138,7 +139,7 @@ namespace Remotion.Web.Security.ExecutionEngine
       {
         throw new WxeException (string.Format (
             "WxeFunction '{1}' has a {0} applied, but does not define any parameters to supply the 'this-object'.",
-            _attribute.GetType ().Name, _functionType.FullName));
+            _attribute.GetType ().Name, _functionType.GetFullNameSafe()));
       }
 
       if (string.IsNullOrEmpty (_attribute.ParameterName))
@@ -152,7 +153,7 @@ namespace Remotion.Web.Security.ExecutionEngine
 
       throw new WxeException (string.Format (
           "The parameter '{1}' specified by the {0} applied to WxeFunction '{2}' is not a valid parameter of this function.",
-          _attribute.GetType ().Name, _attribute.ParameterName, _functionType.FullName));
+          _attribute.GetType ().Name, _attribute.ParameterName, _functionType.GetFullNameSafe()));
     }
 
     private void CheckMethodNameNotNullOrEmpty (Type functionType, string methodName)
@@ -161,7 +162,7 @@ namespace Remotion.Web.Security.ExecutionEngine
       {
         throw new WxeException (string.Format (
             "The {0} applied to WxeFunction '{1}' does not specify the method to get the required permissions from.",
-            _attribute.GetType ().Name, functionType.FullName));
+            _attribute.GetType ().Name, functionType.GetFullNameSafe()));
       }
     }
 
@@ -172,7 +173,7 @@ namespace Remotion.Web.Security.ExecutionEngine
       {
         throw new WxeException (string.Format (
             "The {0} applied to WxeFunction '{1}' does not specify a type implementing interface '{2}'.",
-            _attribute.GetType ().Name, functionType.FullName, typeof (ISecurableObject).FullName));
+            _attribute.GetType ().Name, functionType.GetFullNameSafe(), typeof (ISecurableObject).GetFullNameSafe()));
       }
     }
 
@@ -185,9 +186,9 @@ namespace Remotion.Web.Security.ExecutionEngine
                 "The parameter '{1}' specified by the {0} applied to WxeFunction '{2}' is of type '{3}', which is not a base type of type '{4}'.",
                 _attribute.GetType ().Name,
                 parameterName,
-                _functionType.FullName,
-                parameterType.FullName,
-                SecurableClass.FullName));
+                _functionType.GetFullNameSafe(),
+                parameterType.GetFullNameSafe(),
+                SecurableClass.GetFullNameSafe()));
       }
     }
 

--- a/Remotion/Web/Security/ExecutionEngine/WxeDemandTargetPermissionAttribute.cs
+++ b/Remotion/Web/Security/ExecutionEngine/WxeDemandTargetPermissionAttribute.cs
@@ -15,6 +15,7 @@
 // along with re-motion; if not, see http://www.gnu.org/licenses.
 // 
 using System;
+using Remotion.Reflection;
 using Remotion.Security;
 using Remotion.Utilities;
 
@@ -92,14 +93,14 @@ namespace Remotion.Web.Security.ExecutionEngine
       Type enumType = methodNameEnum.GetType ();
 
       if (enumType.DeclaringType == null)
-        throw new ArgumentException (string.Format ("Enumerated type '{0}' is not declared as a nested type.", enumType.FullName), "methodNameEnum");
+        throw new ArgumentException (string.Format ("Enumerated type '{0}' is not declared as a nested type.", enumType.GetFullNameSafe()), "methodNameEnum");
 
       if (!typeof (ISecurableObject).IsAssignableFrom (enumType.DeclaringType))
       {
         throw new ArgumentException (string.Format (
                 "The declaring type of enumerated type '{0}' does not implement interface '{1}'.",
-                enumType.FullName,
-                typeof (ISecurableObject).FullName),
+                enumType.GetFullNameSafe(),
+                typeof (ISecurableObject).GetFullNameSafe()),
             "methodNameEnum");
       }
     }

--- a/Remotion/Web/Security/UI/DemandTargetPermissionAttribute.cs
+++ b/Remotion/Web/Security/UI/DemandTargetPermissionAttribute.cs
@@ -15,6 +15,7 @@
 // along with re-motion; if not, see http://www.gnu.org/licenses.
 // 
 using System;
+using Remotion.Reflection;
 using Remotion.Security;
 using Remotion.Utilities;
 using Remotion.Web.ExecutionEngine;
@@ -120,14 +121,14 @@ namespace Remotion.Web.Security.UI
       Type enumType = methodNameEnum.GetType ();
 
       if (enumType.DeclaringType == null)
-        throw new ArgumentException (string.Format ("Enumerated type '{0}' is not declared as a nested type.", enumType.FullName), "methodNameEnum");
+        throw new ArgumentException (string.Format ("Enumerated type '{0}' is not declared as a nested type.", enumType.GetFullNameSafe()), "methodNameEnum");
 
       if (!typeof (ISecurableObject).IsAssignableFrom (enumType.DeclaringType))
       {
         throw new ArgumentException (string.Format (
                 "The declaring type of enumerated type '{0}' does not implement interface '{1}'.",
-                enumType.FullName,
-                typeof (ISecurableObject).FullName),
+                enumType.GetFullNameSafe(),
+                typeof (ISecurableObject).GetFullNameSafe()),
             "methodNameEnum");
       }
     }

--- a/SecurityManager/Clients.Web/Classes/BaseControl.cs
+++ b/SecurityManager/Clients.Web/Classes/BaseControl.cs
@@ -38,7 +38,7 @@ namespace Remotion.SecurityManager.Clients.Web.Classes
 
     // static members and constants
 
-    private static readonly string s_currentTenantHandleKey = typeof (BaseControl).FullName + "_CurrentTenantID";
+    private static readonly string s_currentTenantHandleKey = typeof (BaseControl).GetFullNameChecked() + "_CurrentTenantID";
 
     // member fields
 
@@ -148,13 +148,13 @@ namespace Remotion.SecurityManager.Clients.Web.Classes
       if (!(control is TControl))
       {
         throw new InvalidOperationException (
-            string.Format ("Control '{0}' on {2} must be of type '{1}'.", controlID, typeof (TControl).FullName, GetType().Name));
+            string.Format ("Control '{0}' on {2} must be of type '{1}'.", controlID, typeof (TControl).GetFullNameSafe(), GetType().Name));
       }
 
       if (!(control is IFocusableControl))
       {
         throw new InvalidOperationException (
-            string.Format ("Control '{0}' on {2} must implement the '{1}' interface.", controlID, typeof (IFocusableControl).FullName, GetType().Name));
+            string.Format ("Control '{0}' on {2} must implement the '{1}' interface.", controlID, typeof (IFocusableControl).GetFullNameSafe(), GetType().Name));
       }
 
       var boundEditableWebControl = (TControl) control;

--- a/SecurityManager/Clients.Web/Classes/SecurityManagerHttpApplication.cs
+++ b/SecurityManager/Clients.Web/Classes/SecurityManagerHttpApplication.cs
@@ -20,6 +20,7 @@ using System.Security.Principal;
 using System.Web;
 using System.Web.SessionState;
 using Remotion.Data.DomainObjects;
+using Remotion.Reflection;
 using Remotion.Security;
 using Remotion.SecurityManager.Domain;
 using Remotion.ServiceLocation;
@@ -30,7 +31,7 @@ namespace Remotion.SecurityManager.Clients.Web.Classes
 {
   public class SecurityManagerHttpApplication : HttpApplication
   {
-    private static readonly string s_principalKey = typeof (SecurityManagerHttpApplication).AssemblyQualifiedName + "_Principal";
+    private static readonly string s_principalKey = typeof (SecurityManagerHttpApplication).GetAssemblyQualifiedNameChecked() + "_Principal";
     private ISecurityManagerPrincipalFactory _securityManagerPrincipalFactory;
 
     public SecurityManagerHttpApplication ()

--- a/SecurityManager/Clients.Web/UI/AccessControl/EditPermissionsForm.aspx.cs
+++ b/SecurityManager/Clients.Web/UI/AccessControl/EditPermissionsForm.aspx.cs
@@ -22,6 +22,7 @@ using System.Web.UI;
 using System.Web.UI.HtmlControls;
 using System.Web.UI.WebControls;
 using Remotion.Globalization;
+using Remotion.Reflection;
 using Remotion.SecurityManager.Clients.Web.Classes;
 using Remotion.SecurityManager.Clients.Web.Classes.AccessControl;
 using Remotion.SecurityManager.Domain.AccessControl;
@@ -303,7 +304,7 @@ namespace Remotion.SecurityManager.Clients.Web.UI.AccessControl
 
       HtmlHeadAppender.Current.RegisterUtilitiesJavaScriptInclude ();
       var url = ResourceUrlFactory.CreateResourceUrl (typeof (EditPermissionsForm), ResourceType.Html, "EditPermissionsForm.js");
-      HtmlHeadAppender.Current.RegisterJavaScriptInclude (GetType().FullName + "_script", url);
+      HtmlHeadAppender.Current.RegisterJavaScriptInclude (GetType().GetFullNameChecked() + "_script", url);
     }
 
     private void EnableNewAccessControlListButton ()

--- a/SecurityManager/Clients.Web/UI/SecurityManagerUserContextControl.ascx.cs
+++ b/SecurityManager/Clients.Web/UI/SecurityManagerUserContextControl.ascx.cs
@@ -48,9 +48,9 @@ namespace Remotion.SecurityManager.Clients.Web.UI
       CurrentTenantCommandTooltip
     }
 
-    private static readonly string s_isTenantSelectionEnabledKey = typeof (SecurityManagerUserContextControl).FullName + "_IsTenantSelectionEnabled";
-    private static readonly string s_enableAbstractTenantsKey = typeof (SecurityManagerUserContextControl).FullName + "_EnableAbstractTenants";
-    private static readonly string s_isSubstitutionSelectionEnabledKey = typeof (SecurityManagerUserContextControl).FullName + "_IsSubstitutionSelectionEnabled";
+    private static readonly string s_isTenantSelectionEnabledKey = typeof (SecurityManagerUserContextControl).GetFullNameChecked() + "_IsTenantSelectionEnabled";
+    private static readonly string s_enableAbstractTenantsKey = typeof (SecurityManagerUserContextControl).GetFullNameChecked() + "_EnableAbstractTenants";
+    private static readonly string s_isSubstitutionSelectionEnabledKey = typeof (SecurityManagerUserContextControl).GetFullNameChecked() + "_IsSubstitutionSelectionEnabled";
 
     private bool _isCurrentTenantFieldReadOnly = true;
     private bool _isCurrentSubstitutionFieldReadOnly = true;

--- a/SecurityManager/Core/Domain/AccessControl/AccessControlEntryPropertiesEnumerationValueFilter.cs
+++ b/SecurityManager/Core/Domain/AccessControl/AccessControlEntryPropertiesEnumerationValueFilter.cs
@@ -18,6 +18,7 @@
 using System;
 using Remotion.ObjectBinding;
 using Remotion.ObjectBinding.BindableObject;
+using Remotion.Reflection;
 using Remotion.SecurityManager.Configuration;
 using Remotion.Utilities;
 
@@ -54,7 +55,7 @@ namespace Remotion.SecurityManager.Domain.AccessControl
         case "UserCondition":
           return value.IsEnabled && IsUserConditionEnabled ((UserCondition) value.Value, isStateful);
         default:
-          throw CreateInvalidOperationException ("The property '{0}' is not supported by the '{1}'.", property.Identifier, typeof (AccessControlEntryPropertiesEnumerationValueFilter).FullName);
+          throw CreateInvalidOperationException ("The property '{0}' is not supported by the '{1}'.", property.Identifier, typeof (AccessControlEntryPropertiesEnumerationValueFilter).GetFullNameChecked());
       }
     }
 

--- a/SecurityManager/Core/Domain/SearchInfrastructure/OrganizationalStructure/RolePropertiesSearchService.cs
+++ b/SecurityManager/Core/Domain/SearchInfrastructure/OrganizationalStructure/RolePropertiesSearchService.cs
@@ -21,6 +21,7 @@ using System.Linq;
 using Remotion.Data.DomainObjects;
 using Remotion.ObjectBinding;
 using Remotion.ObjectBinding.BindableObject;
+using Remotion.Reflection;
 using Remotion.Security;
 using Remotion.SecurityManager.Domain.OrganizationalStructure;
 using Remotion.Utilities;
@@ -58,7 +59,7 @@ namespace Remotion.SecurityManager.Domain.SearchInfrastructure.OrganizationalStr
       if (!SupportsProperty (property))
       {
         throw new ArgumentException (
-            string.Format ("The property '{0}' is not supported by the '{1}' type.", property.Identifier, GetType().FullName));
+            string.Format ("The property '{0}' is not supported by the '{1}' type.", property.Identifier, GetType().GetFullNameSafe()));
       }
 
       var positions = GetPositions (rolePropertiesSearchArguments);

--- a/SecurityManager/Core/Domain/SearchInfrastructure/SecurityManagerPropertyBasedSearchServiceBase.cs
+++ b/SecurityManager/Core/Domain/SearchInfrastructure/SecurityManagerPropertyBasedSearchServiceBase.cs
@@ -19,6 +19,7 @@ using System;
 using System.Collections.Generic;
 using Remotion.ObjectBinding;
 using Remotion.ObjectBinding.BindableObject;
+using Remotion.Reflection;
 using Remotion.Utilities;
 
 namespace Remotion.SecurityManager.Domain.SearchInfrastructure
@@ -58,7 +59,7 @@ namespace Remotion.SecurityManager.Domain.SearchInfrastructure
       if (!_queryFactories.TryGetValue (property.Identifier, out queryFactory))
       {
         throw new ArgumentException (
-            string.Format ("The property '{0}' is not supported by the '{1}' type.", property.Identifier, GetType().FullName));
+            string.Format ("The property '{0}' is not supported by the '{1}' type.", property.Identifier, GetType().GetFullNameSafe()));
       }
       return queryFactory;
     }

--- a/SecurityManager/Core/Domain/SearchInfrastructure/SecurityManagerPropertyTypeBasedSearchServiceBase.cs
+++ b/SecurityManager/Core/Domain/SearchInfrastructure/SecurityManagerPropertyTypeBasedSearchServiceBase.cs
@@ -19,6 +19,7 @@ using System;
 using System.Linq;
 using Remotion.ObjectBinding;
 using Remotion.ObjectBinding.BindableObject;
+using Remotion.Reflection;
 using Remotion.Utilities;
 
 namespace Remotion.SecurityManager.Domain.SearchInfrastructure
@@ -60,7 +61,7 @@ namespace Remotion.SecurityManager.Domain.SearchInfrastructure
                 "The type of the property '{0}', declared on '{1}', is not supported by the '{2}' type.",
                 property.Identifier,
                 property.ReflectedClass.Identifier,
-                GetType().FullName));
+                GetType().GetFullNameSafe()));
       }
 
       return CreateQuery;

--- a/SecurityManager/Core/Persistence/RevisionStorageProviderExtension.cs
+++ b/SecurityManager/Core/Persistence/RevisionStorageProviderExtension.cs
@@ -27,6 +27,7 @@ using Remotion.Data.DomainObjects.Persistence;
 using Remotion.Data.DomainObjects.Persistence.Rdbms;
 using Remotion.Data.DomainObjects.Queries;
 using Remotion.Data.DomainObjects.Queries.Configuration;
+using Remotion.Reflection;
 using Remotion.SecurityManager.Domain;
 using Remotion.SecurityManager.Domain.Metadata;
 using Remotion.SecurityManager.Domain.OrganizationalStructure;
@@ -241,7 +242,7 @@ namespace Remotion.SecurityManager.Persistence
 
     private string GetPropertyIdentifierFromTypeAndShortName (Type domainObjectType, string shortPropertyName)
     {
-      return domainObjectType.FullName + "." + shortPropertyName;
+      return domainObjectType.GetFullNameChecked() + "." + shortPropertyName;
     }
 
     private void IncrementRevision (IRdbmsProviderCommandExecutionContext executionContext, IRevisionKey revisionKey)

--- a/SecurityManager/Metadata.Importer/Program.cs
+++ b/SecurityManager/Metadata.Importer/Program.cs
@@ -154,7 +154,7 @@ namespace Remotion.SecurityManager.Metadata.Importer
         Console.Error.WriteLine ("Execution aborted. Exception stack:");
 
         for (; exception != null; exception = exception.InnerException)
-          Console.Error.WriteLine ("{0}: {1}\n{2}", exception.GetType().FullName, exception.Message, exception.StackTrace);
+          Console.Error.WriteLine ("{0}: {1}\n{2}", exception.GetType().GetFullNameSafe(), exception.Message, exception.StackTrace);
       }
       else
         Console.Error.WriteLine ("Execution aborted: {0}", exception.Message);

--- a/SharedSource/Core/Reflection/AssemblyExtensions.cs
+++ b/SharedSource/Core/Reflection/AssemblyExtensions.cs
@@ -16,6 +16,7 @@
 // 
 using System;
 using System.Reflection;
+using System.Runtime.CompilerServices;
 
 namespace Remotion.Reflection
 {
@@ -24,5 +25,16 @@ namespace Remotion.Reflection
   /// </summary>
   static partial class AssemblyExtensions
   {
+    public static string GetFullNameSafe (this Assembly assembly)
+    {
+      // ReSharper disable once ConstantNullCoalescingCondition
+      return assembly.FullName ?? "<undefined>";
+    }
+    
+    public static string GetFullNameChecked (this Assembly assembly)
+    {
+      // ReSharper disable once ConstantNullCoalescingCondition
+      return assembly.FullName ?? throw new InvalidOperationException ("Assembly name is undefined.");
+    }
   }
 }

--- a/SharedSource/Core/Reflection/AssemblyExtensions.cs
+++ b/SharedSource/Core/Reflection/AssemblyExtensions.cs
@@ -1,0 +1,28 @@
+﻿// This file is part of the re-motion Core Framework (www.re-motion.org)
+// Copyright (c) rubicon IT GmbH, www.rubicon.eu
+// 
+// The re-motion Core Framework is free software; you can redistribute it 
+// and/or modify it under the terms of the GNU Lesser General Public License 
+// as published by the Free Software Foundation; either version 2.1 of the 
+// License, or (at your option) any later version.
+// 
+// re-motion is distributed in the hope that it will be useful, 
+// but WITHOUT ANY WARRANTY; without even the implied warranty of 
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the 
+// GNU Lesser General Public License for more details.
+// 
+// You should have received a copy of the GNU Lesser General Public License
+// along with re-motion; if not, see http://www.gnu.org/licenses.
+// 
+using System;
+using System.Reflection;
+
+namespace Remotion.Reflection
+{
+  /// <summary>
+  /// Defines extension methods for working with <see cref="Assembly"/>.
+  /// </summary>
+  static partial class AssemblyExtensions
+  {
+  }
+}

--- a/SharedSource/Core/Reflection/AssemblyNameExtensions.cs
+++ b/SharedSource/Core/Reflection/AssemblyNameExtensions.cs
@@ -1,0 +1,28 @@
+﻿// This file is part of the re-motion Core Framework (www.re-motion.org)
+// Copyright (c) rubicon IT GmbH, www.rubicon.eu
+// 
+// The re-motion Core Framework is free software; you can redistribute it 
+// and/or modify it under the terms of the GNU Lesser General Public License 
+// as published by the Free Software Foundation; either version 2.1 of the 
+// License, or (at your option) any later version.
+// 
+// re-motion is distributed in the hope that it will be useful, 
+// but WITHOUT ANY WARRANTY; without even the implied warranty of 
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the 
+// GNU Lesser General Public License for more details.
+// 
+// You should have received a copy of the GNU Lesser General Public License
+// along with re-motion; if not, see http://www.gnu.org/licenses.
+// 
+using System;
+using System.Reflection;
+
+namespace Remotion.Reflection
+{
+  /// <summary>
+  /// Defines extension methods for working with <see cref="AssemblyName"/>.
+  /// </summary>
+  static partial class AssemblyNameExtensions
+  {
+  }
+}

--- a/SharedSource/Core/Reflection/AssemblyNameExtensions.cs
+++ b/SharedSource/Core/Reflection/AssemblyNameExtensions.cs
@@ -16,6 +16,7 @@
 // 
 using System;
 using System.Reflection;
+using System.Runtime.CompilerServices;
 
 namespace Remotion.Reflection
 {
@@ -24,5 +25,16 @@ namespace Remotion.Reflection
   /// </summary>
   static partial class AssemblyNameExtensions
   {
+    public static string GetNameSafe (this AssemblyName assemblyName)
+    {
+      // ReSharper disable once ConstantNullCoalescingCondition
+      return assemblyName.Name ?? "<undefined>";
+    }
+
+    public static string GetNameChecked (this AssemblyName assemblyName)
+    {
+      // ReSharper disable once ConstantNullCoalescingCondition
+      return assemblyName.Name ?? throw new InvalidOperationException ("Assembly name is undefined.");
+    }
   }
 }

--- a/SharedSource/Core/Reflection/TypeExtensions.cs
+++ b/SharedSource/Core/Reflection/TypeExtensions.cs
@@ -15,6 +15,7 @@
 // along with re-motion; if not, see http://www.gnu.org/licenses.
 // 
 using System;
+using System.Runtime.CompilerServices;
 
 namespace Remotion.Reflection
 {
@@ -23,5 +24,17 @@ namespace Remotion.Reflection
   /// </summary>
   static partial class TypeExtensions
   {
+    public static string GetAssemblyQualifiedNameSafe (this Type type)
+    {
+      // ReSharper disable once ConstantNullCoalescingCondition
+      return type.AssemblyQualifiedName ?? type.FullName ?? type.Name ?? "<undefined>";
+    }
+
+    public static string GetAssemblyQualifiedNameChecked (this Type type)
+    {
+      // ReSharper disable once ConstantNullCoalescingCondition
+      return type.AssemblyQualifiedName
+             ?? throw new InvalidOperationException (string.Format ("Type '{0}' does not have an assembly qualified name.", type.FullName ?? type.Name));
+    }
   }
 }

--- a/SharedSource/Core/Reflection/TypeExtensions.cs
+++ b/SharedSource/Core/Reflection/TypeExtensions.cs
@@ -37,6 +37,18 @@ namespace Remotion.Reflection
              ?? throw new InvalidOperationException (string.Format ("Type '{0}' does not have an assembly qualified name.", type.FullName ?? type.Name));
     }
 
+    public static string GetFullNameSafe (this Type type)
+    {
+      // ReSharper disable once ConstantNullCoalescingCondition
+      return type.FullName ?? type.Name;
+    }
+
+    public static string GetFullNameChecked (this Type type)
+    {
+      // ReSharper disable once ConstantNullCoalescingCondition
+      return type.FullName ?? throw new InvalidOperationException (string.Format ("Type '{0}' does not have a full name.", type.FullName ?? type.Name));
+    }
+
     public static string GetNamespaceSafe (this Type type)
     {
       // ReSharper disable once ConstantNullCoalescingCondition

--- a/SharedSource/Core/Reflection/TypeExtensions.cs
+++ b/SharedSource/Core/Reflection/TypeExtensions.cs
@@ -36,5 +36,17 @@ namespace Remotion.Reflection
       return type.AssemblyQualifiedName
              ?? throw new InvalidOperationException (string.Format ("Type '{0}' does not have an assembly qualified name.", type.FullName ?? type.Name));
     }
+
+    public static string GetNamespaceSafe (this Type type)
+    {
+      // ReSharper disable once ConstantNullCoalescingCondition
+      return type.Namespace ?? "<undefined>";
+    }
+
+    public static string GetNamespaceChecked (this Type type)
+    {
+      // ReSharper disable once ConstantNullCoalescingCondition
+      return type.Namespace ?? throw new InvalidOperationException (string.Format ("Type '{0}' does not have a namespace.", type.Name));
+    }
   }
 }

--- a/SharedSource/Core/Reflection/TypeExtensions.cs
+++ b/SharedSource/Core/Reflection/TypeExtensions.cs
@@ -1,0 +1,27 @@
+﻿// This file is part of the re-motion Core Framework (www.re-motion.org)
+// Copyright (c) rubicon IT GmbH, www.rubicon.eu
+// 
+// The re-motion Core Framework is free software; you can redistribute it 
+// and/or modify it under the terms of the GNU Lesser General Public License 
+// as published by the Free Software Foundation; either version 2.1 of the 
+// License, or (at your option) any later version.
+// 
+// re-motion is distributed in the hope that it will be useful, 
+// but WITHOUT ANY WARRANTY; without even the implied warranty of 
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the 
+// GNU Lesser General Public License for more details.
+// 
+// You should have received a copy of the GNU Lesser General Public License
+// along with re-motion; if not, see http://www.gnu.org/licenses.
+// 
+using System;
+
+namespace Remotion.Reflection
+{
+  /// <summary>
+  /// Defines extension methods for working with <see cref="Type"/>.
+  /// </summary>
+  static partial class TypeExtensions
+  {
+  }
+}

--- a/SharedSource/Core/SharedSource.Core.csproj
+++ b/SharedSource/Core/SharedSource.Core.csproj
@@ -45,6 +45,9 @@
     <Compile Include="FunctionalProgramming\EnumerableExtensions.cs" />
     <Compile Include="FunctionalProgramming\EnumerableUtility.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Reflection\AssemblyExtensions.cs" />
+    <Compile Include="Reflection\AssemblyNameExtensions.cs" />
+    <Compile Include="Reflection\TypeExtensions.cs" />
     <Compile Include="ReSharperAnnotations\AssertionConditionAttribute.cs" />
     <Compile Include="ReSharperAnnotations\AssertionConditionType.cs" />
     <Compile Include="ReSharperAnnotations\AssertionMethodAttribute.cs" />


### PR DESCRIPTION
TODOS:

- [x] Decide if the names are ok
- [x] Decide the default values (altough I think it will be an empty string for all)
- [x] Decide on the type of exception thrown and its message
- [x] Add the guards for Type.FullName

@MichaelKetting I want the current changes to be reviewed before I go over and convert Type.FullName since it has the most usages.