### PR TITLE
RM-7917 Create styles for new theme for BocEnumValue

### DIFF
--- a/Remotion/ObjectBinding/Web.UnitTests/UI/Controls/BocEnumValueImplementation/Rendering/BocEnumValueRendererTests/RadioButtons_BEVRT.cs
+++ b/Remotion/ObjectBinding/Web.UnitTests/UI/Controls/BocEnumValueImplementation/Rendering/BocEnumValueRendererTests/RadioButtons_BEVRT.cs
@@ -320,7 +320,7 @@ namespace Remotion.ObjectBinding.Web.UnitTests.UI.Controls.BocEnumValueImplement
       if (string.IsNullOrEmpty (cssClass))
         cssClass = _enumValue.Object.Attributes["class"];
       if (string.IsNullOrEmpty (cssClass))
-        cssClass = renderer.GetCssClassBase(_enumValue.Object);
+        cssClass = "bocEnumValue radioButtonList";
 
       Html.AssertAttribute (div, "id", c_clientID);
       Html.AssertAttribute (div, "class", cssClass, HtmlHelperBase.AttributeValueCompareMode.Contains);

--- a/Remotion/ObjectBinding/Web.UnitTests/UI/Controls/BocEnumValueImplementation/Rendering/BocEnumValueRendererTests/ReadOnly_BEVRT.cs
+++ b/Remotion/ObjectBinding/Web.UnitTests/UI/Controls/BocEnumValueImplementation/Rendering/BocEnumValueRendererTests/ReadOnly_BEVRT.cs
@@ -258,7 +258,7 @@ namespace Remotion.ObjectBinding.Web.UnitTests.UI.Controls.BocEnumValueImplement
       if (string.IsNullOrEmpty (cssClass))
         cssClass = _enumValue.Object.Attributes["class"];
       if (string.IsNullOrEmpty (cssClass))
-        cssClass = renderer.GetCssClassBase(_enumValue.Object);
+        cssClass = "bocEnumValue";
 
       Html.AssertAttribute (div, "id", "MyEnumValue");
       Html.AssertAttribute (div, "class", cssClass, HtmlHelperBase.AttributeValueCompareMode.Contains);

--- a/Remotion/ObjectBinding/Web.UnitTests/UI/Controls/BocEnumValueImplementation/Rendering/BocEnumValueRendererTests/SelectListDisabled_BEVRT.cs
+++ b/Remotion/ObjectBinding/Web.UnitTests/UI/Controls/BocEnumValueImplementation/Rendering/BocEnumValueRendererTests/SelectListDisabled_BEVRT.cs
@@ -212,7 +212,7 @@ namespace Remotion.ObjectBinding.Web.UnitTests.UI.Controls.BocEnumValueImplement
       if (string.IsNullOrEmpty (cssClass))
         cssClass = _enumValue.Object.Attributes["class"];
       if (string.IsNullOrEmpty (cssClass))
-        cssClass = renderer.GetCssClassBase(_enumValue.Object);
+        cssClass = "bocEnumValue dropDownList";
 
       Html.AssertAttribute (div, "id", "MyEnumValue");
       Html.AssertAttribute (div, "class", cssClass, HtmlHelperBase.AttributeValueCompareMode.Contains);

--- a/Remotion/ObjectBinding/Web.UnitTests/UI/Controls/BocEnumValueImplementation/Rendering/BocEnumValueRendererTests/SelectList_BEVRT.cs
+++ b/Remotion/ObjectBinding/Web.UnitTests/UI/Controls/BocEnumValueImplementation/Rendering/BocEnumValueRendererTests/SelectList_BEVRT.cs
@@ -259,7 +259,7 @@ namespace Remotion.ObjectBinding.Web.UnitTests.UI.Controls.BocEnumValueImplement
       if (string.IsNullOrEmpty (cssClass))
         cssClass = _enumValue.Object.Attributes["class"];
       if (string.IsNullOrEmpty (cssClass))
-        cssClass = renderer.GetCssClassBase(_enumValue.Object);
+        cssClass = "bocEnumValue dropDownList";
 
       Html.AssertAttribute (div, "id", "MyEnumValue");
       Html.AssertAttribute (div, "class", cssClass, HtmlHelperBase.AttributeValueCompareMode.Contains);

--- a/Remotion/ObjectBinding/Web/Res/Themes/NovaViso/HTML/BocEnumValue.css
+++ b/Remotion/ObjectBinding/Web/Res/Themes/NovaViso/HTML/BocEnumValue.css
@@ -4,7 +4,6 @@ span.bocEnumValue,
 div.bocEnumValue.readOnly
 {
   display: inline-flex;
-  align-items: center;
   width: var(--remotion-themed-control-width);
   min-height: var(--remotion-themed-min-height);
 }

--- a/Remotion/ObjectBinding/Web/Res/Themes/NovaViso/HTML/BocEnumValue.css
+++ b/Remotion/ObjectBinding/Web/Res/Themes/NovaViso/HTML/BocEnumValue.css
@@ -3,112 +3,10 @@
 span.bocEnumValue,
 div.bocEnumValue.readOnly
 {
+  display: inline-flex;
+  align-items: center;
   width: var(--remotion-themed-control-width);
   min-height: var(--remotion-themed-min-height);
-  position: relative;
-  display: flex;
-  overflow: hidden;
-}
-
-div.bocEnumValue.readOnly span
-{
-  /*box-sizing: border-box;*/
-  display: inline-flex;
-  align-items: center;
-}
-
-/*div.bocEnumValue table
-{
-  height: 100%;
-  box-sizing: border-box;
-}*/
-
-div.bocEnumValue td,
-div.bocEnumValue td span
-{
-  box-sizing: border-box;
-  display: inline-flex;
-  align-items: center;
-  margin-right: 0.4em;
-}
-
-div.bocEnumValue input
-{
-  box-sizing: border-box;
-  /* Has to be set explicitely at the moment, since otherwise a top  
-     margin is applied I have not able to determine the source of. */
-  margin: 0 0.4em 0 0;
-}
-
-.bocEnumValue.readOnly span
-/*div.bocEnumValue.readOnly*/
-{
-  /*padding: var(--remotion-themed-padding);*/
-  box-sizing: border-box;
-  
-}
-
-span.bocEnumValue.readOnly span,
-div.bocEnumValue.readOnly span
-{
-  /*padding: var(--remotion-themed-padding);*/
-  min-height: var(--remotion-themed-min-height);
-}
-
-
-.bocEnumValue.disabled
-{
-}
-
-span.bocEnumValue select
-{
-  box-sizing: border-box;
-  width: 100%;
-  min-height: calc(var(--remotion-themed-min-height));
-  /*gap: 10em;*/
-
-}
-
-span.bocEnumValue option
-{
-  box-sizing: border-box;
-  padding: var(--remotion-themed-padding);
-  /*padding: calc(var(--remotion-themed-padding) * 0.75);*/
-  /*padding: calc(var(--remotion-themed-padding) * 0.5);*/
-  border-radius: calc(var(--remotion-themed-border-radius));
-  /*margin: calc(var(--remotion-themed-padding));*/
-  /*gap: 2em;*/
-  /*line-height: 3em;*/
-}
-
-
-span.bocEnumValue option:hover
-{
-  background-color: var(--color-highlight);
-  /*flex: 4;*/
-}
-
-span.bocEnumValue.disabled option
-{
-  background-color: var(--color-disabled-background);
-  text-decoration: none;
-  color: var(--color-disabled-text);
-}
-
-
-
-
-
-span.bocEnumValue select[size]
-{
-  /*height: auto;*/
-}
-
-span.bocEnumValue select[size="1"]
-{
-  /*height: 1.68em;*/
-  /*height: var(--remotion-themed-line-height);*/
-  /*height: auto;*/
 }
 
 .bocEnumValue td
@@ -118,7 +16,67 @@ span.bocEnumValue select[size="1"]
 
 .bocEnumValue td label
 {
-  /*vertical-align: text-bottom;*/
+  padding: var(--remotion-themed-padding);
+}
+
+div.bocEnumValue td,
+div.bocEnumValue td span
+{
+  display: inline-flex;
+  align-items: center;
+  box-sizing: border-box;
+}
+
+div.bocEnumValue input
+{
+  /* Has to be set explicitely for input. */
+  margin: 0;
+}
+
+div.bocEnumValue input:focus
+{
+  /* In order to have an outline for the radio buttons as well. */
+  outline: auto;
+}
+
+div.bocEnumValue input:hover
+{
+  cursor: pointer;
+}
+
+div.bocEnumValue input:disabled
+{
+  cursor: default;
+}
+
+span.bocEnumValue select:hover,
+span.bocEnumValue option:hover
+{
+  background-color: var(--color-highlight);
+}
+
+span.bocEnumValue select
+{
+  width: 100%;
+}
+
+span.bocEnumValue option
+{
+  padding: calc(var(--remotion-themed-padding) * 0.75);
+  border-radius: var(--remotion-themed-border-radius);
+}
+
+span.bocEnumValue.disabled option
+{
+  background-color: var(--color-disabled-background);
+  color: var(--color-disabled-text);
+  text-decoration: none;
+}
+
+.bocEnumValue.readOnly span
+{
+  box-sizing: border-box;
+  padding: var(--remotion-themed-padding) 0;
 }
 
 .bocEnumValue.readOnly span[tabindex]:empty

--- a/Remotion/ObjectBinding/Web/Res/Themes/NovaViso/HTML/BocEnumValue.css
+++ b/Remotion/ObjectBinding/Web/Res/Themes/NovaViso/HTML/BocEnumValue.css
@@ -8,24 +8,32 @@
   min-height: var(--remotion-themed-min-height);
 }
 
-.bocEnumValue td
+.bocEnumValue.radioButtonList
 {
+  min-width: var(--remotion-themed-control-width);
+  width: auto;
+}
+
+.bocEnumValue table
+{
+  display: inline;
+}
+
+.bocEnumValue tr
+{
+  display: inline-flex;
+  flex-wrap: wrap;
+  gap: calc(var(--remotion-themed-spacing) * 2);
+}
+
+.bocEnumValue td,
+.bocEnumValue.disabled td > span
+{
+  display: inline-flex;
+  align-items: center;
+  box-sizing: border-box;
+  gap: var(--remotion-themed-spacing);
   white-space: nowrap;
-  display: inline-flex;
-  align-items: center;
-  box-sizing: border-box;
-}
-
-.bocEnumValue td label
-{
-  padding: var(--remotion-themed-padding);
-}
-
-.bocEnumValue td span
-{
-  display: inline-flex;
-  align-items: center;
-  box-sizing: border-box;
 }
 
 .bocEnumValue input

--- a/Remotion/ObjectBinding/Web/Res/Themes/NovaViso/HTML/BocEnumValue.css
+++ b/Remotion/ObjectBinding/Web/Res/Themes/NovaViso/HTML/BocEnumValue.css
@@ -38,18 +38,13 @@ div.bocEnumValue input:focus
   outline: auto;
 }
 
-div.bocEnumValue input:hover
+div.bocEnumValue input:not([disabled]):hover
 {
   cursor: pointer;
 }
 
-div.bocEnumValue input:disabled
-{
-  cursor: default;
-}
-
-span.bocEnumValue select:hover,
-span.bocEnumValue option:hover
+span.bocEnumValue select:not([disabled]):hover,
+span.bocEnumValue:not(.disabled) option:hover
 {
   background-color: var(--color-highlight);
 }
@@ -63,13 +58,6 @@ span.bocEnumValue option
 {
   padding: calc(var(--remotion-themed-padding) * 0.75);
   border-radius: var(--remotion-themed-border-radius);
-}
-
-span.bocEnumValue.disabled option
-{
-  background-color: var(--color-disabled-background);
-  color: var(--color-disabled-text);
-  text-decoration: none;
 }
 
 .bocEnumValue.readOnly span

--- a/Remotion/ObjectBinding/Web/Res/Themes/NovaViso/HTML/BocEnumValue.css
+++ b/Remotion/ObjectBinding/Web/Res/Themes/NovaViso/HTML/BocEnumValue.css
@@ -3,18 +3,58 @@
 span.bocEnumValue,
 div.bocEnumValue.readOnly
 {
-  width: 15em;
+  width: var(--remotion-themed-control-width);
+  min-height: var(--remotion-themed-min-height);
   position: relative;
-  display: inline-block;
-  vertical-align: middle;
+  display: flex;
   overflow: hidden;
 }
 
-.bocEnumValue.readOnly
+div.bocEnumValue.readOnly span
 {
-  /* Ensures that the outline is visible in Firefox. */
-  overflow: visible;
+  /*box-sizing: border-box;*/
+  display: inline-flex;
+  align-items: center;
 }
+
+/*div.bocEnumValue table
+{
+  height: 100%;
+  box-sizing: border-box;
+}*/
+
+div.bocEnumValue td,
+div.bocEnumValue td span
+{
+  box-sizing: border-box;
+  display: inline-flex;
+  align-items: center;
+  margin-right: 0.4em;
+}
+
+div.bocEnumValue input
+{
+  box-sizing: border-box;
+  /* Has to be set explicitely at the moment, since otherwise a top  
+     margin is applied I have not able to determine the source of. */
+  margin: 0 0.4em 0 0;
+}
+
+.bocEnumValue.readOnly span
+/*div.bocEnumValue.readOnly*/
+{
+  /*padding: var(--remotion-themed-padding);*/
+  box-sizing: border-box;
+  
+}
+
+span.bocEnumValue.readOnly span,
+div.bocEnumValue.readOnly span
+{
+  /*padding: var(--remotion-themed-padding);*/
+  min-height: var(--remotion-themed-min-height);
+}
+
 
 .bocEnumValue.disabled
 {
@@ -22,18 +62,53 @@ div.bocEnumValue.readOnly
 
 span.bocEnumValue select
 {
+  box-sizing: border-box;
   width: 100%;
-  height: 1.68em;
+  min-height: calc(var(--remotion-themed-min-height));
+  /*gap: 10em;*/
+
 }
+
+span.bocEnumValue option
+{
+  box-sizing: border-box;
+  padding: var(--remotion-themed-padding);
+  /*padding: calc(var(--remotion-themed-padding) * 0.75);*/
+  /*padding: calc(var(--remotion-themed-padding) * 0.5);*/
+  border-radius: calc(var(--remotion-themed-border-radius));
+  /*margin: calc(var(--remotion-themed-padding));*/
+  /*gap: 2em;*/
+  /*line-height: 3em;*/
+}
+
+
+span.bocEnumValue option:hover
+{
+  background-color: var(--color-highlight);
+  /*flex: 4;*/
+}
+
+span.bocEnumValue.disabled option
+{
+  background-color: var(--color-disabled-background);
+  text-decoration: none;
+  color: var(--color-disabled-text);
+}
+
+
+
+
 
 span.bocEnumValue select[size]
 {
-  height: auto;
+  /*height: auto;*/
 }
 
 span.bocEnumValue select[size="1"]
 {
-  height: 1.68em;
+  /*height: 1.68em;*/
+  /*height: var(--remotion-themed-line-height);*/
+  /*height: auto;*/
 }
 
 .bocEnumValue td
@@ -43,36 +118,20 @@ span.bocEnumValue select[size="1"]
 
 .bocEnumValue td label
 {
-  vertical-align: text-bottom;
-}
-
-.bocEnumValue.readOnly span[tabindex]
-{
-  /* Ensures that diacritic marks can be rendered without being cut off. 
-     Using line-height instead of padding works better with BocEnumValue. When using padding, the text is not aligned with the label. */
-  /*line-height: 1.5em;*/
-  /* Ensures that the outline is rendered outside of the space reserved for diacritic marks. */
-  display: inline-block;
-}
-
-.bocEnumValue.readOnly span[tabindex]:first-child
-{
-  /* Ensures that diacritic marks can be rendered without being cut off. */
-  padding-top: 0.2em;
-}
-
-.bocEnumValue.readOnly span[tabindex]:last-child
-{
-  /* Ensures that diacritic marks can be rendered without being cut off. */
-  padding-bottom: 0.2em;
+  /*vertical-align: text-bottom;*/
 }
 
 .bocEnumValue.readOnly span[tabindex]:empty
 {
-  /* Ensures that empty readonly values are not collapsed and can therefor visualize the keyboard focus */
+  /* Ensures that the keyboard focus of empty readonly values surrounds the entire width of the span. */
   width: 100%;
-  min-height: 1.5em;
-  padding-top: 0;
-  padding-bottom: 0;
-  vertical-align: -0.2em;
+}
+
+.bocEnumValue.readOnly span[tabindex]:empty:before
+{
+  /* Inserting a 'zero width space' unicode character as placeholder so that empty 
+    readonly values are not collapsed and can therefore visualize the keyboard focus. 
+    This also scales with the font size and min-height doesn't have to be set since
+    line height remains unchanged. */
+  content: "\200b";
 }

--- a/Remotion/ObjectBinding/Web/Res/Themes/NovaViso/HTML/BocEnumValue.css
+++ b/Remotion/ObjectBinding/Web/Res/Themes/NovaViso/HTML/BocEnumValue.css
@@ -1,7 +1,7 @@
 /* Style applied to the BocEnumValue. */
 
-span.bocEnumValue,
-div.bocEnumValue.readOnly
+.bocEnumValue,
+.bocEnumValue.readOnly
 {
   display: inline-flex;
   width: var(--remotion-themed-control-width);
@@ -11,6 +11,9 @@ div.bocEnumValue.readOnly
 .bocEnumValue td
 {
   white-space: nowrap;
+  display: inline-flex;
+  align-items: center;
+  box-sizing: border-box;
 }
 
 .bocEnumValue td label
@@ -18,46 +21,44 @@ div.bocEnumValue.readOnly
   padding: var(--remotion-themed-padding);
 }
 
-div.bocEnumValue td,
-div.bocEnumValue td span
+.bocEnumValue td span
 {
   display: inline-flex;
   align-items: center;
   box-sizing: border-box;
 }
 
-div.bocEnumValue input
+.bocEnumValue input
 {
   /* Has to be set explicitely for input. */
   margin: 0;
 }
 
-div.bocEnumValue input:focus
+.bocEnumValue input:focus
 {
   /* In order to have an outline for the radio buttons as well. */
   outline: auto;
 }
 
-div.bocEnumValue input:not([disabled]):hover
+.bocEnumValue input:not([disabled]):hover
 {
   cursor: pointer;
 }
 
-span.bocEnumValue select:not([disabled]):hover,
-span.bocEnumValue:not(.disabled) option:hover
-{
-  background-color: var(--color-highlight);
-}
-
-span.bocEnumValue select
+.bocEnumValue select
 {
   width: 100%;
 }
 
-span.bocEnumValue option
+.bocEnumValue option
 {
   padding: calc(var(--remotion-themed-padding) * 0.75);
   border-radius: var(--remotion-themed-border-radius);
+}
+
+.bocEnumValue select:not([disabled]) option:hover
+{
+  background-color: var(--color-highlight);
 }
 
 .bocEnumValue.readOnly span

--- a/Remotion/ObjectBinding/Web/UI/Controls/BocEnumValueImplementation/Rendering/BocEnumValueRenderer.cs
+++ b/Remotion/ObjectBinding/Web/UI/Controls/BocEnumValueImplementation/Rendering/BocEnumValueRenderer.cs
@@ -106,6 +106,7 @@ namespace Remotion.ObjectBinding.Web.UI.Controls.BocEnumValueImplementation.Rend
       bool isControlWidthEmpty = renderingContext.Control.Width.IsEmpty && string.IsNullOrEmpty (renderingContext.Control.Style["width"]);
       Label label = GetLabel (renderingContext);
       ListControl listControl = GetListControl (renderingContext);
+      
       WebControl innerControl = renderingContext.Control.IsReadOnly ? (WebControl) label : listControl;
       innerControl.Page = renderingContext.Control.Page.WrappedInstance;
 
@@ -128,6 +129,19 @@ namespace Remotion.ObjectBinding.Web.UI.Controls.BocEnumValueImplementation.Rend
           }
         }
       }
+
+      //if (listControl.Enabled && !listControl.IsDisabled & listControl.SupportsDisabledAttribute)
+      //  renderingContext.Writer.AddAttribute(HtmlTextWriterAttribute.Disabled, "disabled");
+      //if (listControl.SupportsDisabledAttribute && !listControl.Enabled)
+      //if (!listControl.Enabled && WebControl.DisabledCssClass.Equals ("aspNetDisabled"))
+      //if (innerControl.ClientID.Contains("body_DataEditControl_DisabledUnboundMarriageStatusField") && !listControl.Enabled)
+      //if (!listControl.Enabled && WebControl.DisabledCssClass.Equals("aspNetDisabled"))
+      //if (!listControl.Enabled)
+      //{
+      //    listControl.
+      //    listControl.Attributes.Add("disabled", "disabled");
+      //}
+
 
       _validationErrorRenderer.SetValidationErrorsReferenceOnControl (innerControl, validationErrorsID, validationErrors);
 
@@ -152,7 +166,7 @@ namespace Remotion.ObjectBinding.Web.UI.Controls.BocEnumValueImplementation.Rend
 
       renderingContext.Writer.AddAttribute (DiagnosticMetadataAttributesForObjectBinding.NullIdentifier, renderingContext.Control.NullIdentifier);
     }
-
+        
     private ListControl GetListControl (BocEnumValueRenderingContext renderingContext)
     {
       ListControl listControl = renderingContext.Control.ListControlStyle.Create (false);
@@ -167,10 +181,13 @@ namespace Remotion.ObjectBinding.Web.UI.Controls.BocEnumValueImplementation.Rend
 
       var isRadioButtonList = renderingContext.Control.ListControlStyle.ControlType == ListControlType.RadioButtonList;
       var isDropDownList = renderingContext.Control.ListControlStyle.ControlType == ListControlType.DropDownList;
+      var isListBox = renderingContext.Control.ListControlStyle.ControlType == ListControlType.ListBox;
 
       if (isRadioButtonList)
         listControl.Attributes.Add (HtmlTextWriterAttribute2.Role, HtmlRoleAttributeValue.RadioGroup);
-
+      
+      if (isListBox && !listControl.Enabled)
+        listControl.Attributes.Add ("disabled", "disabled");
 
       var labelIDs = renderingContext.Control.GetLabelIDs().ToArray();
       _labelReferenceRenderer.SetLabelReferenceOnControl (listControl, labelIDs);
@@ -231,8 +248,13 @@ namespace Remotion.ObjectBinding.Web.UI.Controls.BocEnumValueImplementation.Rend
         radioButton.InputAttributes.Add (HtmlTextWriterAttribute2.AriaRequired, HtmlAriaRequiredAttributeValue.True);
       }
 
+
+
       return listControl;
     }
+
+
+
 
     private bool IsNullItemVisible (BocEnumValueRenderingContext renderingContext)
     {

--- a/Remotion/ObjectBinding/Web/UI/Controls/BocEnumValueImplementation/Rendering/BocEnumValueRenderer.cs
+++ b/Remotion/ObjectBinding/Web/UI/Controls/BocEnumValueImplementation/Rendering/BocEnumValueRenderer.cs
@@ -172,9 +172,6 @@ namespace Remotion.ObjectBinding.Web.UI.Controls.BocEnumValueImplementation.Rend
       if (isRadioButtonList)
         listControl.Attributes.Add (HtmlTextWriterAttribute2.Role, HtmlRoleAttributeValue.RadioGroup);
 
-      if (isListBox && !listControl.Enabled)
-        listControl.Attributes.Add ("disabled", "disabled");
-
       var labelIDs = renderingContext.Control.GetLabelIDs().ToArray();
       _labelReferenceRenderer.SetLabelReferenceOnControl (listControl, labelIDs);
 

--- a/Remotion/ObjectBinding/Web/UI/Controls/BocEnumValueImplementation/Rendering/BocEnumValueRenderer.cs
+++ b/Remotion/ObjectBinding/Web/UI/Controls/BocEnumValueImplementation/Rendering/BocEnumValueRenderer.cs
@@ -331,7 +331,21 @@ namespace Remotion.ObjectBinding.Web.UI.Controls.BocEnumValueImplementation.Rend
 
     public override string GetCssClassBase (IBocEnumValue control)
     {
-      return "bocEnumValue";
+      const string cssClassBase = "bocEnumValue";
+      if (control.IsReadOnly)
+        return cssClassBase;
+
+      switch (control.ListControlStyle.ControlType)
+      {
+        case ListControlType.DropDownList:
+          return cssClassBase + " dropDownList";
+        case ListControlType.ListBox:
+          return cssClassBase + " listBox";
+        case ListControlType.RadioButtonList:
+          return cssClassBase + " radioButtonList";
+        default:
+          throw new ArgumentOutOfRangeException();
+      }
     }
   }
 }

--- a/Remotion/ObjectBinding/Web/UI/Controls/BocEnumValueImplementation/Rendering/BocEnumValueRenderer.cs
+++ b/Remotion/ObjectBinding/Web/UI/Controls/BocEnumValueImplementation/Rendering/BocEnumValueRenderer.cs
@@ -128,7 +128,7 @@ namespace Remotion.ObjectBinding.Web.UI.Controls.BocEnumValueImplementation.Rend
           }
         }
       }
-      
+
       _validationErrorRenderer.SetValidationErrorsReferenceOnControl (innerControl, validationErrorsID, validationErrors);
 
       innerControl.RenderControl (renderingContext.Writer);
@@ -171,7 +171,7 @@ namespace Remotion.ObjectBinding.Web.UI.Controls.BocEnumValueImplementation.Rend
 
       if (isRadioButtonList)
         listControl.Attributes.Add (HtmlTextWriterAttribute2.Role, HtmlRoleAttributeValue.RadioGroup);
-      
+
       if (isListBox && !listControl.Enabled)
         listControl.Attributes.Add ("disabled", "disabled");
 

--- a/Remotion/ObjectBinding/Web/UI/Controls/BocEnumValueImplementation/Rendering/BocEnumValueRenderer.cs
+++ b/Remotion/ObjectBinding/Web/UI/Controls/BocEnumValueImplementation/Rendering/BocEnumValueRenderer.cs
@@ -106,7 +106,6 @@ namespace Remotion.ObjectBinding.Web.UI.Controls.BocEnumValueImplementation.Rend
       bool isControlWidthEmpty = renderingContext.Control.Width.IsEmpty && string.IsNullOrEmpty (renderingContext.Control.Style["width"]);
       Label label = GetLabel (renderingContext);
       ListControl listControl = GetListControl (renderingContext);
-      
       WebControl innerControl = renderingContext.Control.IsReadOnly ? (WebControl) label : listControl;
       innerControl.Page = renderingContext.Control.Page.WrappedInstance;
 
@@ -129,20 +128,7 @@ namespace Remotion.ObjectBinding.Web.UI.Controls.BocEnumValueImplementation.Rend
           }
         }
       }
-
-      //if (listControl.Enabled && !listControl.IsDisabled & listControl.SupportsDisabledAttribute)
-      //  renderingContext.Writer.AddAttribute(HtmlTextWriterAttribute.Disabled, "disabled");
-      //if (listControl.SupportsDisabledAttribute && !listControl.Enabled)
-      //if (!listControl.Enabled && WebControl.DisabledCssClass.Equals ("aspNetDisabled"))
-      //if (innerControl.ClientID.Contains("body_DataEditControl_DisabledUnboundMarriageStatusField") && !listControl.Enabled)
-      //if (!listControl.Enabled && WebControl.DisabledCssClass.Equals("aspNetDisabled"))
-      //if (!listControl.Enabled)
-      //{
-      //    listControl.
-      //    listControl.Attributes.Add("disabled", "disabled");
-      //}
-
-
+      
       _validationErrorRenderer.SetValidationErrorsReferenceOnControl (innerControl, validationErrorsID, validationErrors);
 
       innerControl.RenderControl (renderingContext.Writer);
@@ -166,7 +152,7 @@ namespace Remotion.ObjectBinding.Web.UI.Controls.BocEnumValueImplementation.Rend
 
       renderingContext.Writer.AddAttribute (DiagnosticMetadataAttributesForObjectBinding.NullIdentifier, renderingContext.Control.NullIdentifier);
     }
-        
+
     private ListControl GetListControl (BocEnumValueRenderingContext renderingContext)
     {
       ListControl listControl = renderingContext.Control.ListControlStyle.Create (false);
@@ -248,13 +234,8 @@ namespace Remotion.ObjectBinding.Web.UI.Controls.BocEnumValueImplementation.Rend
         radioButton.InputAttributes.Add (HtmlTextWriterAttribute2.AriaRequired, HtmlAriaRequiredAttributeValue.True);
       }
 
-
-
       return listControl;
     }
-
-
-
 
     private bool IsNullItemVisible (BocEnumValueRenderingContext renderingContext)
     {

--- a/Remotion/ObjectBinding/Web/UI/Controls/BocEnumValueImplementation/Rendering/BocEnumValueRenderer.cs
+++ b/Remotion/ObjectBinding/Web/UI/Controls/BocEnumValueImplementation/Rendering/BocEnumValueRenderer.cs
@@ -167,7 +167,6 @@ namespace Remotion.ObjectBinding.Web.UI.Controls.BocEnumValueImplementation.Rend
 
       var isRadioButtonList = renderingContext.Control.ListControlStyle.ControlType == ListControlType.RadioButtonList;
       var isDropDownList = renderingContext.Control.ListControlStyle.ControlType == ListControlType.DropDownList;
-      var isListBox = renderingContext.Control.ListControlStyle.ControlType == ListControlType.ListBox;
 
       if (isRadioButtonList)
         listControl.Attributes.Add (HtmlTextWriterAttribute2.Role, HtmlRoleAttributeValue.RadioGroup);


### PR DESCRIPTION
Currently, I fail to find a way to center the currently selected option in a single-line select in Firefox. In Chrome, it is by default centered, which doesn't make it viable to add padding since even though it's then centered in Firefox, it is off in Chrome.

![grafik](https://user-images.githubusercontent.com/62145161/131140170-c160b432-1b2c-46b0-bb78-1c2e67d7f813.png)
