### PR TITLE
feature/RM-8420-Refactor-SmartPage-ClientSide-DirtyState-Tracking

### DIFF
--- a/Remotion/Web/ClientScript/Scripts/SmartPage.ts
+++ b/Remotion/Web/ClientScript/Scripts/SmartPage.ts
@@ -69,7 +69,7 @@ class SmartPage_Context
 {
   private _theForm: HTMLFormElement;
 
-  private _isDirtyStateTrackingEnabled: boolean;
+  private _isAbortConfirmationRequiredIndependentOfDirtyState: boolean;
   private _dirtyStates: Set<string> = new Set<string>();
 
   // The message displayed when the user attempts to leave the page.
@@ -141,8 +141,7 @@ class SmartPage_Context
   private _mouseUpHandler = function (evt: MouseEvent) { SmartPage_Context.Instance!.OnMouseUp(evt); };
 
   // theFormID: The ID of the HTML Form on the page.
-  // isDirtyStateTrackingEnabled: true if the page should watch the form-fields for changes.
-  // isDirty: true if the page is dirty (client or server-side)
+  // isAbortConfirmationRequiredIndependentOfDirtyState: true if the page should always display the abort configuration regardless of the dirty state.
   // abortMessage: The message displayed when the user attempts to leave the page. null to disable the message.
   // statusIsSubmittingMessage: The message displayed when the user attempts to submit while a submit is already in 
   //    progress. null to disable the message.
@@ -153,13 +152,13 @@ class SmartPage_Context
   // eventHandlers: The hashtable of eventhandlers: Hashtable < event-key, Array < event-handler > >
   constructor (
       theFormID: string,
-      isDirtyStateTrackingEnabled: boolean,
+      isAbortConfirmationRequiredIndependentOfDirtyState: boolean,
       abortMessage: Nullable<string>, statusIsSubmittingMessage: Nullable<string>,
       smartScrollingFieldID: Nullable<string>, smartFocusFieldID: Nullable<string>,
       smartPageTokenFieldID: string, checkFormStateFunctionName: Nullable<string>)
   {
     ArgumentUtility.CheckNotNullAndTypeIsString('theFormID', theFormID);
-    ArgumentUtility.CheckNotNullAndTypeIsBoolean('isDirtyStateTrackingEnabled', isDirtyStateTrackingEnabled);
+    ArgumentUtility.CheckNotNullAndTypeIsBoolean('isAbortConfirmationRequiredIndependentOfDirtyState', isAbortConfirmationRequiredIndependentOfDirtyState);
     ArgumentUtility.CheckTypeIsString('abortMessage', abortMessage);
     ArgumentUtility.CheckTypeIsString('statusIsSubmittingMessage', statusIsSubmittingMessage);
     ArgumentUtility.CheckTypeIsString('smartScrollingFieldID', smartScrollingFieldID);
@@ -167,7 +166,7 @@ class SmartPage_Context
     ArgumentUtility.CheckNotNullAndTypeIsString('smartPageTokenFieldID', smartPageTokenFieldID);
     ArgumentUtility.CheckTypeIsString('checkFormStateFunctionName', checkFormStateFunctionName);
 
-    this._isDirtyStateTrackingEnabled = isDirtyStateTrackingEnabled;
+    this._isAbortConfirmationRequiredIndependentOfDirtyState = isAbortConfirmationRequiredIndependentOfDirtyState;
 
     this._abortMessage = abortMessage;
     this._isAbortConfirmationEnabled = abortMessage != null;
@@ -261,8 +260,7 @@ class SmartPage_Context
 
     this._dirtyStates = dirtyStates;
 
-    if (this._isDirtyStateTrackingEnabled)
-      this.AttachDataChangedEventHandlers();
+    this.AttachDataChangedEventHandlers();
 
     var pageRequestManager = this.GetPageRequestManager();
     if (pageRequestManager != null)
@@ -597,7 +595,7 @@ class SmartPage_Context
         var submitterElement = this.GetSubmitterOrActiveElement();
         var isJavaScriptAnchor = this.IsJavaScriptAnchor(submitterElement);
         var isAbortConfirmationRequired = !isJavaScriptAnchor
-          && (!this._isDirtyStateTrackingEnabled || this.IsDirty(undefined));
+          && (this._isAbortConfirmationRequiredIndependentOfDirtyState || this.IsDirty(undefined));
 
         if (isAbortConfirmationRequired)
         {
@@ -1306,7 +1304,7 @@ class SmartPage_Context
 
   public ShowAbortConfirmation(conditions: Optional<string[]>): boolean
   {
-    if (this._isAbortConfirmationEnabled && (!this._isDirtyStateTrackingEnabled || this.IsDirty(conditions)))
+    if (this._isAbortConfirmationEnabled && (this._isAbortConfirmationRequiredIndependentOfDirtyState || this.IsDirty(conditions)))
       return window.confirm(this._abortMessage!);
     else
       return true;

--- a/Remotion/Web/Core/UI/SmartPageImplementation/SmartPageInfo.cs
+++ b/Remotion/Web/Core/UI/SmartPageImplementation/SmartPageInfo.cs
@@ -346,7 +346,7 @@ namespace Remotion.Web.UI.SmartPageImplementation
           smartFocusFieldID = "'" + c_smartFocusID + "'";
       }
 
-      string isDirtyStateTrackingEnabled = "false";
+      string isAbortConfirmationRequiredIndependentOfDirtyState = "true";
 
       StringBuilder initScript = new StringBuilder(500);
       StringBuilder startupScript = new StringBuilder(500);
@@ -367,7 +367,7 @@ namespace Remotion.Web.UI.SmartPageImplementation
 
       if (_page.IsDirtyStateTrackingEnabled)
       {
-        isDirtyStateTrackingEnabled = "true";
+        isAbortConfirmationRequiredIndependentOfDirtyState = "false";
         bool isDirtyOnServerSide = false;
         foreach (var dirtyState in _page.GetDirtyStates())
         {
@@ -392,7 +392,7 @@ namespace Remotion.Web.UI.SmartPageImplementation
 
       initScript.AppendLine("    SmartPage_Context.Instance = new SmartPage_Context (");
       initScript.Append("        '").Append(htmlForm.ClientID).AppendLine("',");
-      initScript.Append("        ").Append(isDirtyStateTrackingEnabled).AppendLine(",");
+      initScript.Append("        ").Append(isAbortConfirmationRequiredIndependentOfDirtyState).AppendLine(",");
       initScript.Append("        ").Append(abortMessage).AppendLine(",");
       initScript.Append("        ").Append(statusIsSubmittingMessage).AppendLine(",");
       initScript.Append("        ").Append(smartScrollingFieldID).AppendLine(",");


### PR DESCRIPTION
https://re-motion.atlassian.net/browse/RM-8420

This change simply inverts the usage of the boolean flag and removes redundancies in the loop evaluation. There should be no observable change.