### PR TITLE
RM-8050 Exclude *.exe files in .net5.0 from SearchPathRootAssemblyFinder

### DIFF
--- a/Remotion/Core/Core/Reflection/TypeDiscovery/AssemblyFinding/SearchPathRootAssemblyFinder.cs
+++ b/Remotion/Core/Core/Reflection/TypeDiscovery/AssemblyFinding/SearchPathRootAssemblyFinder.cs
@@ -120,7 +120,9 @@ namespace Remotion.Reflection.TypeDiscovery.AssemblyFinding
     {
       var fileSearchService = new FileSystemSearchService ();
       var specifications = new[] { 
+#if NETFRAMEWORK
           new FilePatternSpecification ("*.exe", FilePatternSpecificationKind.IncludeFollowReferences), 
+#endif
           new FilePatternSpecification ("*.dll", FilePatternSpecificationKind.IncludeFollowReferences) 
       };
 

--- a/Remotion/Core/UnitTests/Reflection/TypeDiscovery/AssemblyFinding/SearchPathRootAssemblyFinderTest.cs
+++ b/Remotion/Core/UnitTests/Reflection/TypeDiscovery/AssemblyFinding/SearchPathRootAssemblyFinderTest.cs
@@ -70,7 +70,9 @@ namespace Remotion.UnitTests.Reflection.TypeDiscovery.AssemblyFinding
       var finderSpecs = CheckCombinedFinderAndGetSpecifications(finder);
 
       Assert.That (finderSpecs, Is.EquivalentTo (new[] { 
+#if NETFRAMEWORK
           new FilePatternSpecification ("*.exe", FilePatternSpecificationKind.IncludeFollowReferences), 
+#endif
           new FilePatternSpecification ("*.dll", FilePatternSpecificationKind.IncludeFollowReferences) }));
     }
 
@@ -102,7 +104,9 @@ namespace Remotion.UnitTests.Reflection.TypeDiscovery.AssemblyFinding
 
       Assert.That (finderDirectories, Has.Member("dynamicDirectory"));
       Assert.That (finderSpecs, Is.EquivalentTo (new[] { 
+#if NETFRAMEWORK
           new FilePatternSpecification ("*.exe", FilePatternSpecificationKind.IncludeFollowReferences), 
+#endif
           new FilePatternSpecification ("*.dll", FilePatternSpecificationKind.IncludeFollowReferences) }));
       Assert.That (finderService, Is.InstanceOf (typeof (FileSystemSearchService)));
     }


### PR DESCRIPTION
https://re-motion.atlassian.net/browse/RM-8050