### PR TITLE
bugfix/RM-8427-BocAutoCompleteReferenceValue-Does-Not-Trigger-Clientside-DirtyState-Tracking-When-Value-Is-Selected-Via-DropDownButton-v3.0

### DIFF
--- a/Remotion/ObjectBinding/Web.UnitTests/UI/Controls/BocAutoCompleteReferenceValueTest.cs
+++ b/Remotion/ObjectBinding/Web.UnitTests/UI/Controls/BocAutoCompleteReferenceValueTest.cs
@@ -129,7 +129,7 @@ namespace Remotion.ObjectBinding.Web.UnitTests.UI.Controls
       string[] actual = _control.GetTrackedClientIDs();
       Assert.That(actual, Is.Not.Null);
       Assert.That(actual.Length, Is.EqualTo(1));
-      Assert.That(actual[0], Is.EqualTo(((IBocAutoCompleteReferenceValue)_control).GetTextValueName()));
+      Assert.That(actual[0], Is.EqualTo(((IBocAutoCompleteReferenceValue)_control).GetKeyValueName()));
     }
 
     [Test]

--- a/Remotion/ObjectBinding/Web/UI/Controls/BocAutoCompleteReferenceValue.cs
+++ b/Remotion/ObjectBinding/Web/UI/Controls/BocAutoCompleteReferenceValue.cs
@@ -479,7 +479,7 @@ namespace Remotion.ObjectBinding.Web.UI.Controls
     /// <seealso cref="BusinessObjectBoundEditableWebControl.GetTrackedClientIDs">BusinessObjectBoundEditableWebControl.GetTrackedClientIDs</seealso>
     public override string[] GetTrackedClientIDs ()
     {
-      return IsReadOnly ? new string[0] : new[] { GetTextValueName() };
+      return IsReadOnly ? new string[0] : new[] { GetKeyValueName() };
     }
 
     /// <summary> The <see cref="BocReferenceValue"/> supports only scalar properties. </summary>


### PR DESCRIPTION
https://re-motion.atlassian.net/browse/RM-8427