### PR TITLE
RM-7872: Assert that Thread.CurrentPrincipal.Identity property return …

### DIFF
--- a/Remotion/Security/Core/ThreadPrincipalProvider.cs
+++ b/Remotion/Security/Core/ThreadPrincipalProvider.cs
@@ -33,9 +33,9 @@ namespace Remotion.Security
 
     public ISecurityPrincipal GetPrincipal ()
     {
-      // TODO RM-7872: Add notnull assertions
-      IIdentity identity = Thread.CurrentPrincipal!.Identity!;
-      if (!identity.IsAuthenticated)
+      var identity = Thread.CurrentPrincipal?.Identity;
+
+      if (identity is null or { IsAuthenticated: false })
         return s_nullSecurityPrincipal;
 
       // TODO RM-7873: Add notnull assertion

--- a/Remotion/Security/UnitTests/ThreadPrincipalProviderTest.cs
+++ b/Remotion/Security/UnitTests/ThreadPrincipalProviderTest.cs
@@ -17,6 +17,7 @@
 using System;
 using System.Security.Principal;
 using System.Threading;
+using Moq;
 using NUnit.Framework;
 
 namespace Remotion.Security.UnitTests
@@ -48,6 +49,29 @@ namespace Remotion.Security.UnitTests
     {
       Thread.CurrentPrincipal = new GenericPrincipal(new GenericIdentity(string.Empty), new string[0]);
       Assert.That(Thread.CurrentPrincipal.Identity.IsAuthenticated, Is.False);
+      Assert.That(_principalProvider.GetPrincipal().IsNull, Is.True);
+    }
+
+    [Test]
+    public void GetPrincipal_WithCurrentPrincipalNull_ReturnsNullObject ()
+    {
+      Thread.CurrentPrincipal = null;
+#if NETFRAMEWORK
+      Assert.That(Thread.CurrentPrincipal, Is.Not.Null);
+#else
+      Assert.That(Thread.CurrentPrincipal, Is.Null);
+#endif
+      Assert.That(_principalProvider.GetPrincipal().IsNull, Is.True);
+    }
+
+    [Test]
+    public void GetPrincipal_WithCurrentPrincipalIdentityNull_ReturnsNullObject ()
+    {
+      var principalStub = new Mock<IPrincipal>();
+      Thread.CurrentPrincipal = principalStub.Object;
+
+      Assert.That(Thread.CurrentPrincipal, Is.Not.Null);
+      Assert.That(Thread.CurrentPrincipal.Identity, Is.Null);
       Assert.That(_principalProvider.GetPrincipal().IsNull, Is.True);
     }
 


### PR DESCRIPTION
…values are not null