### PR TITLE
RM-8047 ContextAwareTypeUtility can fail during static initialization due to recursive callchain

### DIFF
--- a/Remotion/Core/Core/Reflection/ContextAwareTypeUtility.cs
+++ b/Remotion/Core/Core/Reflection/ContextAwareTypeUtility.cs
@@ -34,11 +34,13 @@ namespace Remotion.Reflection
     private class Fields
     {
       public readonly Lazy<ITypeDiscoveryService> DefaultTypeDiscoveryService =
-          new Lazy<ITypeDiscoveryService> (TypeDiscoveryConfiguration.Current.CreateTypeDiscoveryService, 
+          new Lazy<ITypeDiscoveryService> (
+              () => TypeDiscoveryConfiguration.Current.CreateTypeDiscoveryService(),
               LazyThreadSafetyMode.ExecutionAndPublication);
 
       public readonly Lazy<ITypeResolutionService> DefaultTypeResolutionService =
-          new Lazy<ITypeResolutionService> (TypeResolutionConfiguration.Current.CreateTypeResolutionService, 
+          new Lazy<ITypeResolutionService> (
+              () => TypeResolutionConfiguration.Current.CreateTypeResolutionService(),
               LazyThreadSafetyMode.ExecutionAndPublication);
     }
 


### PR DESCRIPTION
https://re-motion.atlassian.net/browse/RM-8052
https://re-motion.atlassian.net/browse/RM-8047