### PR TITLE
RM-8443: Add ExtractPlainText & integrate instead of StripHtmlTags

### DIFF
--- a/Remotion/ObjectBinding/Sample/ObjectBinding.Sample.csproj
+++ b/Remotion/ObjectBinding/Sample/ObjectBinding.Sample.csproj
@@ -12,6 +12,7 @@
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\Core\Core\Core.Core.csproj" />
+    <ProjectReference Include="..\..\Globalization\Core\Globalization.Core.csproj" />
     <ProjectReference Include="..\..\Mixins\Core\Mixins.Core.csproj" />
     <ProjectReference Include="..\..\Validation\Core\Validation.Core.csproj" />
     <ProjectReference Include="..\..\Web\Core\Web.Core.csproj" />

--- a/Remotion/ObjectBinding/Sample/Person.cs
+++ b/Remotion/ObjectBinding/Sample/Person.cs
@@ -21,6 +21,7 @@ using System.Collections.ObjectModel;
 using System.Linq;
 using System.Xml.Serialization;
 using Remotion.Collections;
+using Remotion.Globalization;
 using Remotion.Utilities;
 
 namespace Remotion.ObjectBinding.Sample
@@ -298,6 +299,7 @@ namespace Remotion.ObjectBinding.Sample
 
   public enum MarriageStatus
   {
+    [MultiLingualName("Vermählt", "")]
     Married,
     Single,
     Divorced,

--- a/Remotion/ObjectBinding/Web.Development.WebTesting.IntegrationTests/BocEnumValueControlObjectTest.cs
+++ b/Remotion/ObjectBinding/Web.Development.WebTesting.IntegrationTests/BocEnumValueControlObjectTest.cs
@@ -159,64 +159,64 @@ namespace Remotion.ObjectBinding.Web.Development.WebTesting.IntegrationTests
       var home = Start();
 
       var dropDownListBocEnumValue = home.EnumValues().GetByLocalID("MarriageStatusField_DropDownListNormal");
-      AssertSelectedOption(dropDownListBocEnumValue, "Married", -1, "Married");
+      AssertSelectedOption(dropDownListBocEnumValue, "Married", -1, "Vermählt");
 
       dropDownListBocEnumValue = home.EnumValues().GetByLocalID("MarriageStatusField_DropDownListReadOnly");
-      AssertSelectedOption(dropDownListBocEnumValue, "Married", -1, "Married");
+      AssertSelectedOption(dropDownListBocEnumValue, "Married", -1, "Vermählt");
 
       dropDownListBocEnumValue = home.EnumValues().GetByLocalID("MarriageStatusField_DropDownListReadOnlyWithoutSelectedValue");
       AssertSelectedOption(dropDownListBocEnumValue, "==null==", -1, "");
 
       dropDownListBocEnumValue = home.EnumValues().GetByLocalID("MarriageStatusField_DropDownListDisabled");
-      AssertSelectedOption(dropDownListBocEnumValue, "Married", -1, "Married");
+      AssertSelectedOption(dropDownListBocEnumValue, "Married", -1, "Vermählt");
 
       dropDownListBocEnumValue = home.EnumValues().GetByLocalID("MarriageStatusField_DropDownListNoAutoPostBack");
-      AssertSelectedOption(dropDownListBocEnumValue, "Married", -1, "Married");
+      AssertSelectedOption(dropDownListBocEnumValue, "Married", -1, "Vermählt");
 
       var listBoxBocEnumValue = home.EnumValues().GetByLocalID("MarriageStatusField_ListBoxNormal");
-      AssertSelectedOption(listBoxBocEnumValue, "Married", -1, "Married");
+      AssertSelectedOption(listBoxBocEnumValue, "Married", -1, "Vermählt");
 
       listBoxBocEnumValue = home.EnumValues().GetByLocalID("MarriageStatusField_ListBoxReadOnly");
-      AssertSelectedOption(listBoxBocEnumValue, "Married", -1, "Married");
+      AssertSelectedOption(listBoxBocEnumValue, "Married", -1, "Vermählt");
 
       listBoxBocEnumValue = home.EnumValues().GetByLocalID("MarriageStatusField_ListBoxReadOnlyWithoutSelectedValue");
       AssertSelectedOption(listBoxBocEnumValue, "==null==", -1, "");
 
       listBoxBocEnumValue = home.EnumValues().GetByLocalID("MarriageStatusField_ListBoxDisabled");
-      AssertSelectedOption(listBoxBocEnumValue, "Married", -1, "Married");
+      AssertSelectedOption(listBoxBocEnumValue, "Married", -1, "Vermählt");
 
       listBoxBocEnumValue = home.EnumValues().GetByLocalID("MarriageStatusField_ListBoxNoAutoPostBack");
-      AssertSelectedOption(listBoxBocEnumValue, "Married", -1, "Married");
+      AssertSelectedOption(listBoxBocEnumValue, "Married", -1, "Vermählt");
 
       var radioButtonListBocEnumValue = home.EnumValues().GetByLocalID("MarriageStatusField_RadioButtonListNormal");
-      AssertSelectedOption(radioButtonListBocEnumValue, "Married", -1, "Married");
+      AssertSelectedOption(radioButtonListBocEnumValue, "Married", -1, "Vermählt");
 
       radioButtonListBocEnumValue = home.EnumValues().GetByLocalID("MarriageStatusField_RadioButtonListReadOnly");
-      AssertSelectedOption(radioButtonListBocEnumValue, "Married", -1, "Married");
+      AssertSelectedOption(radioButtonListBocEnumValue, "Married", -1, "Vermählt");
 
       radioButtonListBocEnumValue = home.EnumValues().GetByLocalID("MarriageStatusField_RadioButtonListReadOnlyWithoutSelectedValue");
       AssertSelectedOption(radioButtonListBocEnumValue, "==null==", -1, "");
 
       radioButtonListBocEnumValue = home.EnumValues().GetByLocalID("MarriageStatusField_RadioButtonListDisabled");
-      AssertSelectedOption(radioButtonListBocEnumValue, "Married", -1, "Married");
+      AssertSelectedOption(radioButtonListBocEnumValue, "Married", -1, "Vermählt");
 
       radioButtonListBocEnumValue = home.EnumValues().GetByLocalID("MarriageStatusField_RadioButtonListNoAutoPostBack");
-      AssertSelectedOption(radioButtonListBocEnumValue, "Married", -1, "Married");
+      AssertSelectedOption(radioButtonListBocEnumValue, "Married", -1, "Vermählt");
 
       radioButtonListBocEnumValue = home.EnumValues().GetByLocalID("MarriageStatusField_RadioButtonListMultiColumn");
-      AssertSelectedOption(radioButtonListBocEnumValue, "Married", -1, "Married");
+      AssertSelectedOption(radioButtonListBocEnumValue, "Married", -1, "Vermählt");
 
       radioButtonListBocEnumValue = home.EnumValues().GetByLocalID("MarriageStatusField_RadioButtonListFlow");
-      AssertSelectedOption(radioButtonListBocEnumValue, "Married", -1, "Married");
+      AssertSelectedOption(radioButtonListBocEnumValue, "Married", -1, "Vermählt");
 
       radioButtonListBocEnumValue = home.EnumValues().GetByLocalID("MarriageStatusField_RadioButtonListOrderedList");
-      AssertSelectedOption(radioButtonListBocEnumValue, "Married", -1, "Married");
+      AssertSelectedOption(radioButtonListBocEnumValue, "Married", -1, "Vermählt");
 
       radioButtonListBocEnumValue = home.EnumValues().GetByLocalID("MarriageStatusField_RadioButtonListUnorderedList");
-      AssertSelectedOption(radioButtonListBocEnumValue, "Married", -1, "Married");
+      AssertSelectedOption(radioButtonListBocEnumValue, "Married", -1, "Vermählt");
 
       radioButtonListBocEnumValue = home.EnumValues().GetByLocalID("MarriageStatusField_RadioButtonListLabelLeft");
-      AssertSelectedOption(radioButtonListBocEnumValue, "Married", -1, "Married");
+      AssertSelectedOption(radioButtonListBocEnumValue, "Married", -1, "Vermählt");
 
       radioButtonListBocEnumValue = home.EnumValues().GetByLocalID("MarriageStatusField_RadioButtonListRequiredWithoutSelectedValue");
       AssertSelectedOption(radioButtonListBocEnumValue, "==null==", -1, "");
@@ -281,12 +281,15 @@ namespace Remotion.ObjectBinding.Web.Development.WebTesting.IntegrationTests
       Assert.That(options[0].Text, Is.EqualTo("Is_So_Undefined"));
       Assert.That(options[0].IsSelected, Is.False);
 
+      Assert.That(options[1].ItemID, Is.EqualTo("Married"));
+      Assert.That(options[1].Index, Is.EqualTo(2));
+      Assert.That(options[1].Text, Is.EqualTo("Vermählt"));
+      Assert.That(options[1].IsSelected, Is.True);
+
       Assert.That(options[3].ItemID, Is.EqualTo("Divorced"));
       Assert.That(options[3].Index, Is.EqualTo(4));
       Assert.That(options[3].Text, Is.EqualTo("Divorced"));
       Assert.That(options[3].IsSelected, Is.False);
-
-      Assert.That(options[1].IsSelected, Is.True);
     }
 
     [Test]
@@ -327,7 +330,7 @@ namespace Remotion.ObjectBinding.Web.Development.WebTesting.IntegrationTests
           Throws.InvalidOperationException.With.Message.EqualTo("A read-only control cannot contain a null option definition."));
 
       listBoxBocEnumValue = home.EnumValues().GetByLocalID("MarriageStatusField_ListBoxDisabled");
-      AssertSelectedOption(listBoxBocEnumValue, "Married", -1, "Married");
+      AssertSelectedOption(listBoxBocEnumValue, "Married", -1, "Vermählt");
 
       listBoxBocEnumValue = home.EnumValues().GetByLocalID("MarriageStatusField_ListBoxNoAutoPostBack");
       Assert.That(listBoxBocEnumValue.HasNullOptionDefinition(), Is.False);
@@ -573,6 +576,19 @@ namespace Remotion.ObjectBinding.Web.Development.WebTesting.IntegrationTests
       Assert.That(normalRadioButtonListBocEnumValueCompletionDetection.GetAndReset(), Is.TypeOf<WxePostBackCompletionDetectionStrategy>());
       Assert.That(home.Scope.FindIdEndingWith("RadioButtonListNormalCurrentValueLabel").Text, Is.EqualTo(divorced));
       Assert.That(home.Scope.FindIdEndingWith("RadioButtonListNoAutoPostBackCurrentValueLabel").Text, Is.EqualTo(single));
+    }
+
+    [Test]
+    public void TestSelectOptionWithUmlaut ()
+    {
+      var home = Start();
+
+      var dropDownListBocEnumValue = home.EnumValues().GetByLocalID("MarriageStatusField_DropDownListNormal");
+
+      // select other option first to trigger an auto-postback on value-changed
+      Assert.That(dropDownListBocEnumValue.SelectOption().WithDisplayText("Divorced"), Is.Not.Null);
+
+      Assert.That(dropDownListBocEnumValue.SelectOption().WithDisplayText("Vermählt"), Is.Not.Null);
     }
 
     private WxePageObject Start ()

--- a/Remotion/ObjectBinding/Web.Development.WebTesting.TestSite.Shared/Controls/BocListUserControl.ascx
+++ b/Remotion/ObjectBinding/Web.Development.WebTesting.TestSite.Shared/Controls/BocListUserControl.ascx
@@ -392,4 +392,25 @@
     </td>
     <td>&nbsp; (empty with variable columns)</td>
   </tr>
+  <tr>
+    <td></td>
+    <td>
+      <testsite:TestBocListWithRowMenuItems
+        ID="JobList_Empty_Umlauts"
+        ReadOnly="False"
+        DataSourceControl="EmptyObject"
+        PropertyIdentifier="Jobs"
+        Index="SortedOrder"
+        IndexColumnTitle="(html)Indexübersicht"
+
+        ShowAllProperties="True"
+        ShowEmptyListMessage="True"
+
+        Width="100%"
+        Height="10em"
+        runat="server">
+      </testsite:TestBocListWithRowMenuItems>
+    </td>
+    <td>&nbsp; (empty with umlauts)</td>
+  </tr>
 </table>

--- a/Remotion/ObjectBinding/Web.Development.WebTesting.TestSite.Shared/Controls/BocListUserControl.ascx.designer.cs
+++ b/Remotion/ObjectBinding/Web.Development.WebTesting.TestSite.Shared/Controls/BocListUserControl.ascx.designer.cs
@@ -155,5 +155,14 @@ namespace Remotion.ObjectBinding.Web.Development.WebTesting.TestSite.Shared.Cont
         /// To modify, move the field declaration from the designer file to a code-behind file.
         /// </remarks>
         protected global::Remotion.ObjectBinding.Web.Development.WebTesting.TestSite.Shared.Controls.TestBocListWithRowMenuItems JobList_Empty_VariableColumns;
+        
+        /// <summary>
+        /// JobList_Empty_Umlauts control.
+        /// </summary>
+        /// <remarks>
+        /// Auto-generated field.
+        /// To modify, move the field declaration from the designer file to a code-behind file.
+        /// </remarks>
+        protected global::Remotion.ObjectBinding.Web.Development.WebTesting.TestSite.Shared.Controls.TestBocListWithRowMenuItems JobList_Empty_Umlauts;
     }
 }

--- a/Remotion/ObjectBinding/Web/UI/Controls/BocEnumValueImplementation/Rendering/BocEnumValueRenderer.cs
+++ b/Remotion/ObjectBinding/Web/UI/Controls/BocEnumValueImplementation/Rendering/BocEnumValueRenderer.cs
@@ -196,7 +196,7 @@ namespace Remotion.ObjectBinding.Web.UI.Controls.BocEnumValueImplementation.Rend
         {
           nullItem.Attributes[DiagnosticMetadataAttributes.ItemID] = nullItem.Value;
           nullItem.Attributes[DiagnosticMetadataAttributes.IndexInCollection] = oneBasedIndex.ToString();
-          nullItem.Attributes[DiagnosticMetadataAttributes.Content] = HtmlUtility.StripHtmlTags(nullItemText);
+          nullItem.Attributes[DiagnosticMetadataAttributes.Content] = HtmlUtility.ExtractPlainText(PlainTextString.CreateFromText(nullItemText)).GetValue();
         }
 
         listControl.Items.Add(nullItem);
@@ -216,7 +216,7 @@ namespace Remotion.ObjectBinding.Web.UI.Controls.BocEnumValueImplementation.Rend
         {
           item.Attributes[DiagnosticMetadataAttributes.ItemID] = item.Value;
           item.Attributes[DiagnosticMetadataAttributes.IndexInCollection] = oneBasedIndex.ToString();
-          item.Attributes[DiagnosticMetadataAttributes.Content] = HtmlUtility.StripHtmlTags(item.Text);
+          item.Attributes[DiagnosticMetadataAttributes.Content] = HtmlUtility.ExtractPlainText(PlainTextString.CreateFromText(item.Text)).GetValue();
         }
 
         listControl.Items.Add(item);

--- a/Remotion/ObjectBinding/Web/UI/Controls/BocListImplementation/Rendering/BocColumnRendererBase.cs
+++ b/Remotion/ObjectBinding/Web/UI/Controls/BocListImplementation/Rendering/BocColumnRendererBase.cs
@@ -125,7 +125,7 @@ namespace Remotion.ObjectBinding.Web.UI.Controls.BocListImplementation.Rendering
           renderingContext.Writer.AddAttribute(DiagnosticMetadataAttributes.ItemID, columnItemID);
 
         var columnTitle = renderingContext.ColumnDefinition.ColumnTitleDisplayValue;
-        renderingContext.Writer.AddAttribute(DiagnosticMetadataAttributes.Content, HtmlUtility.StripHtmlTags(columnTitle));
+        HtmlUtility.ExtractPlainText(columnTitle).AddAttributeTo(renderingContext.Writer, DiagnosticMetadataAttributes.Content);
 
         var oneBasedCellIndex = renderingContext.VisibleColumnIndex + 1;
         renderingContext.Writer.AddAttribute(DiagnosticMetadataAttributesForObjectBinding.BocListCellIndex, oneBasedCellIndex.ToString());

--- a/Remotion/ObjectBinding/Web/UI/Controls/BocListImplementation/Rendering/BocIndexColumnRenderer.cs
+++ b/Remotion/ObjectBinding/Web/UI/Controls/BocListImplementation/Rendering/BocIndexColumnRenderer.cs
@@ -103,7 +103,7 @@ namespace Remotion.ObjectBinding.Web.UI.Controls.BocListImplementation.Rendering
       {
         var columnTitle = renderingContext.Control.IndexColumnTitle;
         if (!columnTitle.IsEmpty)
-          renderingContext.Writer.AddAttribute(DiagnosticMetadataAttributes.Content, HtmlUtility.StripHtmlTags(columnTitle));
+          HtmlUtility.ExtractPlainText(columnTitle).AddAttributeTo(renderingContext.Writer, DiagnosticMetadataAttributes.Content);
 
         AddDiagnosticMetadataListCellIndex(renderingContext);
       }

--- a/Remotion/Web/Core/UI/Controls/DropDownMenuImplementation/Rendering/DropDownMenuRenderer.cs
+++ b/Remotion/Web/Core/UI/Controls/DropDownMenuImplementation/Rendering/DropDownMenuRenderer.cs
@@ -16,6 +16,7 @@
 // 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Text;
 using System.Web.UI;
 using Remotion.Globalization;
@@ -258,7 +259,7 @@ namespace Remotion.Web.UI.Controls.DropDownMenuImplementation.Rendering
     {
       base.AddDiagnosticMetadataAttributes(renderingContext);
 
-      renderingContext.Writer.AddAttribute(DiagnosticMetadataAttributes.Content, HtmlUtility.StripHtmlTags(renderingContext.Control.TitleText));
+      HtmlUtility.ExtractPlainText(renderingContext.Control.TitleText).AddAttributeTo(renderingContext.Writer, DiagnosticMetadataAttributes.Content);
       renderingContext.Writer.AddAttribute(DiagnosticMetadataAttributes.IsDisabled, (!renderingContext.Control.Enabled).ToString().ToLower());
       renderingContext.Writer.AddAttribute(DiagnosticMetadataAttributes.ButtonType, renderingContext.Control.ButtonType.ToString());
     }
@@ -422,7 +423,7 @@ namespace Remotion.Web.UI.Controls.DropDownMenuImplementation.Rendering
         var diagnosticMetadataDictionary = new Dictionary<string, string?>();
         diagnosticMetadataDictionary.Add(HtmlTextWriterAttribute.Id.ToString(), htmlID);
         diagnosticMetadataDictionary.Add(DiagnosticMetadataAttributes.ItemID, menuItem.ItemID);
-        diagnosticMetadataDictionary.Add(DiagnosticMetadataAttributes.Content, HtmlUtility.StripHtmlTags(diagnosticMetadataText));
+        diagnosticMetadataDictionary.Add(DiagnosticMetadataAttributes.Content, HtmlUtility.ExtractPlainText(diagnosticMetadataText).GetValue());
 
         stringBuilder.WriteDictionaryAsJson(diagnosticMetadataDictionary);
 

--- a/Remotion/Web/Core/UI/Controls/ListMenuImplementation/Rendering/ListMenuRenderer.cs
+++ b/Remotion/Web/Core/UI/Controls/ListMenuImplementation/Rendering/ListMenuRenderer.cs
@@ -360,7 +360,7 @@ namespace Remotion.Web.UI.Controls.ListMenuImplementation.Rendering
           diagnosticMetadataDictionary.Add(DiagnosticMetadataAttributes.ItemID, menuItem.ItemID);
 
         if (!menuItem.Text.IsEmpty)
-          diagnosticMetadataDictionary.Add(DiagnosticMetadataAttributes.Content, HtmlUtility.StripHtmlTags(menuItem.Text));
+          diagnosticMetadataDictionary.Add(DiagnosticMetadataAttributes.Content, HtmlUtility.ExtractPlainText(menuItem.Text).GetValue());
 
         stringBuilder.WriteDictionaryAsJson(diagnosticMetadataDictionary);
 

--- a/Remotion/Web/Core/UI/Controls/WebButton.cs
+++ b/Remotion/Web/Core/UI/Controls/WebButton.cs
@@ -262,10 +262,8 @@ namespace Remotion.Web.UI.Controls
 
       if (!Text.IsEmpty)
       {
-        if (Text.Type == WebStringType.Encoded)
-          writer.AddAttribute(DiagnosticMetadataAttributes.Content, HtmlUtility.StripHtmlTags(Text));
-        else
-          s_noneHotkeyFormatter.GetFormattedText(Text).AddAttributeTo(writer, DiagnosticMetadataAttributes.Content);
+        var contentAttributeText = Text.Type == WebStringType.Encoded ? Text : s_noneHotkeyFormatter.GetFormattedText(Text);
+        HtmlUtility.ExtractPlainText(contentAttributeText).AddAttributeTo(writer, DiagnosticMetadataAttributes.Content);
       }
 
       if (!string.IsNullOrEmpty(CommandName))

--- a/Remotion/Web/Core/UI/Controls/WebTabStripImplementation/Rendering/WebTabRenderer.cs
+++ b/Remotion/Web/Core/UI/Controls/WebTabStripImplementation/Rendering/WebTabRenderer.cs
@@ -108,10 +108,8 @@ namespace Remotion.Web.UI.Controls.WebTabStripImplementation.Rendering
 
         if (!tab.Text.IsEmpty)
         {
-          if (tab.Text.Type == WebStringType.Encoded)
-            renderingContext.Writer.AddAttribute(DiagnosticMetadataAttributes.Content, HtmlUtility.StripHtmlTags(tab.Text));
-          else
-            s_noneHotkeyFormatter.GetFormattedText(tab.Text).AddAttributeTo(renderingContext.Writer, DiagnosticMetadataAttributes.Content);
+          var contentAttributeText = tab.Text.Type == WebStringType.Encoded ? tab.Text : s_noneHotkeyFormatter.GetFormattedText(tab.Text);
+          HtmlUtility.ExtractPlainText(contentAttributeText).AddAttributeTo(renderingContext.Writer, DiagnosticMetadataAttributes.Content);
         }
 
         renderingContext.Writer.AddAttribute(DiagnosticMetadataAttributes.IsDisabled, (isDisabled).ToString().ToLower());

--- a/Remotion/Web/Core/UI/Controls/WebTreeView.cs
+++ b/Remotion/Web/Core/UI/Controls/WebTreeView.cs
@@ -640,7 +640,7 @@ namespace Remotion.Web.UI.Controls
           if (!string.IsNullOrEmpty(node.ItemID))
             writer.AddAttribute(DiagnosticMetadataAttributes.ItemID, node.ItemID);
           if (!node.Text.IsEmpty)
-            writer.AddAttribute(DiagnosticMetadataAttributes.Content, HtmlUtility.StripHtmlTags(node.Text));
+            HtmlUtility.ExtractPlainText(node.Text).AddAttributeTo(writer, DiagnosticMetadataAttributes.Content);
           if (node.IsSelected)
             writer.AddAttribute(DiagnosticMetadataAttributes.WebTreeViewIsSelectedNode, "true");
           if (node.IsEvaluated)
@@ -651,9 +651,9 @@ namespace Remotion.Web.UI.Controls
           writer.AddAttribute(DiagnosticMetadataAttributes.IndexInCollection, (i + 1).ToString());
           if (node.Badge is { Value: { IsEmpty: false } })
           {
-            writer.AddAttribute(DiagnosticMetadataAttributes.WebTreeViewBadgeValue, HtmlUtility.StripHtmlTags(node.Badge.Value));
+            node.Badge.Value.AddAttributeTo(writer, DiagnosticMetadataAttributes.WebTreeViewBadgeValue);
             if (!node.Badge.Description.IsEmpty)
-              writer.AddAttribute(DiagnosticMetadataAttributes.WebTreeViewBadgeDescription, HtmlUtility.StripHtmlTags(node.Badge.Description));
+              node.Badge.Description.AddAttributeTo(writer, DiagnosticMetadataAttributes.WebTreeViewBadgeDescription);
           }
           if (!string.IsNullOrEmpty(node.Category))
             writer.AddAttribute(DiagnosticMetadataAttributes.WebTreeViewNodeCategory, node.Category);

--- a/Remotion/Web/Core/Utilities/HtmlUtility.cs
+++ b/Remotion/Web/Core/Utilities/HtmlUtility.cs
@@ -16,10 +16,10 @@
 // 
 using System;
 using System.Text.RegularExpressions;
+using System.Web;
 using System.Web.UI;
 using JetBrains.Annotations;
 using Remotion.Obsolete;
-using Remotion.Utilities;
 
 namespace Remotion.Web.Utilities
 {
@@ -52,18 +52,33 @@ namespace Remotion.Web.Utilities
 
     private static readonly Regex s_stripHtmlTagsRegex = new Regex("<.*?>", RegexOptions.Compiled);
 
+    [Obsolete("Use HtmlUtility.ExtractPlainText instead. (Version 3.0.0)", true)]
     public static string StripHtmlTags ([NotNull] string text)
     {
-      ArgumentUtility.CheckNotNull("text", text);
-
-      return s_stripHtmlTagsRegex.Replace(text, string.Empty);
+      throw new NotSupportedException("Use HtmlUtility.ExtractPlainText instead. (Version 3.0.0)");
     }
 
+    [Obsolete("Use HtmlUtility.ExtractPlainText instead. (Version 3.0.0)", true)]
     public static string StripHtmlTags (WebString text)
     {
-      return text.Type == WebStringType.Encoded
-          ? StripHtmlTags(text.GetValue())
-          : text.GetValue();
+      throw new NotSupportedException("Use HtmlUtility.ExtractPlainText instead. (Version 3.0.0)");
+    }
+
+    /// <summary>
+    /// Creates an approximation of <c>innerText</c> for an HTML element. Use this method when creating diagnostic metadata from a <see cref="WebString"/>.
+    /// </summary>
+    public static PlainTextString ExtractPlainText (WebString webString)
+    {
+      if (webString.Type == WebStringType.Encoded)
+      {
+        var valueWithoutHtmlTags = s_stripHtmlTagsRegex.Replace(webString.GetValue(), string.Empty);
+        var htmlDecodedValue = HttpUtility.HtmlDecode(valueWithoutHtmlTags);
+        return PlainTextString.CreateFromText(htmlDecodedValue);
+      }
+      else
+      {
+        return webString.ToPlainTextString();
+      }
     }
 
     private HtmlUtility ()

--- a/Remotion/Web/Core/Utilities/HtmlUtility.cs
+++ b/Remotion/Web/Core/Utilities/HtmlUtility.cs
@@ -50,6 +50,7 @@ namespace Remotion.Web.Utilities
       WebString.CreateFromText(nonHtmlString).WriteTo(writer);
     }
 
+    private static readonly Regex s_replaceLineBreaks = new Regex("<br\\s*/>", RegexOptions.Compiled);
     private static readonly Regex s_stripHtmlTagsRegex = new Regex("<.*?>", RegexOptions.Compiled);
 
     [Obsolete("Use HtmlUtility.ExtractPlainText instead. (Version 3.0.0)", true)]
@@ -71,7 +72,8 @@ namespace Remotion.Web.Utilities
     {
       if (webString.Type == WebStringType.Encoded)
       {
-        var valueWithoutHtmlTags = s_stripHtmlTagsRegex.Replace(webString.GetValue(), string.Empty);
+        var valueWithoutHtmlLineBreaks = s_replaceLineBreaks.Replace(webString.GetValue(), "\n");
+        var valueWithoutHtmlTags = s_stripHtmlTagsRegex.Replace(valueWithoutHtmlLineBreaks, string.Empty);
         var htmlDecodedValue = HttpUtility.HtmlDecode(valueWithoutHtmlTags);
         return PlainTextString.CreateFromText(htmlDecodedValue);
       }

--- a/Remotion/Web/Development.WebTesting.IntegrationTests/DropDownMenuControlObjectTest.cs
+++ b/Remotion/Web/Development.WebTesting.IntegrationTests/DropDownMenuControlObjectTest.cs
@@ -123,6 +123,14 @@ namespace Remotion.Web.Development.WebTesting.IntegrationTests
     }
 
     [Test]
+    public void TestUmlaut_GetByTextContent ()
+    {
+      var home = Start();
+
+      Assert.That(home.DropDownMenus().GetByTextContent("UmlautÖ"), Is.Not.Null);
+    }
+
+    [Test]
     public void TestGetItemDefinitions ()
     {
       var home = Start();

--- a/Remotion/Web/Development.WebTesting.IntegrationTests/ListMenuControlObjectTest.cs
+++ b/Remotion/Web/Development.WebTesting.IntegrationTests/ListMenuControlObjectTest.cs
@@ -110,7 +110,7 @@ namespace Remotion.Web.Development.WebTesting.IntegrationTests
       var listMenu = home.ListMenus().GetByLocalID("MyListMenu");
 
       var items = listMenu.GetItemDefinitions();
-      Assert.That(items.Count, Is.EqualTo(6));
+      Assert.That(items.Count, Is.EqualTo(9));
 
       Assert.That(items[0].ItemID, Is.EqualTo("ItemID1"));
       Assert.That(items[0].Index, Is.EqualTo(1));
@@ -123,6 +123,18 @@ namespace Remotion.Web.Development.WebTesting.IntegrationTests
       Assert.That(items[4].Index, Is.EqualTo(5));
       Assert.That(items[4].Text, Is.EqualTo(""));
       Assert.That(items[4].IsDisabled, Is.False);
+    }
+
+    [Test]
+    public void TestDisplayTextSelection_WithEncoded ()
+    {
+      var home = Start();
+
+      var listMenu = home.ListMenus().GetByLocalID("MyListMenu");
+
+      Assert.That(listMenu.SelectItem().WithDisplayText("Text-Umlaut ö"), Is.Not.Null);
+      Assert.That(listMenu.SelectItem().WithDisplayText("Html-Umlaut ö"), Is.Not.Null);
+      Assert.That(listMenu.SelectItem().WithDisplayText("Html-Encoded-Umlaut ö"), Is.Not.Null);
     }
 
     [Test]

--- a/Remotion/Web/Development.WebTesting.IntegrationTests/WebButtonControlObjectTest.cs
+++ b/Remotion/Web/Development.WebTesting.IntegrationTests/WebButtonControlObjectTest.cs
@@ -196,6 +196,14 @@ namespace Remotion.Web.Development.WebTesting.IntegrationTests
       Assert.That(webButton.GetText(), Is.EqualTo("LegacyButton"));
     }
 
+    [Test]
+    public void TestGetButtonWithUmlaut ()
+    {
+      var home = Start();
+
+      Assert.That(home.WebButtons().GetByTextContent("UmlautÖ"), Is.Not.Null);
+    }
+
     private WxePageObject Start ()
     {
       return Start<WxePageObject>("WebButtonTest.wxe");

--- a/Remotion/Web/Development.WebTesting.IntegrationTests/WebTabStripControlObjectTest.cs
+++ b/Remotion/Web/Development.WebTesting.IntegrationTests/WebTabStripControlObjectTest.cs
@@ -166,6 +166,16 @@ namespace Remotion.Web.Development.WebTesting.IntegrationTests
       Assert.That(home.Scope.FindId("TestOutputLabel").Text, Is.EqualTo("MyTabStrip2/Tab1"));
     }
 
+    [Test]
+    public void Test_TabWithUmlaut ()
+    {
+      var home = Start();
+
+      var tabStrip = home.WebTabStrips().GetByLocalID("MyTabStripWithUmlaut");
+
+      Assert.That(tabStrip.GetTabDefinitions().Single(t => t.Title == "UmlautÖ"), Is.Not.Null);
+    }
+
     private WxePageObject Start ()
     {
       return Start<WxePageObject>("WebTabStripTest.wxe");

--- a/Remotion/Web/Development.WebTesting.IntegrationTests/WebTreeViewControlObjectTest.cs
+++ b/Remotion/Web/Development.WebTesting.IntegrationTests/WebTreeViewControlObjectTest.cs
@@ -145,5 +145,15 @@ namespace Remotion.Web.Development.WebTesting.IntegrationTests
 
       Assert.That(treeViewNode.GetCategory(), Is.Empty);
     }
+
+    [Test]
+    public void TreeView_WithUmlaut ()
+    {
+      var home = Start();
+
+      var treeView = home.WebTreeViews().GetByLocalID("MyWebTreeViewWithUmlauts");
+
+      Assert.That(treeView.GetNode().WithDisplayText("UmlautÖ"), Is.Not.Null);
+    }
   }
 }

--- a/Remotion/Web/Development.WebTesting.TestSite/DropDownMenuTest.aspx
+++ b/Remotion/Web/Development.WebTesting.TestSite/DropDownMenuTest.aspx
@@ -265,6 +265,8 @@
       </remotion:DropDownMenu>
       <h3>DropDownMenu (many menu items)</h3>
       <remotion:DropDownMenu ID="MyDropDownMenu_ManyMenuItems" Mode="DropDownMenu" TitleText="Many menu items" runat="server" />
+      <h3>DropDownMenu (umlauts)</h3>
+      <remotion:DropDownMenu ID="MyDropDownMenu_Umlaut" TitleText="(html)UmlautÖ" runat="server" />
     </ContentTemplate>
   </asp:UpdatePanel>
 </asp:Content>

--- a/Remotion/Web/Development.WebTesting.TestSite/DropDownMenuTest.aspx.designer.cs
+++ b/Remotion/Web/Development.WebTesting.TestSite/DropDownMenuTest.aspx.designer.cs
@@ -213,6 +213,15 @@ namespace Remotion.Web.Development.WebTesting.TestSite
         protected global::Remotion.Web.UI.Controls.DropDownMenu MyDropDownMenu_ManyMenuItems;
 
         /// <summary>
+        /// MyDropDownMenu_Umlaut control.
+        /// </summary>
+        /// <remarks>
+        /// Auto-generated field.
+        /// To modify move field declaration from designer file to code-behind file.
+        /// </remarks>
+        protected global::Remotion.Web.UI.Controls.DropDownMenu MyDropDownMenu_Umlaut;
+
+        /// <summary>
         /// Master property.
         /// </summary>
         /// <remarks>

--- a/Remotion/Web/Development.WebTesting.TestSite/ListMenuTest.aspx.cs
+++ b/Remotion/Web/Development.WebTesting.TestSite/ListMenuTest.aspx.cs
@@ -28,6 +28,10 @@ namespace Remotion.Web.Development.WebTesting.TestSite
 
       MyListMenu.EventCommandClick += MyListMenuOnCommandClick;
       MyListMenu.WxeFunctionCommandClick += MyListMenuOnCommandClick;
+
+      MyListMenu.MenuItems.Add(new WebMenuItem { ItemID = "Encoded1", Text = WebString.CreateFromText("Text-Umlaut ö") });
+      MyListMenu.MenuItems.Add(new WebMenuItem { ItemID = "Encoded2", Text = WebString.CreateFromHtml("Html-Umlaut ö") });
+      MyListMenu.MenuItems.Add(new WebMenuItem { ItemID = "Encoded3", Text = WebString.CreateFromHtml("Html-Encoded-Umlaut &#246;") });
     }
 
     private void MyListMenuOnCommandClick (object sender, WebMenuItemClickEventArgs webMenuItemClickEventArgs)

--- a/Remotion/Web/Development.WebTesting.TestSite/WebButtonTest.aspx
+++ b/Remotion/Web/Development.WebTesting.TestSite/WebButtonTest.aspx
@@ -44,6 +44,8 @@
       <h3>WebButton with Access Keys</h3>
       <remotion:WebButton ID="MyWebButtonWithAccessKey" Text="Button with access key" AccessKey="A" CommandName="Sync" RequiresSynchronousPostBack="true" runat="server" />
       <remotion:WebButton ID="MyWebButtonWithImplicitAccessKey" Text="Button with implicit access &key" CommandName="Sync" RequiresSynchronousPostBack="true" runat="server" />
+      <h3>WebButton with Umlauts</h3>
+      <remotion:WebButton ID="MyWebButtonWithUmlauts" Text="(html)UmlautÖ" runat="server" />
     </ContentTemplate>
   </asp:UpdatePanel>
 </asp:Content>

--- a/Remotion/Web/Development.WebTesting.TestSite/WebButtonTest.aspx.designer.cs
+++ b/Remotion/Web/Development.WebTesting.TestSite/WebButtonTest.aspx.designer.cs
@@ -168,6 +168,15 @@ namespace Remotion.Web.Development.WebTesting.TestSite
         protected global::Remotion.Web.UI.Controls.WebButton MyWebButtonWithImplicitAccessKey;
 
         /// <summary>
+        /// MyWebButtonWithUmlauts control.
+        /// </summary>
+        /// <remarks>
+        /// Auto-generated field.
+        /// To modify move field declaration from designer file to code-behind file.
+        /// </remarks>
+        protected global::Remotion.Web.UI.Controls.WebButton MyWebButtonWithUmlauts;
+
+        /// <summary>
         /// Master property.
         /// </summary>
         /// <remarks>

--- a/Remotion/Web/Development.WebTesting.TestSite/WebTabStripTest.aspx
+++ b/Remotion/Web/Development.WebTesting.TestSite/WebTabStripTest.aspx
@@ -43,4 +43,10 @@
       <remotion:WebTab ItemID="TabDisabledWithAccessKey" Text="Tab disabled with access key" IsDisabled="True" AccessKey="D"/>
     </Tabs>
   </remotion:WebTabStrip>
+  <h3>WebTabStrip1</h3>
+  <remotion:WebTabStrip ID="MyTabStripWithUmlaut" style="width: 300px" runat="server">
+    <Tabs>
+      <remotion:WebTab ItemID="Tab1" Text="(html)UmlautÖ"/>
+    </Tabs>
+  </remotion:WebTabStrip>
 </asp:Content>

--- a/Remotion/Web/Development.WebTesting.TestSite/WebTabStripTest.aspx.designer.cs
+++ b/Remotion/Web/Development.WebTesting.TestSite/WebTabStripTest.aspx.designer.cs
@@ -42,6 +42,15 @@ namespace Remotion.Web.Development.WebTesting.TestSite
         protected global::Remotion.Web.UI.Controls.WebTabStrip MyTabStripWithAccessKeys;
 
         /// <summary>
+        /// MyTabStripWithUmlaut control.
+        /// </summary>
+        /// <remarks>
+        /// Auto-generated field.
+        /// To modify move field declaration from designer file to code-behind file.
+        /// </remarks>
+        protected global::Remotion.Web.UI.Controls.WebTabStrip MyTabStripWithUmlaut;
+
+        /// <summary>
         /// Master property.
         /// </summary>
         /// <remarks>

--- a/Remotion/Web/Development.WebTesting.TestSite/WebTreeViewTest.aspx
+++ b/Remotion/Web/Development.WebTesting.TestSite/WebTreeViewTest.aspx
@@ -32,4 +32,6 @@
   <remotion:WebTreeView ID="MyWebTreeViewWithCategories" runat="server"/>
   <h3>MyWebTreeViewWithoutCategories</h3>
   <remotion:WebTreeView ID="MyWebTreeViewWithoutCategories" runat="server"/>
+  <h3>MyWebTreeViewWithUmlauts</h3>
+  <remotion:WebTreeView ID="MyWebTreeViewWithUmlauts" runat="server"/>
 </asp:Content>

--- a/Remotion/Web/Development.WebTesting.TestSite/WebTreeViewTest.aspx.cs
+++ b/Remotion/Web/Development.WebTesting.TestSite/WebTreeViewTest.aspx.cs
@@ -58,6 +58,7 @@ namespace Remotion.Web.Development.WebTesting.TestSite
       MyUnorderedWebTreeView.Nodes.AddRange(treeViewNodes);
       MyWebTreeViewWithCategories.Nodes.Add(new WebTreeNode("Node1", WebString.CreateFromText("1")) { Category = "a category" });
       MyWebTreeViewWithoutCategories.Nodes.Add(new WebTreeNode("Node1", WebString.CreateFromText("1")));
+      MyWebTreeViewWithUmlauts.Nodes.Add(new WebTreeNode("Node1", WebString.CreateFromHtml("UmlautÖ")));
     }
   }
 }

--- a/Remotion/Web/Development.WebTesting.TestSite/WebTreeViewTest.aspx.designer.cs
+++ b/Remotion/Web/Development.WebTesting.TestSite/WebTreeViewTest.aspx.designer.cs
@@ -76,6 +76,15 @@ namespace Remotion.Web.Development.WebTesting.TestSite {
         protected global::Remotion.Web.UI.Controls.WebTreeView MyWebTreeViewWithoutCategories;
         
         /// <summary>
+        /// MyWebTreeViewWithUmlauts control.
+        /// </summary>
+        /// <remarks>
+        /// Auto-generated field.
+        /// To modify, move the field declaration from the designer file to a code-behind file.
+        /// </remarks>
+        protected global::Remotion.Web.UI.Controls.WebTreeView MyWebTreeViewWithUmlauts;
+        
+        /// <summary>
         /// Master property.
         /// </summary>
         /// <remarks>

--- a/Remotion/Web/UnitTests/Core/UI/Controls/WebTabStripImplementation/Rendering/WebTabStripRendererTest.cs
+++ b/Remotion/Web/UnitTests/Core/UI/Controls/WebTabStripImplementation/Rendering/WebTabStripRendererTest.cs
@@ -280,7 +280,7 @@ namespace Remotion.Web.UnitTests.Core.UI.Controls.WebTabStripImplementation.Rend
       var tab = wrapper.GetAssertedChildElement("span", 1);
       tab.AssertAttributeValueEquals(DiagnosticMetadataAttributes.ItemID, _tab4.Object.ItemID);
       if (_tab4.Object.Text.Type == WebStringType.Encoded)
-        tab.AssertAttributeValueEquals(DiagnosticMetadataAttributes.Content, HtmlUtility.StripHtmlTags(_tab4.Object.Text.GetValue()));
+        tab.AssertAttributeValueEquals(DiagnosticMetadataAttributes.Content, HtmlUtility.ExtractPlainText(_tab4.Object.Text));
       else
         tab.AssertAttributeValueEquals(DiagnosticMetadataAttributes.Content, _tab4.Object.Text.GetValue());
       tab.AssertAttributeValueEquals(DiagnosticMetadataAttributes.IsDisabled, (!_tab4.Object.EvaluateEnabled()).ToString().ToLower());

--- a/Remotion/Web/UnitTests/Core/Utilities/HtmlUtilityTest.cs
+++ b/Remotion/Web/UnitTests/Core/Utilities/HtmlUtilityTest.cs
@@ -82,8 +82,32 @@ namespace Remotion.Web.UnitTests.Core.Utilities
     public void ExtractPlainText_SelfClosingTagRemoval ()
     {
       Assert.That(
-          HtmlUtility.ExtractPlainText(WebString.CreateFromHtml("Simple<br/>Stri<img src=\"WithAttributes.html\"/>ng")),
+          HtmlUtility.ExtractPlainText(WebString.CreateFromHtml("Simple<div/>Stri<img src=\"WithAttributes.html\"/>ng")),
           Is.EqualTo(PlainTextString.CreateFromText("SimpleString")));
+    }
+
+    [Test]
+    public void ExtractPlainText_ReplacesLineBreaks ()
+    {
+      Assert.That(
+          HtmlUtility.ExtractPlainText(WebString.CreateFromHtml("Simple<br/>Stri<b>n</b>g")),
+          Is.EqualTo(PlainTextString.CreateFromText("Simple\nString")));
+    }
+
+    [Test]
+    public void ExtractPlainText_ReplacesLineBreaks2 ()
+    {
+      Assert.That(
+          HtmlUtility.ExtractPlainText(WebString.CreateFromHtml("Simple<br />Stri<b>n</b>g")),
+          Is.EqualTo(PlainTextString.CreateFromText("Simple\nString")));
+    }
+
+    [Test]
+    public void ExtractPlainText_ReplacesMultipleLineBreaks ()
+    {
+      Assert.That(
+          HtmlUtility.ExtractPlainText(WebString.CreateFromHtml("Simple<br/><br/>Stri<b>n</b>g")),
+          Is.EqualTo(PlainTextString.CreateFromText("Simple\n\nString")));
     }
 
     [Test]
@@ -95,7 +119,7 @@ namespace Remotion.Web.UnitTests.Core.Utilities
     }
 
     [Test]
-    public void ExtractPlainText_WithPlainTextWebString_DoesNotStripsHtmlTags ()
+    public void ExtractPlainText_WithPlainTextWebString_DoesNotStripHtmlTags ()
     {
       Assert.That(
           HtmlUtility.ExtractPlainText(WebString.CreateFromText("<span>SimpleS<i>tr<b>i</b>n</i></span>g")),

--- a/Remotion/Web/UnitTests/Core/Utilities/HtmlUtilityTest.cs
+++ b/Remotion/Web/UnitTests/Core/Utilities/HtmlUtilityTest.cs
@@ -55,43 +55,75 @@ namespace Remotion.Web.UnitTests.Core.Utilities
     }
 
     [Test]
-    public void StripHtmlTags ()
-    {
-      Assert.That(HtmlUtility.StripHtmlTags("SimpleString"), Is.EqualTo("SimpleString"));
-    }
-
-    [Test]
-    public void StripHtmlTags_Empty ()
-    {
-      Assert.That(HtmlUtility.StripHtmlTags(""), Is.EqualTo(""));
-    }
-
-    [Test]
-    public void StripHtmlTags_OpenedAndClosedTagRemoval ()
-    {
-      Assert.That(HtmlUtility.StripHtmlTags("<span>SimpleS<i>tr<b>i</b>n</i></span>g"), Is.EqualTo("SimpleString"));
-    }
-
-    [Test]
-    public void StripHtmlTags_SelfClosingTagRemoval ()
-    {
-      Assert.That(HtmlUtility.StripHtmlTags("Simple<br/>Stri<img src=\"WithAttributes.html\"/>ng"), Is.EqualTo("SimpleString"));
-    }
-
-    [Test]
-    public void StripHtmlTags_WithEncodedWebString_StripsHtmlTags ()
+    public void ExtractPlainText ()
     {
       Assert.That(
-          HtmlUtility.StripHtmlTags(WebString.CreateFromHtml("<span>SimpleS<i>tr<b>i</b>n</i></span>g")),
-          Is.EqualTo("SimpleString"));
+          HtmlUtility.ExtractPlainText(WebString.CreateFromText("SimpleString")),
+          Is.EqualTo(PlainTextString.CreateFromText("SimpleString")));
     }
 
     [Test]
-    public void StripHtmlTags_WithPlainTextWebString_DoesNotStripsHtmlTags ()
+    public void ExtractPlainText_Empty ()
     {
       Assert.That(
-          HtmlUtility.StripHtmlTags(WebString.CreateFromText("<span>SimpleS<i>tr<b>i</b>n</i></span>g")),
-          Is.EqualTo("<span>SimpleS<i>tr<b>i</b>n</i></span>g"));
+          HtmlUtility.ExtractPlainText(WebString.CreateFromText("")),
+          Is.EqualTo(PlainTextString.CreateFromText("")));
+    }
+
+    [Test]
+    public void ExtractPlainText_OpenedAndClosedTagRemoval ()
+    {
+      Assert.That(
+          HtmlUtility.ExtractPlainText(WebString.CreateFromHtml("<span>SimpleS<i>tr<b>i</b>n</i></span>g")),
+          Is.EqualTo(PlainTextString.CreateFromText("SimpleString")));
+    }
+
+    [Test]
+    public void ExtractPlainText_SelfClosingTagRemoval ()
+    {
+      Assert.That(
+          HtmlUtility.ExtractPlainText(WebString.CreateFromHtml("Simple<br/>Stri<img src=\"WithAttributes.html\"/>ng")),
+          Is.EqualTo(PlainTextString.CreateFromText("SimpleString")));
+    }
+
+    [Test]
+    public void ExtractPlainText_WithEncodedWebString_StripsHtmlTags ()
+    {
+      Assert.That(
+          HtmlUtility.ExtractPlainText(WebString.CreateFromHtml("<span>SimpleS<i>tr<b>i</b>n</i></span>g")),
+          Is.EqualTo(PlainTextString.CreateFromText("SimpleString")));
+    }
+
+    [Test]
+    public void ExtractPlainText_WithPlainTextWebString_DoesNotStripsHtmlTags ()
+    {
+      Assert.That(
+          HtmlUtility.ExtractPlainText(WebString.CreateFromText("<span>SimpleS<i>tr<b>i</b>n</i></span>g")),
+          Is.EqualTo(PlainTextString.CreateFromText("<span>SimpleS<i>tr<b>i</b>n</i></span>g")));
+    }
+
+    [Test]
+    public void ExtractPlainText_WithUmlautInPlainTextWebString ()
+    {
+      Assert.That(
+          HtmlUtility.ExtractPlainText(WebString.CreateFromText("Text-Umlaut ö")),
+          Is.EqualTo(PlainTextString.CreateFromText("Text-Umlaut ö")));
+    }
+
+    [Test]
+    public void ExtractPlainText_WithUmlautInEncodedWebString ()
+    {
+      Assert.That(
+          HtmlUtility.ExtractPlainText(WebString.CreateFromHtml("Html-Umlaut ö")),
+          Is.EqualTo(PlainTextString.CreateFromText("Html-Umlaut ö")));
+    }
+
+    [Test]
+    public void ExtractPlainText_WithEncodedUmlautInEncodedWebString ()
+    {
+      Assert.That(
+          HtmlUtility.ExtractPlainText(WebString.CreateFromHtml("Html-Encoded-Umlaut &#246;")),
+          Is.EqualTo(PlainTextString.CreateFromText("Html-Encoded-Umlaut ö")));
     }
   }
 }


### PR DESCRIPTION
- [x] Deleted StripHtmlTags tests should be adapted for ExtractPlainText
- [x] Search localization attribute and use it instead of the new "vermaehlt" enum value.
- [x] Check if `<br/>` should be replaced with a space character