### PR TITLE
RM-8131 Change `FormGridLabel.Text` type from `string` to `WebString`

### DIFF
--- a/Remotion/Web/Core/UI/Controls/ValidationStateViewer.cs
+++ b/Remotion/Web/Core/UI/Controls/ValidationStateViewer.cs
@@ -223,7 +223,7 @@ public class ValidationStateViewer : WebControl, IControl
             if (control is SmartLabel)
               text = ((SmartLabel) control).GetText();
             else if (control is FormGridLabel)
-              text = ((FormGridLabel) control).Text;
+              text = ((FormGridLabel) control).Text.ToString (WebStringEncoding.HtmlWithTransformedLineBreaks);
             else if (control is Label)
               text = ((Label) control).Text;
             else if (control is LiteralControl)


### PR DESCRIPTION
<details>
  <summary>Task List</summary>

- [x] FormGridLabel.Text is defined on System.Web.Label. To change the datatype of the Text property, the property is redefined on FormGridLabel.  
- [x] System.Web.Label.Text persists its value in the ViewState. For compatibility, this practice is continued and the raw value (WebString.GetValue()) is written into the same slot used by System.Web.Label.Text when setting FormGridLabel.Text. In addition, the WebString.Type is also written into the ViewState. 
- [x] When getting FormGridLabel.Text, the Remotion.WebString is reconstiuted from the two ViewState values. If Type is not available in the ViewState, WebStringType.PlainText is assumed. This makes setting the System.Web.Label.Text property safe.
- [x] Render FormGridLabel.Text during RenderContents (see existing WebLinkButton for example). Alternatively, we could set and reset the Text value before just calling the base implementation of RenderContents but this seems less clean. Neither solution is perfect but this way we’re consistent.
- [x] Instead of System.String.IsNullOrEmpty, Remotion.WebString.IsEmpty can be used.
- [x] Properties of type Remotion.WebString are declared as not-nullable.
- [x] When FormGridLabel.Text is loaded via the help of ResourceManagerUtility.GetGlobalResourceKey(...) based on the resource-key-encoded property value, the WebStringType from the property is preserved.
# Breaking Changes to document:
- [x] Changed of datatype for the Text property from String to WebString
- [x] Change of default encoding for System.Web.Label.Text from plain to encoded.

</details>