### PR TITLE
RM-8231 NovaViso: BocAutoCompleteReferenceValue and BocReferenceValue is not clickable in the middle because of an invisible span

### DIFF
--- a/Remotion/ObjectBinding/Web.UnitTests/UI/Controls/BocReferenceValueImplementation/Rendering/BocAutoCompleteReferenceValueRendererTest.cs
+++ b/Remotion/ObjectBinding/Web.UnitTests/UI/Controls/BocReferenceValueImplementation/Rendering/BocAutoCompleteReferenceValueRendererTest.cs
@@ -365,7 +365,7 @@ namespace Remotion.ObjectBinding.Web.UnitTests.UI.Controls.BocReferenceValueImpl
       XmlNode span = GetAssertedContainerSpan (false);
       AssertControl (span, OptionMenuConfiguration.NoOptionsMenu, AutoPostBack.Disabled);
 
-      var input = span.GetAssertedChildElement ("span", 0).GetAssertedChildElement ("span", 0).GetAssertedChildElement ("input", 2);
+      var input = span.GetAssertedChildElement ("span", 0).GetAssertedChildElement ("span", 1).GetAssertedChildElement ("input", 2);
       input.AssertAttributeValueEquals ("id", c_keyValueName);
       input.AssertAttributeValueEquals ("name", c_keyValueName);
     }
@@ -436,7 +436,7 @@ namespace Remotion.ObjectBinding.Web.UnitTests.UI.Controls.BocReferenceValueImpl
       if (Control.Object.IsReadOnly && Control.Object.GetIcon() == null)
         return false;
 
-      var iconOffset = Control.Object.IsReadOnly ? 0 : 1;
+      var iconOffset = 0;
       var iconParent = parent.GetAssertedChildElement ("span", iconOffset);
 
       iconParent.AssertAttributeValueEquals ("class", "icon");
@@ -536,7 +536,7 @@ namespace Remotion.ObjectBinding.Web.UnitTests.UI.Controls.BocReferenceValueImpl
       var iconOffset = 1;
       var hasIconCssClass = hasIcon ? " hasIcon" : "";
 
-      var contentSpan = contentDiv.GetAssertedChildElement ("span", 0);
+      var contentSpan = contentDiv.GetAssertedChildElement ("span", iconOffset);
       contentSpan.AssertAttributeValueEquals ("id",  c_contentID);
       switch (optionMenuConfiguration)
       {

--- a/Remotion/ObjectBinding/Web.UnitTests/UI/Controls/BocReferenceValueImplementation/Rendering/BocReferenceValueRendererTest.cs
+++ b/Remotion/ObjectBinding/Web.UnitTests/UI/Controls/BocReferenceValueImplementation/Rendering/BocReferenceValueRendererTest.cs
@@ -369,7 +369,7 @@ namespace Remotion.ObjectBinding.Web.UnitTests.UI.Controls.BocReferenceValueImpl
           new StubValidationErrorRenderer());
       renderer.Render (CreateRenderingContext ());
       var document = Html.GetResultDocument ();
-      var span = document.GetAssertedChildElement ("span", 0).GetAssertedChildElement ("span", 0).GetAssertedChildElement ("span", 0);
+      var span = document.GetAssertedChildElement ("span", 0).GetAssertedChildElement ("span", 0).GetAssertedChildElement ("span", 1);
       var select = span.GetAssertedChildElement ("select", 0);
       select.AssertAttributeValueEquals ("id", c_valueName);
       select.AssertAttributeValueEquals ("name", c_valueName);
@@ -455,7 +455,7 @@ namespace Remotion.ObjectBinding.Web.UnitTests.UI.Controls.BocReferenceValueImpl
       var iconOffset = 1;
       var hasIconCssClass = hasIcon ? " hasIcon" : "";
 
-      var contentSpan = contentDiv.GetAssertedChildElement ("span", 0);
+      var contentSpan = contentDiv.GetAssertedChildElement ("span", iconOffset);
       contentSpan.AssertAttributeValueEquals ("id",  c_contentID);
       switch (optionMenuConfiguration)
       {
@@ -534,7 +534,7 @@ namespace Remotion.ObjectBinding.Web.UnitTests.UI.Controls.BocReferenceValueImpl
       if (Control.Object.IsReadOnly && Control.Object.GetIcon() == null)
         return false;
 
-      var iconOffset = Control.Object.IsReadOnly ? 0 : 1;
+      var iconOffset = 0;
       var iconParent = parent.GetAssertedChildElement ("span", iconOffset);
 
       iconParent.AssertAttributeValueEquals ("class", "icon");

--- a/Remotion/ObjectBinding/Web/UI/Controls/BocReferenceValueImplementation/Rendering/BocReferenceValueRendererBase.cs
+++ b/Remotion/ObjectBinding/Web/UI/Controls/BocReferenceValueImplementation/Rendering/BocReferenceValueRendererBase.cs
@@ -184,9 +184,10 @@ namespace Remotion.ObjectBinding.Web.UI.Controls.BocReferenceValueImplementation
       renderingContext.Writer.AddAttribute (HtmlTextWriterAttribute.Class, CssClassContent);
       renderingContext.Writer.RenderBeginTag (HtmlTextWriterTag.Span);
 
+      RenderIcon (renderingContext);
+
       if (renderingContext.Control.IsReadOnly)
       {
-        RenderIcon (renderingContext);
         RenderReadOnlyValue (renderingContext);
       }
       else
@@ -198,7 +199,6 @@ namespace Remotion.ObjectBinding.Web.UI.Controls.BocReferenceValueImplementation
         RenderEditModeValue (renderingContext);
 
         renderingContext.Writer.RenderEndTag();
-        RenderIcon (renderingContext);
       }
 
       bool hasOptionsMenu = renderingContext.Control.HasOptionsMenu;


### PR DESCRIPTION
https://re-motion.atlassian.net/browse/RM-8231