### PR TITLE
RM-8120: Change type of `WebButton.Text` from `string` to `WebString`

### DIFF
--- a/Remotion/ObjectBinding/Web.Test/ClientForm.aspx.cs
+++ b/Remotion/ObjectBinding/Web.Test/ClientForm.aspx.cs
@@ -125,14 +125,14 @@ public class ClientForm : TestWxeBasePage
 
     WebButton saveButton = new WebButton ();
     saveButton.ID = "SaveButton";
-    saveButton.Text = "Save";
+    saveButton.Text = WebString.CreateFromText ("Save");
     saveButton.Style["margin-right"] = "10pt";
     saveButton.Click += new EventHandler(SaveButton_Click);
     MultiView.TopControls.Add (saveButton);
 
     WebButton cancelButton = new WebButton ();
     cancelButton.ID = "CancelButton";
-    cancelButton.Text = "Cancel";
+    cancelButton.Text = WebString.CreateFromText ("Cancel");
     cancelButton.Style["margin-right"] = "10pt";
     cancelButton.Click += new EventHandler(CancelButton_Click);
     cancelButton.UseSubmitBehavior = false;

--- a/Remotion/ObjectBinding/Web.Test/IndividualControlTests/Form.aspx
+++ b/Remotion/ObjectBinding/Web.Test/IndividualControlTests/Form.aspx
@@ -29,7 +29,7 @@
           <div>
             <remotion:WebButton ID="PostBackButton" runat="server" Text="Post Back" />&nbsp;
             <remotion:WebButton ID="SaveButton" runat="server" Width="10em" Text="Save" />&nbsp;
-            <remotion:WebButton ID="SaveAndRestartButton" runat="server" Width="10em" Text="Save &&amp;amp; Restart" />&nbsp;
+            <remotion:WebButton ID="SaveAndRestartButton" runat="server" Width="10em" Text="Save &amp; Restart" />&nbsp;
             <remotion:WebButton ID="CancelButton" runat="server" Width="10em" Text="Cancel" />
           </div>
         </asp:PlaceHolder>

--- a/Remotion/ObjectBinding/Web.Test/TestTabbedForm.aspx.cs
+++ b/Remotion/ObjectBinding/Web.Test/TestTabbedForm.aspx.cs
@@ -195,21 +195,21 @@ public class TestTabbedForm : TestWxeBasePage
 
     WebButton saveButton = new WebButton ();
     saveButton.ID = "SaveButton";
-    saveButton.Text = "Save";
+    saveButton.Text = WebString.CreateFromText ("Save");
     saveButton.Style["margin-right"] = "10pt";
     saveButton.Click += new EventHandler(SaveButton_Click);
     MultiView.TopControls.Add (saveButton);
 
     WebButton cancelButton = new WebButton ();
     cancelButton.ID = "CancelButton";
-    cancelButton.Text = "Cancel";
+    cancelButton.Text = WebString.CreateFromText ("Cancel");
     cancelButton.Style["margin-right"] = "10pt";
     cancelButton.Click += new EventHandler(CancelButton_Click);
     MultiView.TopControls.Add (cancelButton);
 
     WebButton postBackButton = new WebButton();
     postBackButton.ID = "PostBackButton";
-    postBackButton.Text = "Postback";
+    postBackButton.Text = WebString.CreateFromText ("Postback");
     postBackButton.Style["margin-right"] = "10pt";
     MultiView.BottomControls.Add (postBackButton);
 

--- a/Remotion/Web/Development.WebTesting.ControlObjects/WebButtonControlObject.cs
+++ b/Remotion/Web/Development.WebTesting.ControlObjects/WebButtonControlObject.cs
@@ -44,11 +44,19 @@ namespace Remotion.Web.Development.WebTesting.ControlObjects
     }
 
     /// <summary>
-    /// Returns the text diplayed on the button.
+    /// Returns the text displayed on the button.
     /// </summary>
     public string GetText ()
     {
       return Scope.Text.Trim();
+    }
+
+    /// <summary>
+    /// Returns the set access key. <see langword="null" /> if missing.
+    /// </summary>
+    public string? GetAccessKey ()
+    {
+      return Scope["accesskey"];
     }
 
     /// <summary>

--- a/Remotion/Web/Development.WebTesting.IntegrationTests/WebButtonControlObjectTest.cs
+++ b/Remotion/Web/Development.WebTesting.IntegrationTests/WebButtonControlObjectTest.cs
@@ -74,6 +74,24 @@ namespace Remotion.Web.Development.WebTesting.IntegrationTests
     }
 
     [Test]
+    public void TestGetAccessKey ()
+    {
+      var home = Start();
+
+      var webButton = home.WebButtons().GetByLocalID ("MyWebButton1Sync");
+      Assert.That (webButton.GetAccessKey(), Is.EqualTo ("A"));
+    }
+
+    [Test]
+    public void TestGetAccessKey_AccessKeyNotSet ()
+    {
+      var home = Start();
+
+      var webButton = home.WebButtons().GetByLocalID ("MyWebButtonPrimary1Sync");
+      Assert.That (webButton.GetAccessKey(), Is.Null);
+    }
+
+    [Test]
     public void TestClick ()
     {
       var home = Start();

--- a/Remotion/Web/Development.WebTesting.TestSite/GenericPages/WebButtonGenericTestPage.cs
+++ b/Remotion/Web/Development.WebTesting.TestSite/GenericPages/WebButtonGenericTestPage.cs
@@ -33,7 +33,7 @@ namespace Remotion.Web.Development.WebTesting.TestSite.GenericPages
     public override WebButton CreateControl (GenericTestOptions options)
     {
       var control = base.CreateControl (options);
-      control.Text = options.TextContent;
+      control.Text = WebString.CreateFromText (options.TextContent);
       return control;
     }
   }

--- a/Remotion/Web/Development.WebTesting.TestSite/WebButtonTest.aspx
+++ b/Remotion/Web/Development.WebTesting.TestSite/WebButtonTest.aspx
@@ -19,7 +19,7 @@
   <asp:UpdatePanel ID="UpdatePanel" runat="server">
     <ContentTemplate>
       <h3>WebButton1</h3>
-      <remotion:WebButton ID="MyWebButton1Sync" Text="SyncButton" CommandName="Sync" RequiresSynchronousPostBack="true" runat="server" />
+      <remotion:WebButton ID="MyWebButton1Sync" Text="SyncButton" AccessKey="A" CommandName="Sync" RequiresSynchronousPostBack="true" runat="server" />
       <remotion:WebButton ID="MyWebButtonPrimary1Sync" Text="SyncButton" ButtonType="Primary" CommandName="Sync" RequiresSynchronousPostBack="true" runat="server" />
       <remotion:WebButton ID="MyWebButtonSupplemental1Sync" Text="SyncButton" ButtonType="Supplemental" CommandName="Sync" RequiresSynchronousPostBack="true" runat="server" />
       <h3>WebButton2</h3>

--- a/Remotion/Web/Test.Shared/MultiplePostBackCatching/TestControlGenerator.cs
+++ b/Remotion/Web/Test.Shared/MultiplePostBackCatching/TestControlGenerator.cs
@@ -122,7 +122,7 @@ namespace Remotion.Web.Test.Shared.MultiplePostBackCatching
     {
       WebButton button = new WebButton();
       button.ID = CreateID (prefix, "ButtonSubmit");
-      button.Text = "Submit";
+      button.Text = WebString.CreateFromText ("Submit");
       button.UseSubmitBehavior = true;
       button.Click += OnClick;
       return button;
@@ -132,7 +132,7 @@ namespace Remotion.Web.Test.Shared.MultiplePostBackCatching
     {
       WebButton button = new WebButton();
       button.ID = CreateID (prefix, "ButtonButton");
-      button.Text = "Button";
+      button.Text = WebString.CreateFromText ("Button");
       button.UseSubmitBehavior = false;
       button.Click += OnClick;
 

--- a/Remotion/Web/UnitTests/Core/UI/Controls/WebButtonTests/EncodingTest.cs
+++ b/Remotion/Web/UnitTests/Core/UI/Controls/WebButtonTests/EncodingTest.cs
@@ -1,0 +1,102 @@
+﻿// This file is part of the re-motion Core Framework (www.re-motion.org)
+// Copyright (c) rubicon IT GmbH, www.rubicon.eu
+//
+// The re-motion Core Framework is free software; you can redistribute it
+// and/or modify it under the terms of the GNU Lesser General Public License
+// as published by the Free Software Foundation; either version 2.1 of the
+// License, or (at your option) any later version.
+//
+// re-motion is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with re-motion; if not, see http://www.gnu.org/licenses.
+//
+using System.Web.UI;
+using System.Xml;
+using NUnit.Framework;
+using Remotion.Development.Web.UnitTesting.UI.Controls;
+
+namespace Remotion.Web.UnitTests.Core.UI.Controls.WebButtonTests
+{
+  [TestFixture]
+  public class EncodingTest : BaseTest
+  {
+    private TestWebButton _webButton;
+    private HtmlHelper _html;
+
+    protected override void SetUpPage()
+    {
+      base.SetUpPage();
+      _webButton = new TestWebButton();
+      _webButton.ID = "WebButton";
+      _html = new HtmlHelper();
+    }
+
+    public override void TearDown ()
+    {
+      base.TearDown();
+      _html.Dispose();
+    }
+
+    [Test]
+    public void Text_WithPlainText ()
+    {
+      _webButton.Text = WebString.CreateFromText ("test");
+
+      var result = RenderControl (_webButton);
+
+      var button = _html.GetAssertedChildElement (result, "button", 0);
+      _html.AssertAttribute (button, "value", "test");
+      var buttonBody = _html.GetAssertedChildElement (button, "span", 0);
+      var textSpan = _html.GetAssertedChildElement (buttonBody, "span", 0);
+      _html.AssertTextNode (textSpan, "test", 0);
+    }
+
+    [Test]
+    public void Text_WithHtml ()
+    {
+      _webButton.Text = WebString.CreateFromHtml ("<b>test</b>");
+
+      var result = RenderControl (_webButton);
+
+      var button = _html.GetAssertedChildElement (result, "button", 0);
+      _html.AssertAttribute (button, "value", "<b>test</b>");
+      var buttonBody = _html.GetAssertedChildElement (button, "span", 0);
+      var textSpan = _html.GetAssertedChildElement (buttonBody, "span", 0);
+      var textB = _html.GetAssertedChildElement (textSpan, "b", 0);
+      _html.AssertTextNode (textB, "test", 0);
+    }
+
+    [Test]
+    public void Text_WithHtmlInPlaintext_Encoded ()
+    {
+      _webButton.Text = WebString.CreateFromText ("<b>test</b>");
+
+      var result = RenderControl (_webButton);
+
+      var button = _html.GetAssertedChildElement (result, "button", 0);
+      _html.AssertAttribute (button, "value", "<b>test</b>");
+      var buttonBody = _html.GetAssertedChildElement (button, "span", 0);
+      var textSpan = _html.GetAssertedChildElement (buttonBody, "span", 0);
+      _html.AssertTextNode (textSpan, "<b>test</b>", 0);
+    }
+
+    private XmlDocument RenderControl (Control control)
+    {
+      var page = new Page();
+      page.Controls.Add (control);
+
+      var ci = new ControlInvoker (page);
+      ci.InitRecursive();
+      ci.LoadRecursive();
+      ci.PreRenderRecursive();
+
+      control.RenderControl (_html.Writer);
+
+      return _html.GetResultDocument();
+    }
+  }
+}

--- a/Remotion/Web/UnitTests/Core/UI/Controls/WebButtonTests/WebButtonDiagnosticMetadataTest.cs
+++ b/Remotion/Web/UnitTests/Core/UI/Controls/WebButtonTests/WebButtonDiagnosticMetadataTest.cs
@@ -34,7 +34,7 @@ namespace Remotion.Web.UnitTests.Core.UI.Controls.WebButtonTests
     [Test]
     public void RenderDiagnosticMetadataAttributes ()
     {
-      var webButton = new TestWebButton { ID = "WebButton", Text = "My Button" };
+      var webButton = new TestWebButton { ID = "WebButton", Text = WebString.CreateFromText ("My Button") };
 
       var renderedText = RenderControl (webButton);
 
@@ -43,6 +43,16 @@ namespace Remotion.Web.UnitTests.Core.UI.Controls.WebButtonTests
       Assert.That (renderedText, Does.Contain (DiagnosticMetadataAttributes.Content + "=\"" + webButton.Text + "\""));
       Assert.That (renderedText, Does.Not.Contains (DiagnosticMetadataAttributes.CommandName));
       Assert.That (renderedText, Does.Contain (DiagnosticMetadataAttributes.TriggersPostBack + "=\"true\""));
+    }
+
+    [Test]
+    public void RenderDiagnosticMetadataAttributes_WithHtmlText_StripsTagsInContent ()
+    {
+      var webButton = new TestWebButton { ID = "WebButton", Text = WebString.CreateFromHtml ("<p>My Button</p>") };
+
+      var renderedText = RenderControl (webButton);
+
+      Assert.That (renderedText, Does.Contain (DiagnosticMetadataAttributes.Content + "=\"My Button\""));
     }
 
     [Test]

--- a/SecurityManager/Clients.Web/UI/AccessControl/EditPermissionsForm.aspx.cs
+++ b/SecurityManager/Clients.Web/UI/AccessControl/EditPermissionsForm.aspx.cs
@@ -29,6 +29,7 @@ using Remotion.SecurityManager.Domain.AccessControl;
 using Remotion.SecurityManager.Domain.Metadata;
 using Remotion.Web;
 using Remotion.Web.ExecutionEngine;
+using Remotion.Web.Globalization;
 using Remotion.Web.UI;
 
 namespace Remotion.SecurityManager.Clients.Web.UI.AccessControl
@@ -289,14 +290,12 @@ namespace Remotion.SecurityManager.Clients.Web.UI.AccessControl
       DuplicateStateCombinationsValidator.ErrorMessage = resourceManager.GetString (
           ResourceIdentifier.DuplicateStateCombinationsValidatorErrorMessage);
 
-      NewStatefulAccessControlListButton.Text = resourceManager.GetString (
-          ResourceIdentifier.NewStatefulAccessControlListButtonText);
+      NewStatefulAccessControlListButton.Text = resourceManager.GetText (ResourceIdentifier.NewStatefulAccessControlListButtonText);
 
-      NewStatelessAccessControlListButton.Text = resourceManager.GetString (
-          ResourceIdentifier.NewStatelessAccessControlListButtonText);
+      NewStatelessAccessControlListButton.Text = resourceManager.GetText (ResourceIdentifier.NewStatelessAccessControlListButtonText);
 
-      SaveButton.Text = GlobalResourcesHelper.GetString (GlobalResources.Save);
-      CancelButton.Text = GlobalResourcesHelper.GetString (GlobalResources.Cancel);
+      SaveButton.Text = GlobalResourcesHelper.GetText (GlobalResources.Save);
+      CancelButton.Text = GlobalResourcesHelper.GetText (GlobalResources.Cancel);
 
       base.OnPreRender (e);
 

--- a/SecurityManager/Clients.Web/UI/AccessControl/EditStatefulAccessControlListControl.ascx.cs
+++ b/SecurityManager/Clients.Web/UI/AccessControl/EditStatefulAccessControlListControl.ascx.cs
@@ -23,6 +23,7 @@ using Remotion.Globalization;
 using Remotion.ObjectBinding.Web.UI.Controls;
 using Remotion.SecurityManager.Clients.Web.Classes.AccessControl;
 using Remotion.SecurityManager.Domain.AccessControl;
+using Remotion.Web.Globalization;
 
 namespace Remotion.SecurityManager.Clients.Web.UI.AccessControl
 {
@@ -63,15 +64,15 @@ namespace Remotion.SecurityManager.Clients.Web.UI.AccessControl
     {
       { // Base
         var resourceManager = GetResourceManager (typeof (ResourceIdentifier));
-        DeleteAccessControlListButton.Text = resourceManager.GetString (ResourceIdentifier.DeleteAccessControlListButtonText);
-        NewAccessControlEntryButton.Text = resourceManager.GetString (ResourceIdentifier.NewAccessControlEntryButtonText);
+        DeleteAccessControlListButton.Text = resourceManager.GetText (ResourceIdentifier.DeleteAccessControlListButtonText);
+        NewAccessControlEntryButton.Text = resourceManager.GetText (ResourceIdentifier.NewAccessControlEntryButtonText);
       }
 
       {// This
         var resourceManager = GetResourceManager (typeof (StatefulAccessResourceIdentifier));
         MissingStateCombinationsValidator.ErrorMessage =
             resourceManager.GetString (StatefulAccessResourceIdentifier.MissingStateCombinationsValidatorErrorMessage);
-        NewStateCombinationButton.Text = resourceManager.GetString (StatefulAccessResourceIdentifier.NewStateCombinationButtonText);
+        NewStateCombinationButton.Text = resourceManager.GetText (StatefulAccessResourceIdentifier.NewStateCombinationButtonText);
       }
 
       base.OnPreRender (e);

--- a/SecurityManager/Clients.Web/UI/AccessControl/EditStatelessAccessControlListControl.ascx.cs
+++ b/SecurityManager/Clients.Web/UI/AccessControl/EditStatelessAccessControlListControl.ascx.cs
@@ -17,10 +17,10 @@
 // 
 using System;
 using System.Web.UI;
-using Remotion.Globalization;
 using Remotion.ObjectBinding.Web.UI.Controls;
 using Remotion.SecurityManager.Clients.Web.Classes.AccessControl;
 using Remotion.SecurityManager.Domain.AccessControl;
+using Remotion.Web.Globalization;
 
 namespace Remotion.SecurityManager.Clients.Web.UI.AccessControl
 {
@@ -29,8 +29,8 @@ namespace Remotion.SecurityManager.Clients.Web.UI.AccessControl
     protected override void OnPreRender (EventArgs e)
     {
       var resourceManager = GetResourceManager(typeof(ResourceIdentifier));
-      DeleteAccessControlListButton.Text = resourceManager.GetString(ResourceIdentifier.DeleteAccessControlListButtonText);
-      NewAccessControlEntryButton.Text = resourceManager.GetString(ResourceIdentifier.NewAccessControlEntryButtonText);
+      DeleteAccessControlListButton.Text = resourceManager.GetText(ResourceIdentifier.DeleteAccessControlListButtonText);
+      NewAccessControlEntryButton.Text = resourceManager.GetText(ResourceIdentifier.NewAccessControlEntryButtonText);
 
       base.OnPreRender (e);
     }

--- a/SecurityManager/Clients.Web/UI/GlobalResources.cs
+++ b/SecurityManager/Clients.Web/UI/GlobalResources.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using Remotion.Globalization;
 using Remotion.ServiceLocation;
+using Remotion.Web;
+using Remotion.Web.Globalization;
 
 namespace Remotion.SecurityManager.Clients.Web.UI
 {
@@ -16,6 +18,30 @@ namespace Remotion.SecurityManager.Clients.Web.UI
     {
       var resourceManager = service.GetResourceManager(typeof(GlobalResources));
       return resourceManager.GetString(value);
+    }
+
+    public static WebString GetText (GlobalResources value)
+    {
+      var globalizationService = SafeServiceLocator.Current.GetInstance<IGlobalizationService>();
+      return GetText (globalizationService, value);
+    }
+
+    public static WebString GetText (IGlobalizationService service, GlobalResources value)
+    {
+      var resourceManager = service.GetResourceManager (typeof (GlobalResources));
+      return resourceManager.GetText (value);
+    }
+
+    public static WebString GetHtml (GlobalResources value)
+    {
+      var globalizationService = SafeServiceLocator.Current.GetInstance<IGlobalizationService>();
+      return GetHtml (globalizationService, value);
+    }
+
+    public static WebString GetHtml (IGlobalizationService service, GlobalResources value)
+    {
+      var resourceManager = service.GetResourceManager (typeof (GlobalResources));
+      return resourceManager.GetHtml (value);
     }
   }
 

--- a/SecurityManager/Clients.Web/UI/OrganizationalStructure/EditGroupForm.aspx.cs
+++ b/SecurityManager/Clients.Web/UI/OrganizationalStructure/EditGroupForm.aspx.cs
@@ -19,6 +19,7 @@ using System;
 using Remotion.Globalization;
 using Remotion.SecurityManager.Clients.Web.Classes;
 using Remotion.SecurityManager.Domain.OrganizationalStructure;
+using Remotion.Web;
 using Remotion.Web.ExecutionEngine;
 using Remotion.Web.UI.Controls;
 
@@ -48,8 +49,8 @@ namespace Remotion.SecurityManager.Clients.Web.UI.OrganizationalStructure
     protected override void OnPreRender (EventArgs e)
     {
       Title = GlobalizationService.GetResourceManager (typeof (ResourceIdentifier)).GetString (ResourceIdentifier.Title);
-      SaveButton.Text = GlobalResourcesHelper.GetString (GlobalResources.Save);
-      CancelButton.Text = GlobalResourcesHelper.GetString (GlobalResources.Cancel);
+      SaveButton.Text = GlobalResourcesHelper.GetText (GlobalResources.Save);
+      CancelButton.Text = GlobalResourcesHelper.GetText (GlobalResources.Cancel);
 
       base.OnPreRender (e);
     }

--- a/SecurityManager/Clients.Web/UI/OrganizationalStructure/EditGroupTypeForm.aspx.cs
+++ b/SecurityManager/Clients.Web/UI/OrganizationalStructure/EditGroupTypeForm.aspx.cs
@@ -19,6 +19,7 @@ using System;
 using Remotion.Globalization;
 using Remotion.SecurityManager.Clients.Web.Classes;
 using Remotion.SecurityManager.Domain.OrganizationalStructure;
+using Remotion.Web;
 using Remotion.Web.ExecutionEngine;
 using Remotion.Web.UI.Controls;
 
@@ -49,8 +50,8 @@ namespace Remotion.SecurityManager.Clients.Web.UI.OrganizationalStructure
     {
       Title = GlobalizationService.GetResourceManager (typeof (ResourceIdentifier)).GetString (ResourceIdentifier.Title);
 
-      SaveButton.Text = GlobalResourcesHelper.GetString(GlobalResources.Save);
-      CancelButton.Text = GlobalResourcesHelper.GetString(GlobalResources.Cancel);
+      SaveButton.Text = GlobalResourcesHelper.GetText (GlobalResources.Save);
+      CancelButton.Text = GlobalResourcesHelper.GetText (GlobalResources.Cancel);
 
       base.OnPreRender (e);
     }

--- a/SecurityManager/Clients.Web/UI/OrganizationalStructure/EditPositionForm.aspx.cs
+++ b/SecurityManager/Clients.Web/UI/OrganizationalStructure/EditPositionForm.aspx.cs
@@ -19,6 +19,7 @@ using System;
 using Remotion.Globalization;
 using Remotion.SecurityManager.Clients.Web.Classes;
 using Remotion.SecurityManager.Domain.OrganizationalStructure;
+using Remotion.Web;
 using Remotion.Web.ExecutionEngine;
 using Remotion.Web.UI.Controls;
 
@@ -49,8 +50,8 @@ namespace Remotion.SecurityManager.Clients.Web.UI.OrganizationalStructure
     {
       Title = GlobalizationService.GetResourceManager (typeof (ResourceIdentifier)).GetString (ResourceIdentifier.Title);
 
-      SaveButton.Text = GlobalResourcesHelper.GetString(GlobalResources.Save);
-      CancelButton.Text = GlobalResourcesHelper.GetString(GlobalResources.Cancel);
+      SaveButton.Text = GlobalResourcesHelper.GetText (GlobalResources.Save);
+      CancelButton.Text = GlobalResourcesHelper.GetText (GlobalResources.Cancel);
 
       base.OnPreRender (e);
     }

--- a/SecurityManager/Clients.Web/UI/OrganizationalStructure/EditTenantForm.aspx.cs
+++ b/SecurityManager/Clients.Web/UI/OrganizationalStructure/EditTenantForm.aspx.cs
@@ -19,6 +19,7 @@ using System;
 using Remotion.Globalization;
 using Remotion.SecurityManager.Clients.Web.Classes;
 using Remotion.SecurityManager.Domain.OrganizationalStructure;
+using Remotion.Web;
 using Remotion.Web.ExecutionEngine;
 using Remotion.Web.UI.Controls;
 
@@ -49,8 +50,8 @@ namespace Remotion.SecurityManager.Clients.Web.UI.OrganizationalStructure
     {
       Title = GlobalizationService.GetResourceManager (typeof (ResourceIdentifier)).GetString (ResourceIdentifier.Title);
 
-      SaveButton.Text = GlobalResourcesHelper.GetString(GlobalResources.Save);
-      CancelButton.Text = GlobalResourcesHelper.GetString(GlobalResources.Cancel);
+      SaveButton.Text = GlobalResourcesHelper.GetText (GlobalResources.Save);
+      CancelButton.Text = GlobalResourcesHelper.GetText (GlobalResources.Cancel);
 
       base.OnPreRender (e);
     }

--- a/SecurityManager/Clients.Web/UI/OrganizationalStructure/EditUserForm.aspx.cs
+++ b/SecurityManager/Clients.Web/UI/OrganizationalStructure/EditUserForm.aspx.cs
@@ -19,6 +19,7 @@ using System;
 using Remotion.Globalization;
 using Remotion.SecurityManager.Clients.Web.Classes;
 using Remotion.SecurityManager.Domain.OrganizationalStructure;
+using Remotion.Web;
 using Remotion.Web.ExecutionEngine;
 using Remotion.Web.UI.Controls;
 
@@ -49,8 +50,8 @@ namespace Remotion.SecurityManager.Clients.Web.UI.OrganizationalStructure
     {
       Title = GlobalizationService.GetResourceManager (typeof (ResourceIdentifier)).GetString (ResourceIdentifier.Title);
 
-      SaveButton.Text = GlobalResourcesHelper.GetString(GlobalResources.Save);
-      CancelButton.Text = GlobalResourcesHelper.GetString(GlobalResources.Cancel);
+      SaveButton.Text = GlobalResourcesHelper.GetText (GlobalResources.Save);
+      CancelButton.Text = GlobalResourcesHelper.GetText (GlobalResources.Cancel);
 
       base.OnPreRender (e);
     }

--- a/SecurityManager/Clients.Web/UI/OrganizationalStructure/GroupListControl.ascx.cs
+++ b/SecurityManager/Clients.Web/UI/OrganizationalStructure/GroupListControl.ascx.cs
@@ -29,6 +29,7 @@ using Remotion.SecurityManager.Configuration;
 using Remotion.SecurityManager.Domain.OrganizationalStructure;
 using Remotion.Utilities;
 using Remotion.Web.ExecutionEngine;
+using Remotion.Web.Globalization;
 
 namespace Remotion.SecurityManager.Clients.Web.UI.OrganizationalStructure
 {
@@ -67,7 +68,7 @@ namespace Remotion.SecurityManager.Clients.Web.UI.OrganizationalStructure
     {
       var resourceManager = GetResourceManager (typeof (ResourceIdentifier));
       GroupListLabel.Text = resourceManager.GetString (ResourceIdentifier.GroupListLabelText);
-      NewGroupButton.Text = resourceManager.GetString (ResourceIdentifier.NewGroupButtonText);
+      NewGroupButton.Text = resourceManager.GetText (ResourceIdentifier.NewGroupButtonText);
 
       base.OnPreRender (e);
 

--- a/SecurityManager/Clients.Web/UI/OrganizationalStructure/GroupTypeListControl.ascx.cs
+++ b/SecurityManager/Clients.Web/UI/OrganizationalStructure/GroupTypeListControl.ascx.cs
@@ -28,6 +28,7 @@ using Remotion.SecurityManager.Clients.Web.WxeFunctions.OrganizationalStructure;
 using Remotion.SecurityManager.Domain.OrganizationalStructure;
 using Remotion.Utilities;
 using Remotion.Web.ExecutionEngine;
+using Remotion.Web.Globalization;
 
 namespace Remotion.SecurityManager.Clients.Web.UI.OrganizationalStructure
 {
@@ -65,7 +66,7 @@ namespace Remotion.SecurityManager.Clients.Web.UI.OrganizationalStructure
     {
       var resourceManager = GetResourceManager (typeof (ResourceIdentifier));
       GroupTypeListLabel.Text = resourceManager.GetString(ResourceIdentifier.GroupTypeListLabelText);
-      NewGroupTypeButton.Text = resourceManager.GetString(ResourceIdentifier.NewGroupTypeButtonText);
+      NewGroupTypeButton.Text = resourceManager.GetText (ResourceIdentifier.NewGroupTypeButtonText);
 
       base.OnPreRender (e);
 

--- a/SecurityManager/Clients.Web/UI/OrganizationalStructure/PositionListControl.ascx.cs
+++ b/SecurityManager/Clients.Web/UI/OrganizationalStructure/PositionListControl.ascx.cs
@@ -29,6 +29,7 @@ using Remotion.SecurityManager.Configuration;
 using Remotion.SecurityManager.Domain.OrganizationalStructure;
 using Remotion.Utilities;
 using Remotion.Web.ExecutionEngine;
+using Remotion.Web.Globalization;
 
 namespace Remotion.SecurityManager.Clients.Web.UI.OrganizationalStructure
 {
@@ -67,7 +68,7 @@ namespace Remotion.SecurityManager.Clients.Web.UI.OrganizationalStructure
     {
       var resourceManager = GetResourceManager (typeof (ResourceIdentifier));
       PositionListLabel.Text = resourceManager.GetString (ResourceIdentifier.PositionListLabelText);
-      NewPositionButton.Text = resourceManager.GetString (ResourceIdentifier.NewPositionButtonText);
+      NewPositionButton.Text = resourceManager.GetText (ResourceIdentifier.NewPositionButtonText);
 
       base.OnPreRender (e);
 

--- a/SecurityManager/Clients.Web/UI/OrganizationalStructure/TenantListControl.ascx.cs
+++ b/SecurityManager/Clients.Web/UI/OrganizationalStructure/TenantListControl.ascx.cs
@@ -29,6 +29,7 @@ using Remotion.SecurityManager.Configuration;
 using Remotion.SecurityManager.Domain.OrganizationalStructure;
 using Remotion.Utilities;
 using Remotion.Web.ExecutionEngine;
+using Remotion.Web.Globalization;
 
 namespace Remotion.SecurityManager.Clients.Web.UI.OrganizationalStructure
 {
@@ -67,7 +68,7 @@ namespace Remotion.SecurityManager.Clients.Web.UI.OrganizationalStructure
     {
       var resourceManager = GetResourceManager (typeof (ResourceIdentifier));
       TenantListLabel.Text = resourceManager.GetString (ResourceIdentifier.TenantListLabelText);
-      NewTenantButton.Text = resourceManager.GetString (ResourceIdentifier.NewTenantButtonText);
+      NewTenantButton.Text = resourceManager.GetText (ResourceIdentifier.NewTenantButtonText);
 
       base.OnPreRender (e);
 

--- a/SecurityManager/Clients.Web/UI/OrganizationalStructure/UserListControl.ascx.cs
+++ b/SecurityManager/Clients.Web/UI/OrganizationalStructure/UserListControl.ascx.cs
@@ -29,6 +29,7 @@ using Remotion.SecurityManager.Configuration;
 using Remotion.SecurityManager.Domain.OrganizationalStructure;
 using Remotion.Utilities;
 using Remotion.Web.ExecutionEngine;
+using Remotion.Web.Globalization;
 
 namespace Remotion.SecurityManager.Clients.Web.UI.OrganizationalStructure
 {
@@ -67,7 +68,7 @@ namespace Remotion.SecurityManager.Clients.Web.UI.OrganizationalStructure
     {
       var resourceManager = GetResourceManager (typeof (ResourceIdentifier));
       UserListLabel.Text = resourceManager.GetString (ResourceIdentifier.UserListLabelText);
-      NewUserButton.Text = resourceManager.GetString (ResourceIdentifier.NewUserButtonText);
+      NewUserButton.Text = resourceManager.GetText (ResourceIdentifier.NewUserButtonText);
 
       base.OnPreRender (e);
 


### PR DESCRIPTION
<details>
  <summary>Task List</summary>
  
- [x] WebButton.Text is defined on System.Web.Button. To change the datatype of the Text property, the property is redefined on WebButton.  
- [x] System.Web.Button.Text persists its value in the ViewState. For compatibility, this practice is continued and the raw value (WebString.GetValue()) is written into the same slot used by System.Web.Button.Text when setting WebButton.Text. In addition, the WebString.Type is also written into the ViewState. 
- [x] When getting WebButton.Text, the Remotion.WebString is reconstiuted from the two ViewState values. If Type is not available in the ViewState, WebStringType.PlainText is assumed. This makes setting the System.Web.Button.Text property safe.
- [x] Remove usage of HotkeyFormatter.FormatHotkey(...) and HotkeyParser.Parse(...) from WebButton and verify that property System.Web.Button.AccessKey works as a replacement (i.e. renders as the html attribute accesskey). Remove redunant code left over from hotkey parsing.
- [x] To correctly render the value attribute during AddAttributesToRender, System.Web.Button.Text must be temporarily set to the raw value  (WebString.GetValue()) before the base call then restored after the base call is completed. This way, System.Web.Button can add the value attribute, which is automatically encoded.
- [x] Rework behavior of WebButton.IsLegacyButtonEnabled, which results in rendering an html input element of type button. 
- [x] Instead of System.String.IsNullOrEmpty, Remotion.WebString.IsEmpty can be used.
- [x] Properties of type Remotion.WebString are declared as not-nullable.
- [x] When rendering DiagnosticMetadataAttributes.Content, the raw value (WebString.GetValue()) is used. Html tags are only stripped if the WebString.Type is set to Html. 
- [x] Update WebButtonDiagnosticMetadataTest with new cases (plaintext and encoded)
- [x] Update WebButtonControlObject to expose the AccessKey and add a web test.
- [x] When WebButton.Text is loaded via the help of ResourceManagerUtility.GetGlobalResourceKey(...) based on the resource-key-encoded property value, the WebStringType from the property is preserved. If the property does not use Remotion.WebString, WebStringType.Plaintext is assumed.
- [x] Button.Tooltip and Button.AccessKey are not changed since they are always rendered as encoded attributes by ASP.NET.
# Breaking Changes to document:
- [x] Changed of datatype for the Text property from String to WebString
- [x] Change of default encoding for System.Web.Button.Text from plain to encoded.
- Change of AccessKey support
  - [x] AccessKey must be set manually
  - [x] The access key must be highlighted manually in WebButton.Text, if required.
  - [x] & in WebButton.Text  is no longer used to indicate the access key and should be removed.
  
</details>