### PR TITLE
RM-7902 Introduce CssClassDefinition and use it for disabled and readOnly

### DIFF
--- a/Remotion/ObjectBinding/Web.UnitTests/UI/Controls/BocListImplementation/Rendering/BocSelectorColumnRendererTest.cs
+++ b/Remotion/ObjectBinding/Web.UnitTests/UI/Controls/BocListImplementation/Rendering/BocSelectorColumnRendererTest.cs
@@ -21,6 +21,7 @@ using Remotion.ObjectBinding.Web.Contracts.DiagnosticMetadata;
 using Remotion.ObjectBinding.Web.Services;
 using Remotion.ObjectBinding.Web.UI.Controls;
 using Remotion.ObjectBinding.Web.UI.Controls.BocListImplementation.Rendering;
+using Remotion.Web.UI.Controls;
 using Remotion.Web.UI.Controls.Rendering;
 
 namespace Remotion.ObjectBinding.Web.UnitTests.UI.Controls.BocListImplementation.Rendering
@@ -58,7 +59,7 @@ namespace Remotion.ObjectBinding.Web.UnitTests.UI.Controls.BocListImplementation
       var document = Html.GetResultDocument();
 
       var th = Html.GetAssertedChildElement (document, "th", 0);
-      Html.AssertAttribute (th, "class", _bocListCssClassDefinition.TitleCell + " " + _bocListCssClassDefinition.TitleCellSelector);
+      Html.AssertAttribute (th, "class", _bocListCssClassDefinition.TitleCell + " " + _bocListCssClassDefinition.Themed + " " + _bocListCssClassDefinition.TitleCellSelector);
       Html.AssertAttribute (th, "role", "columnheader");
 
       var input = Html.GetAssertedChildElement (th, "input", 0);
@@ -84,7 +85,7 @@ namespace Remotion.ObjectBinding.Web.UnitTests.UI.Controls.BocListImplementation
       var document = Html.GetResultDocument();
 
       var td = Html.GetAssertedChildElement (document, "td", 0);
-      Html.AssertAttribute (td, "class", "bocListTableCell bocListDataCellRowSelector");
+      Html.AssertAttribute (td, "class", "bocListTableCell remotion-themed bocListDataCellRowSelector");
 
       var input = Html.GetAssertedChildElement (td, "input", 0);
       Html.AssertAttribute (input, "type", "checkbox");
@@ -104,7 +105,7 @@ namespace Remotion.ObjectBinding.Web.UnitTests.UI.Controls.BocListImplementation
       var document = Html.GetResultDocument();
 
       var th = Html.GetAssertedChildElement (document, "th", 0);
-      Html.AssertAttribute (th, "class", _bocListCssClassDefinition.TitleCell + " " + _bocListCssClassDefinition.TitleCellSelector);
+      Html.AssertAttribute (th, "class", _bocListCssClassDefinition.TitleCell + " " + _bocListCssClassDefinition.Themed + " " + _bocListCssClassDefinition.TitleCellSelector);
       Html.AssertAttribute (th, "role", "columnheader");
 
       Html.AssertTextNode (th, HtmlHelper.WhiteSpace, 0);
@@ -124,7 +125,7 @@ namespace Remotion.ObjectBinding.Web.UnitTests.UI.Controls.BocListImplementation
       var document = Html.GetResultDocument();
 
       var td = Html.GetAssertedChildElement (document, "td", 0);
-      Html.AssertAttribute (td, "class", "bocListTableCell bocListDataCellRowSelector");
+      Html.AssertAttribute (td, "class", "bocListTableCell remotion-themed bocListDataCellRowSelector");
       Html.AssertAttribute (td, "role", "cell");
 
       var input = Html.GetAssertedChildElement (td, "input", 0);

--- a/Remotion/ObjectBinding/Web.UnitTests/UI/Controls/BocReferenceValueImplementation/Rendering/BocAutoCompleteReferenceValueRendererTest.cs
+++ b/Remotion/ObjectBinding/Web.UnitTests/UI/Controls/BocReferenceValueImplementation/Rendering/BocAutoCompleteReferenceValueRendererTest.cs
@@ -600,7 +600,7 @@ namespace Remotion.ObjectBinding.Web.UnitTests.UI.Controls.BocReferenceValueImpl
       commandLink.AssertChildElementCount (1);
 
       var contentSpan = commandLink.GetAssertedChildElement ("span", 0);
-      contentSpan.AssertAttributeValueEquals ("class", "content withoutOptionsMenu");
+      contentSpan.AssertAttributeValueEquals ("class", "content remotion-themed withoutOptionsMenu");
       contentSpan.AssertChildElementCount (1);
       
       var innerSpan = contentSpan.GetAssertedChildElement ("span", 0);
@@ -669,13 +669,13 @@ namespace Remotion.ObjectBinding.Web.UnitTests.UI.Controls.BocReferenceValueImpl
       switch (optionMenuConfiguration)
       {
         case OptionMenuConfiguration.NoOptionsMenu:
-          contentSpan.AssertAttributeValueEquals ("class", "content withoutOptionsMenu");
+          contentSpan.AssertAttributeValueEquals ("class", "content remotion-themed withoutOptionsMenu");
           break;
         case OptionMenuConfiguration.SeparateOptionsMenu:
-          contentSpan.AssertAttributeValueEquals ("class", "content separateOptionsMenu");
+          contentSpan.AssertAttributeValueEquals ("class", "content remotion-themed separateOptionsMenu");
           break;
         case OptionMenuConfiguration.EmbeddedOptionsMenu:
-          contentSpan.AssertAttributeValueEquals ("class", "content embeddedOptionsMenu");
+          contentSpan.AssertAttributeValueEquals ("class", "content remotion-themed embeddedOptionsMenu");
           break;
       }
 

--- a/Remotion/ObjectBinding/Web.UnitTests/UI/Controls/BocReferenceValueImplementation/Rendering/BocReferenceValueRendererTest.cs
+++ b/Remotion/ObjectBinding/Web.UnitTests/UI/Controls/BocReferenceValueImplementation/Rendering/BocReferenceValueRendererTest.cs
@@ -535,7 +535,7 @@ namespace Remotion.ObjectBinding.Web.UnitTests.UI.Controls.BocReferenceValueImpl
       Html.AssertAttribute (validationErrors, StubValidationErrorRenderer.ValidationErrorsAttribute, c_validationErrors);
 
       var contentSpan = commandLink.GetAssertedChildElement ("span", 0);
-      contentSpan.AssertAttributeValueEquals ("class", "content withoutOptionsMenu");
+      contentSpan.AssertAttributeValueEquals ("class", "content remotion-themed withoutOptionsMenu");
       contentSpan.AssertChildElementCount (1);
 
       var innerSpan = contentSpan.GetAssertedChildElement ("span", 0);
@@ -564,13 +564,13 @@ namespace Remotion.ObjectBinding.Web.UnitTests.UI.Controls.BocReferenceValueImpl
       switch (optionMenuConfiguration)
       {
         case OptionMenuConfiguration.NoOptionsMenu:
-          contentSpan.AssertAttributeValueEquals ("class", "content withoutOptionsMenu");
+          contentSpan.AssertAttributeValueEquals ("class", "content remotion-themed withoutOptionsMenu");
           break;
         case OptionMenuConfiguration.SeparateOptionsMenu:
-          contentSpan.AssertAttributeValueEquals ("class", "content separateOptionsMenu");
+          contentSpan.AssertAttributeValueEquals ("class", "content remotion-themed separateOptionsMenu");
           break;
         case OptionMenuConfiguration.EmbeddedOptionsMenu:
-          contentSpan.AssertAttributeValueEquals ("class", "content embeddedOptionsMenu");
+          contentSpan.AssertAttributeValueEquals ("class", "content remotion-themed embeddedOptionsMenu");
           break;
       }
 

--- a/Remotion/ObjectBinding/Web/UI/Controls/BocBooleanValueImplementation/Rendering/BocBooleanValueRendererBase.cs
+++ b/Remotion/ObjectBinding/Web/UI/Controls/BocBooleanValueImplementation/Rendering/BocBooleanValueRendererBase.cs
@@ -42,6 +42,12 @@ namespace Remotion.ObjectBinding.Web.UI.Controls.BocBooleanValueImplementation.R
     {
     }
 
+    /// <inheritdoc />
+    protected override bool UseThemingContext
+    {
+      get { return true; }
+    }
+
     protected IEnumerable<string> GetValidationErrorsToRender (BocRenderingContext<TControl> renderingContext)
     {
       ArgumentUtility.CheckNotNull ("renderingContext", renderingContext);

--- a/Remotion/ObjectBinding/Web/UI/Controls/BocDateTimeValueImplementation/Rendering/BocDateTimeValueRenderer.cs
+++ b/Remotion/ObjectBinding/Web/UI/Controls/BocDateTimeValueImplementation/Rendering/BocDateTimeValueRenderer.cs
@@ -213,7 +213,7 @@ namespace Remotion.ObjectBinding.Web.UI.Controls.BocDateTimeValueImplementation.
       if (hasDateField)
       {
         renderingContext.Writer.AddAttribute (
-            HtmlTextWriterAttribute.Class, CssClassDateInputWrapper + " " + GetPositioningCssClass (renderingContext, DateTimeValuePart.Date));
+            HtmlTextWriterAttribute.Class, CssClassDateInputWrapper + " " + CssClassThemed + " " + GetPositioningCssClass (renderingContext, DateTimeValuePart.Date));
         renderingContext.Writer.RenderBeginTag (HtmlTextWriterTag.Span);
 
         _validationErrorRenderer.SetValidationErrorsReferenceOnControl (dateTextBox, dateValueValidationErrorsID, dateValueValidationErrors);
@@ -241,7 +241,7 @@ namespace Remotion.ObjectBinding.Web.UI.Controls.BocDateTimeValueImplementation.
       if (hasTimeField)
       {
         renderingContext.Writer.AddAttribute (
-            HtmlTextWriterAttribute.Class, CssClassTimeInputWrapper + " " + GetPositioningCssClass (renderingContext, DateTimeValuePart.Time));
+            HtmlTextWriterAttribute.Class, CssClassTimeInputWrapper + " " + CssClassThemed + " " + GetPositioningCssClass (renderingContext, DateTimeValuePart.Time));
         renderingContext.Writer.RenderBeginTag (HtmlTextWriterTag.Span);
 
         _validationErrorRenderer.SetValidationErrorsReferenceOnControl (timeTextBox, timeValueValidationErrorsID, timeValueValidationErrors);

--- a/Remotion/ObjectBinding/Web/UI/Controls/BocEnumValueImplementation/Rendering/BocEnumValueRenderer.cs
+++ b/Remotion/ObjectBinding/Web/UI/Controls/BocEnumValueImplementation/Rendering/BocEnumValueRenderer.cs
@@ -66,6 +66,12 @@ namespace Remotion.ObjectBinding.Web.UI.Controls.BocEnumValueImplementation.Rend
       _validationErrorRenderer = validationErrorRenderer;
     }
 
+    /// <inheritdoc />
+    protected override bool UseThemingContext
+    {
+      get { return true; }
+    }
+
     public void RegisterHtmlHeadContents (HtmlHeadAppender htmlHeadAppender)
     {
       ArgumentUtility.CheckNotNull ("htmlHeadAppender", htmlHeadAppender);

--- a/Remotion/ObjectBinding/Web/UI/Controls/BocListImplementation/Rendering/BocListCssClassDefinition.cs
+++ b/Remotion/ObjectBinding/Web/UI/Controls/BocListImplementation/Rendering/BocListCssClassDefinition.cs
@@ -17,6 +17,7 @@
 using System;
 using System.Web.UI.WebControls;
 using Remotion.ServiceLocation;
+using Remotion.Web.UI.Controls;
 
 namespace Remotion.ObjectBinding.Web.UI.Controls.BocListImplementation.Rendering
 {
@@ -43,7 +44,7 @@ namespace Remotion.ObjectBinding.Web.UI.Controls.BocListImplementation.Rendering
     /// </remarks>
     public virtual string ReadOnly
     {
-      get { return "readOnly"; }
+      get { return CssClassDefinition.ReadOnly; }
     }
 
     /// <summary> Gets the CSS-Class applied to the <see cref="IBocRenderableControl"/> when it is displayed disabled. </summary>
@@ -53,7 +54,20 @@ namespace Remotion.ObjectBinding.Web.UI.Controls.BocListImplementation.Rendering
     /// </remarks>
     public virtual string Disabled
     {
-      get { return "disabled"; }
+      get { return CssClassDefinition.Disabled; }
+    }
+
+    /// <summary>
+    /// Gets the CSS-Class applied to the <see cref="IBocRenderableControl"/> when itself and child elements
+    /// that are standard browser controls (e.g. input elements) should be styled in the current theme.
+    /// </summary>
+    /// <remarks> 
+    ///   <para> Class: <c>remotion-themed</c>. </para>
+    ///   <para> Applied in addition to the regular CSS-Class.</para>
+    /// </remarks>
+    public virtual string Themed
+    {
+      get { return CssClassDefinition.Themed; }
     }
 
     /// <summary> Gets the CSS-Class applied to the <see cref="BocList"/>'s <c>table</c> tag. </summary>

--- a/Remotion/ObjectBinding/Web/UI/Controls/BocListImplementation/Rendering/BocListMenuBlockRenderer.cs
+++ b/Remotion/ObjectBinding/Web/UI/Controls/BocListImplementation/Rendering/BocListMenuBlockRenderer.cs
@@ -136,6 +136,7 @@ namespace Remotion.ObjectBinding.Web.UI.Controls.BocListImplementation.Rendering
 
       var availableViewsList = renderingContext.Control.GetAvailableViewsList();
 
+      renderingContext.Writer.AddAttribute (HtmlTextWriterAttribute.Class, CssClasses.Themed);
       renderingContext.Writer.AddStyleAttribute (HtmlTextWriterStyle.Width, "100%");
       renderingContext.Writer.AddStyleAttribute ("margin-bottom", menuBlockItemOffset);
       renderingContext.Writer.RenderBeginTag (HtmlTextWriterTag.Div);

--- a/Remotion/ObjectBinding/Web/UI/Controls/BocListImplementation/Rendering/BocListNavigationBlockRenderer.cs
+++ b/Remotion/ObjectBinding/Web/UI/Controls/BocListImplementation/Rendering/BocListNavigationBlockRenderer.cs
@@ -178,6 +178,7 @@ namespace Remotion.ObjectBinding.Web.UI.Controls.BocListImplementation.Rendering
 
     private void RenderPageInformation (BocListRenderingContext renderingContext)
     {
+      renderingContext.Writer.AddAttribute (HtmlTextWriterAttribute.Class, CssClasses.Themed);
       renderingContext.Writer.RenderBeginTag (HtmlTextWriterTag.Span);
 
       var pageLabelText = GetResourceManager (renderingContext).GetString (ResourceIdentifier.PageLabelText);

--- a/Remotion/ObjectBinding/Web/UI/Controls/BocListImplementation/Rendering/BocSelectorColumnRenderer.cs
+++ b/Remotion/ObjectBinding/Web/UI/Controls/BocListImplementation/Rendering/BocSelectorColumnRenderer.cs
@@ -21,6 +21,7 @@ using Remotion.ObjectBinding.Web.Contracts.DiagnosticMetadata;
 using Remotion.ServiceLocation;
 using Remotion.Utilities;
 using Remotion.Web.UI;
+using Remotion.Web.UI.Controls;
 using Remotion.Web.UI.Controls.Rendering;
 
 namespace Remotion.ObjectBinding.Web.UI.Controls.BocListImplementation.Rendering
@@ -60,7 +61,7 @@ namespace Remotion.ObjectBinding.Web.UI.Controls.BocListImplementation.Rendering
         return;
 
       string selectorControlID = renderingContext.Control.GetSelectorControlName().Replace ('$', '_') + "_" + rowRenderingContext.Row.Index;
-      var cssClass = cssClassTableCell + " " + CssClasses.DataCellSelector;
+      var cssClass = cssClassTableCell + " " + CssClasses.Themed + " " + CssClasses.DataCellSelector;
       var selectorControlName = renderingContext.Control.GetSelectorControlName();
       var selectorControlValue = renderingContext.Control.GetSelectorControlValue (rowRenderingContext.Row);
       var isChecked = rowRenderingContext.IsSelected;
@@ -90,7 +91,7 @@ namespace Remotion.ObjectBinding.Web.UI.Controls.BocListImplementation.Rendering
       if (!renderingContext.Control.IsSelectionEnabled)
         return;
 
-      var cssClass = CssClasses.TitleCell + " " + CssClasses.TitleCellSelector;
+      var cssClass = CssClasses.TitleCell + " " + CssClasses.Themed + " " + CssClasses.TitleCellSelector;
 
       renderingContext.Writer.AddAttribute (HtmlTextWriterAttribute.Class, cssClass);
       renderingContext.Writer.AddAttribute (HtmlTextWriterAttribute2.Role, HtmlRoleAttributeValue.ColumnHeader);

--- a/Remotion/ObjectBinding/Web/UI/Controls/BocReferenceValueImplementation/Rendering/BocAutoCompleteReferenceValueRenderer.cs
+++ b/Remotion/ObjectBinding/Web/UI/Controls/BocReferenceValueImplementation/Rendering/BocAutoCompleteReferenceValueRenderer.cs
@@ -325,7 +325,7 @@ namespace Remotion.ObjectBinding.Web.UI.Controls.BocReferenceValueImplementation
 
       ValidationErrorRenderer.SetValidationErrorsReferenceOnControl (textBox, validationErrorsID, validationErrors);
 
-      renderingContext.Writer.AddAttribute (HtmlTextWriterAttribute.Class, CssClassInput);
+      renderingContext.Writer.AddAttribute (HtmlTextWriterAttribute.Class, CssClassInput + " " + CssClassThemed);
       renderingContext.Writer.AddAttribute (HtmlTextWriterAttribute2.Role, HtmlRoleAttributeValue.Combobox);
       renderingContext.Writer.AddAttribute (HtmlTextWriterAttribute2.AriaHasPopup, HtmlAriaHasPopupAttributeValue.Listbox);
       renderingContext.Writer.AddAttribute (HtmlTextWriterAttribute2.AriaExpanded, HtmlAriaExpandedAttributeValue.False);

--- a/Remotion/ObjectBinding/Web/UI/Controls/BocReferenceValueImplementation/Rendering/BocReferenceValueRendererBase.cs
+++ b/Remotion/ObjectBinding/Web/UI/Controls/BocReferenceValueImplementation/Rendering/BocReferenceValueRendererBase.cs
@@ -509,7 +509,7 @@ namespace Remotion.ObjectBinding.Web.UI.Controls.BocReferenceValueImplementation
 
     private string GetCssClassInnerContent (BocRenderingContext<TControl> renderingContext)
     {
-      string cssClass = CssClassInnerContent;
+      string cssClass = CssClassInnerContent + " " + CssClassThemed;
 
       if (!renderingContext.Control.HasOptionsMenu)
         cssClass += " " + CssClassWithoutOptionsMenu;

--- a/Remotion/ObjectBinding/Web/UI/Controls/BocRendererBase.cs
+++ b/Remotion/ObjectBinding/Web/UI/Controls/BocRendererBase.cs
@@ -148,7 +148,7 @@ namespace Remotion.ObjectBinding.Web.UI.Controls
     /// </remarks>
     public virtual string CssClassReadOnly
     {
-      get { return "readOnly"; }
+      get { return CssClassDefinition.ReadOnly; }
     }
 
     /// <summary> Gets the CSS-Class applied to the <see cref="IBocRenderableControl"/> when it is displayed disabled. </summary>
@@ -158,7 +158,29 @@ namespace Remotion.ObjectBinding.Web.UI.Controls
     /// </remarks>
     public virtual string CssClassDisabled
     {
-      get { return "disabled"; }
+      get { return CssClassDefinition.Disabled; }
+    }
+
+    /// <summary>
+    /// Gets the CSS-Class applied to the <see cref="IBocRenderableControl"/> when itself and child elements
+    /// that are standard browser controls (e.g. input elements) should be styled in the current theme.
+    /// </summary>
+    /// <remarks> 
+    ///   <para> Class: <c>remotion-themed</c>. </para>
+    ///   <para> Applied in addition to the regular CSS-Class.</para>
+    /// </remarks>
+    public virtual string CssClassThemed
+    {
+      get { return CssClassDefinition.Themed; }
+    }
+
+    /// <summary>
+    /// Gets whether the control establishes a theming context which automatically styles standard browser controls (e.g. input elements)
+    /// in the current theme. <see langword="false" /> by default. Derived classes may override this behavior. 
+    /// </summary>
+    protected virtual bool UseThemingContext
+    {
+      get { return false; }
     }
 
     private void OverrideCssClass (RenderingContext<TControl> renderingContext, out string backUpCssClass, out string backUpAttributeCssClass)
@@ -190,10 +212,13 @@ namespace Remotion.ObjectBinding.Web.UI.Controls
 
       var additionalCssClass = string.Empty;
 
+      if (UseThemingContext)
+        additionalCssClass += " " + CssClassThemed;
+
       if (isReadOnly)
-        additionalCssClass = " " + CssClassReadOnly;
+        additionalCssClass += " " + CssClassReadOnly;
       else if (isDisabled)
-        additionalCssClass = " " + CssClassDisabled;
+        additionalCssClass += " " + CssClassDisabled;
 
       return additionalCssClass;
     }

--- a/Remotion/ObjectBinding/Web/UI/Controls/BocTextValueImplementation/Rendering/BocTextValueRendererBase.cs
+++ b/Remotion/ObjectBinding/Web/UI/Controls/BocTextValueImplementation/Rendering/BocTextValueRendererBase.cs
@@ -65,6 +65,12 @@ namespace Remotion.ObjectBinding.Web.UI.Controls.BocTextValueImplementation.Rend
       get { return _labelReferenceRenderer; }
     }
 
+    /// <inheritdoc />
+    protected override bool UseThemingContext
+    {
+      get { return true; }
+    }
+
     /// <summary>
     /// Renders a label when <see cref="IBusinessObjectBoundEditableControl.IsReadOnly"/> is <see langword="true"/>,
     /// a textbox in edit mode.

--- a/Remotion/Web/Core/UI/Controls/CssClassDefinition.cs
+++ b/Remotion/Web/Core/UI/Controls/CssClassDefinition.cs
@@ -1,0 +1,57 @@
+﻿// This file is part of the re-motion Core Framework (www.re-motion.org)
+// Copyright (c) rubicon IT GmbH, www.rubicon.eu
+// 
+// The re-motion Core Framework is free software; you can redistribute it 
+// and/or modify it under the terms of the GNU Lesser General Public License 
+// as published by the Free Software Foundation; either version 2.1 of the 
+// License, or (at your option) any later version.
+// 
+// re-motion is distributed in the hope that it will be useful, 
+// but WITHOUT ANY WARRANTY; without even the implied warranty of 
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the 
+// GNU Lesser General Public License for more details.
+// 
+// You should have received a copy of the GNU Lesser General Public License
+// along with re-motion; if not, see http://www.gnu.org/licenses.
+// 
+namespace Remotion.Web.UI.Controls
+{
+  /// <summary>
+  /// Contains all the CSS class definitions needed throughout UI control rendering.
+  /// </summary>
+  public static class CssClassDefinition
+  {
+    /// <summary> Gets the CSS-Class applied to an UI control when it is displayed in read-only mode. </summary>
+    /// <remarks> 
+    ///   <para> Class: <c>readOnly</c>. </para>
+    ///   <para> Applied in addition to the regular CSS-Class. Use <c>.bocTextValue.readOnly</c> as a selector. </para>
+    /// </remarks>
+    public static string ReadOnly
+    {
+      get { return "readOnly"; }
+    }
+
+    /// <summary> Gets the CSS-Class applied to an UI control when it is displayed disabled. </summary>
+    /// <remarks> 
+    ///   <para> Class: <c>disabled</c>. </para>
+    ///   <para> Applied in addition to the regular CSS-Class. Use <c>.bocTextValue.disabled</c> as a selector.</para>
+    /// </remarks>
+    public static string Disabled
+    {
+      get { return "disabled"; }
+    }
+
+    /// <summary>
+    /// Gets the CSS-Class applied to an UI control when itself and child elements
+    /// that are standard browser controls (e.g. input elements) should be styled in the current theme.
+    /// </summary>
+    /// <remarks> 
+    ///   <para> Class: <c>remotion-themed</c>. </para>
+    ///   <para> Applied in addition to the regular CSS-Class.</para>
+    /// </remarks>
+    public static string Themed
+    {
+      get { return "remotion-themed"; }
+    }
+  }
+}

--- a/Remotion/Web/Core/UI/Controls/DatePickerButtonImplementation/Rendering/DatePickerButtonRenderer.cs
+++ b/Remotion/Web/Core/UI/Controls/DatePickerButtonImplementation/Rendering/DatePickerButtonRenderer.cs
@@ -156,7 +156,7 @@ namespace Remotion.Web.UI.Controls.DatePickerButtonImplementation.Rendering
 
     public string CssClassDisabled
     {
-      get { return "disabled"; }
+      get { return CssClassDefinition.Disabled; }
     }
 
     protected Unit PopUpWidth

--- a/Remotion/Web/Core/UI/Controls/DropDownMenuImplementation/Rendering/DropDownMenuRenderer.cs
+++ b/Remotion/Web/Core/UI/Controls/DropDownMenuImplementation/Rendering/DropDownMenuRenderer.cs
@@ -494,7 +494,7 @@ namespace Remotion.Web.UI.Controls.DropDownMenuImplementation.Rendering
 
     protected string CssClassDisabled
     {
-      get { return "disabled"; }
+      get { return CssClassDefinition.Disabled; }
     }
   }
 }

--- a/Remotion/Web/Core/UI/Controls/WebButton.cs
+++ b/Remotion/Web/Core/UI/Controls/WebButton.cs
@@ -204,6 +204,7 @@ namespace Remotion.Web.UI.Controls
       var originalCssClass = (CssClass ?? "").Replace (DisabledCssClass, "").Trim();
       var isCssStyleOverridden = !string.IsNullOrEmpty (originalCssClass);
       var computedCssClass = isCssStyleOverridden ? originalCssClass : CssClassBase;
+      computedCssClass += " " + CssClassThemed;
       ControlStyle.CssClass = computedCssClass;
 
       base.AddAttributesToRender (writer);
@@ -534,6 +535,19 @@ namespace Remotion.Web.UI.Controls
     protected virtual string CssClassButtonBody
     {
       get { return "buttonBody"; }
+    }
+
+    /// <summary>
+    /// Gets the CSS-Class applied to the <c>div</c> when itself and child elements
+    /// that are standard browser controls (e.g. input elements) should be styled in the current theme.
+    /// </summary>
+    /// <remarks> 
+    ///   <para> Class: <c>remotion-themed</c>. </para>
+    ///   <para> Applied in addition to the regular CSS-Class.</para>
+    /// </remarks>
+    public virtual string CssClassThemed
+    {
+      get { return CssClassDefinition.Themed; }
     }
 
     /// <summary> Gets the CSS-Class applied when the section is empty. </summary>

--- a/Remotion/Web/Core/UI/Controls/WebTabStrip.cs
+++ b/Remotion/Web/Core/UI/Controls/WebTabStrip.cs
@@ -631,7 +631,7 @@ namespace Remotion.Web.UI.Controls
     /// </remarks>
     protected virtual string CssClassDisabled
     {
-      get { return "disabled"; }
+      get { return CssClassDefinition.Disabled; }
     }
 
     #endregion

--- a/Remotion/Web/Core/UI/Controls/WebTabStripImplementation/Rendering/WebTabRenderer.cs
+++ b/Remotion/Web/Core/UI/Controls/WebTabStripImplementation/Rendering/WebTabRenderer.cs
@@ -305,7 +305,7 @@ namespace Remotion.Web.UI.Controls.WebTabStripImplementation.Rendering
     /// </remarks>
     public virtual string CssClassDisabled
     {
-      get { return "disabled"; }
+      get { return CssClassDefinition.Disabled; }
     }
   }
 }

--- a/Remotion/Web/Core/UI/Controls/WebTabStripImplementation/Rendering/WebTabStripRenderer.cs
+++ b/Remotion/Web/Core/UI/Controls/WebTabStripImplementation/Rendering/WebTabStripRenderer.cs
@@ -221,7 +221,7 @@ namespace Remotion.Web.UI.Controls.WebTabStripImplementation.Rendering
     /// </remarks>
     public virtual string CssClassDisabled
     {
-      get { return "disabled"; }
+      get { return CssClassDefinition.Disabled; }
     }
 
     /// <summary> Gets the CSS-Class applied to the div used to clear the flow-layout at the end of the tab-strip. </summary>


### PR DESCRIPTION
https://re-motion.atlassian.net/browse/RM-7902

For testing it is useful to install a CSS injector extension (e.g. Stylus in Chrome) and use the following CSS to highlight elements with the `remotion-themed` class:

```
.remotion-themed {
    /*background: yellow !important;*/
    outline: 1px solid red !important;
    background: rgba(255,0,0,0.1);
}


.remotion-themed input, .remotion-themed select, .remotion-themed button {
        outline: 1px solid blue;
    background: rgba(0,0,255,0.1);
}
```