### PR TITLE
RM-8435 - bugfix/RM-8435-Newlines-in-the-TitleTag-string-should-be-replaced-with-whitespaces

### DIFF
--- a/Remotion/Web/Core/UI/Controls/TitleTag.cs
+++ b/Remotion/Web/Core/UI/Controls/TitleTag.cs
@@ -46,7 +46,11 @@ namespace Remotion.Web.UI.Controls
       ArgumentUtility.CheckNotNull("writer", writer);
 
       writer.RenderBeginTag(HtmlTextWriterTag.Title);
-      _title.WriteTo(writer);
+
+      // title-tag does not support HTML-tags, including line breaks.
+      // By using a PlainTextString and manually encoding the  value, we can ensure that no linebreaks are rendered.
+      writer.WriteEncodedText(_title.GetValue());
+
       writer.RenderEndTag();
       writer.WriteLine();
     }

--- a/Remotion/Web/Core/UI/Controls/TitleTag.cs
+++ b/Remotion/Web/Core/UI/Controls/TitleTag.cs
@@ -15,8 +15,10 @@
 // along with re-motion; if not, see http://www.gnu.org/licenses.
 // 
 using System;
+using System.Diagnostics;
 using System.Web.UI;
 using Remotion.Utilities;
+using Remotion.Web.Utilities;
 
 namespace Remotion.Web.UI.Controls
 {
@@ -25,16 +27,16 @@ namespace Remotion.Web.UI.Controls
   /// </summary>
   public class TitleTag : HtmlHeadElement
   {
-    private readonly WebString _title;
+    private readonly PlainTextString _title;
 
-    public TitleTag (WebString title)
+    public TitleTag (PlainTextString title)
     {
       ArgumentUtility.CheckNotNull("title", title);
 
       _title = title;
     }
 
-    public WebString Title
+    public PlainTextString Title
     {
       get { return _title; }
     }

--- a/Remotion/Web/Core/UI/HtmlHeadAppender.cs
+++ b/Remotion/Web/Core/UI/HtmlHeadAppender.cs
@@ -142,8 +142,8 @@ namespace Remotion.Web.UI
     ///     Registers the title with a default priority of Page.
     ///   </para>
     /// </remarks>
-    /// <param name="title"> The <see cref="WebString"/> to be inserted as the title. </param>
-    public void SetTitle (WebString title)
+    /// <param name="title"> The <see cref="PlainTextString"/> to be inserted as the title. </param>
+    public void SetTitle (PlainTextString title)
     {
       _title = new TitleTag(title);
     }

--- a/Remotion/Web/Test.Shared/MultiplePostBackCatching/TestForm.aspx.cs
+++ b/Remotion/Web/Test.Shared/MultiplePostBackCatching/TestForm.aspx.cs
@@ -28,7 +28,7 @@ namespace Remotion.Web.Test.Shared.MultiplePostBackCatching
 
       var sutFormUrl = SafeServiceLocator.Current.GetInstance<IResourceUrlFactory>().CreateResourceUrl(typeof(SutForm), TestResourceType.Root, "MultiplePostbackCatching/SutForm.aspx").GetUrl();
       TestExpectationsGenerator.GenerateExpectations(this, TestTable.Rows, sutFormUrl);
-      HtmlHeadAppender.Current.SetTitle(WebString.CreateFromText(TestExpectationsGenerator.GetTestCaseUrlParameter(this) ?? "All Multiple Postback Catcher Tests"));
+      HtmlHeadAppender.Current.SetTitle(PlainTextString.CreateFromText(TestExpectationsGenerator.GetTestCaseUrlParameter(this) ?? "All Multiple Postback Catcher Tests"));
     }
   }
 }

--- a/Remotion/Web/Test.Shared/MultiplePostBackCatching/UpdatePanelTestForm.aspx.cs
+++ b/Remotion/Web/Test.Shared/MultiplePostBackCatching/UpdatePanelTestForm.aspx.cs
@@ -28,7 +28,7 @@ namespace Remotion.Web.Test.Shared.MultiplePostBackCatching
 
       var updatePanelSutFromUrl = SafeServiceLocator.Current.GetInstance<IResourceUrlFactory>().CreateResourceUrl(typeof(UpdatePanelSutForm), TestResourceType.Root, "MultiplePostbackCatching/UpdatePanelSutForm.aspx").GetUrl();
       TestExpectationsGenerator.GenerateExpectations(this, TestTable.Rows, updatePanelSutFromUrl);
-      HtmlHeadAppender.Current.SetTitle(WebString.CreateFromText(TestExpectationsGenerator.GetTestCaseUrlParameter(this) ?? "All Multiple Postback Catcher Tests"));
+      HtmlHeadAppender.Current.SetTitle(PlainTextString.CreateFromText(TestExpectationsGenerator.GetTestCaseUrlParameter(this) ?? "All Multiple Postback Catcher Tests"));
     }
   }
 }

--- a/Remotion/Web/UnitTests/Core/UI/Controls/HtmlHeadContentsImplementation/Rendering/HtmlHeadContentsRendererTest.cs
+++ b/Remotion/Web/UnitTests/Core/UI/Controls/HtmlHeadContentsImplementation/Rendering/HtmlHeadContentsRendererTest.cs
@@ -36,7 +36,7 @@ namespace Remotion.Web.UnitTests.Core.UI.Controls.HtmlHeadContentsImplementation
                              {
                                  new StubStyleSheetElement("stylesheet-1"),
                                  new JavaScriptInclude(new StaticResourceUrl("javscript-1")),
-                                 new TitleTag(WebString.CreateFromText("title")),
+                                 new TitleTag(PlainTextString.CreateFromText("title")),
                                  new StubHtmlHeadElement("head-1"),
                                  new StubStyleSheetElement("stylesheet-2"),
                                  new JavaScriptInclude(new StaticResourceUrl("javscript-2")),
@@ -72,8 +72,8 @@ head-2
     {
       var htmlHeadElements = new List<HtmlHeadElement>
                              {
-                                 new TitleTag(WebString.CreateFromText("title-1")),
-                                 new TitleTag(WebString.CreateFromText("title-2")),
+                                 new TitleTag(PlainTextString.CreateFromText("title-1")),
+                                 new TitleTag(PlainTextString.CreateFromText("title-2")),
                              };
       var renderer = new HtmlHeadContentsRenderer();
       var htmlHelper = new HtmlHelper();

--- a/Remotion/Web/UnitTests/Core/UI/Controls/TitleTagTest.cs
+++ b/Remotion/Web/UnitTests/Core/UI/Controls/TitleTagTest.cs
@@ -56,15 +56,14 @@ namespace Remotion.Web.UnitTests.Core.UI.Controls
     }
 
     [Test]
-    [Ignore("RM-8435")]
-    public void Render_ReplacesNewlines ()
+    public void Render_IgnoresNewlines ()
     {
       var titleTag = new TitleTag(PlainTextString.CreateFromText("My\nTitle"));
 
       titleTag.Render(_htmlHelper.Writer);
 
       var document = _htmlHelper.GetResultDocument();
-      document.FirstChild.AssertTextNode("My Title", 0);
+      document.FirstChild.AssertTextNode("My\nTitle", 0);
     }
   }
 }

--- a/Remotion/Web/UnitTests/Core/UI/Controls/TitleTagTest.cs
+++ b/Remotion/Web/UnitTests/Core/UI/Controls/TitleTagTest.cs
@@ -35,7 +35,7 @@ namespace Remotion.Web.UnitTests.Core.UI.Controls
     [Test]
     public void Render ()
     {
-      var titleTag = new TitleTag(WebString.CreateFromText("My Title"));
+      var titleTag = new TitleTag(PlainTextString.CreateFromText("My Title"));
 
       titleTag.Render(_htmlHelper.Writer);
 
@@ -47,7 +47,7 @@ namespace Remotion.Web.UnitTests.Core.UI.Controls
     [Test]
     public void Render_UsesHtmlEncoding ()
     {
-      var titleTag = new TitleTag(WebString.CreateFromText("My <Title>"));
+      var titleTag = new TitleTag(PlainTextString.CreateFromText("My <Title>"));
 
       titleTag.Render(_htmlHelper.Writer);
 
@@ -59,7 +59,7 @@ namespace Remotion.Web.UnitTests.Core.UI.Controls
     [Ignore("RM-8435")]
     public void Render_ReplacesNewlines ()
     {
-      var titleTag = new TitleTag(WebString.CreateFromText("My\nTitle"));
+      var titleTag = new TitleTag(PlainTextString.CreateFromText("My\nTitle"));
 
       titleTag.Render(_htmlHelper.Writer);
 

--- a/Remotion/Web/UnitTests/Core/UI/HtmlHeadAppenderTest.cs
+++ b/Remotion/Web/UnitTests/Core/UI/HtmlHeadAppenderTest.cs
@@ -39,7 +39,7 @@ namespace Remotion.Web.UnitTests.Core.UI
     [Test]
     public void SetTitle ()
     {
-      _htmlHeadAppender.SetTitle(WebString.CreateFromText("The Title"));
+      _htmlHeadAppender.SetTitle(PlainTextString.CreateFromText("The Title"));
 
       var htmlHeadElements = _htmlHeadAppender.GetHtmlHeadElements().ToArray();
 
@@ -47,21 +47,21 @@ namespace Remotion.Web.UnitTests.Core.UI
 
       Assert.That(htmlHeadElements[0], Is.InstanceOf(typeof(TitleTag)));
       var titleTag = (TitleTag)htmlHeadElements[0];
-      Assert.That(titleTag.Title, Is.EqualTo(WebString.CreateFromText("The Title")));
+      Assert.That(titleTag.Title, Is.EqualTo(PlainTextString.CreateFromText("The Title")));
     }
 
     [Test]
     public void SetTitle_Twice ()
     {
-      _htmlHeadAppender.SetTitle(WebString.CreateFromText("The Title1"));
-      _htmlHeadAppender.SetTitle(WebString.CreateFromText("The Title2"));
+      _htmlHeadAppender.SetTitle(PlainTextString.CreateFromText("The Title1"));
+      _htmlHeadAppender.SetTitle(PlainTextString.CreateFromText("The Title2"));
 
       var htmlHeadElements = _htmlHeadAppender.GetHtmlHeadElements().ToArray();
 
       Assert.That(htmlHeadElements.Length, Is.EqualTo(1));
 
       var titleTag = (TitleTag)htmlHeadElements[0];
-      Assert.That(titleTag.Title, Is.EqualTo(WebString.CreateFromText("The Title2")));
+      Assert.That(titleTag.Title, Is.EqualTo(PlainTextString.CreateFromText("The Title2")));
     }
 
     [Test]
@@ -256,7 +256,7 @@ namespace Remotion.Web.UnitTests.Core.UI
       var element1 = new Mock<HtmlHeadElement>();
       _htmlHeadAppender.RegisterHeadElement("element1", element1.Object, HtmlHeadAppender.Priority.Library);
 
-      _htmlHeadAppender.SetTitle(WebString.CreateFromText("The Title"));
+      _htmlHeadAppender.SetTitle(PlainTextString.CreateFromText("The Title"));
 
       var element2 = new Mock<HtmlHeadElement>();
       _htmlHeadAppender.RegisterHeadElement("element2", element2.Object, HtmlHeadAppender.Priority.Library);

--- a/SecurityManager/Clients.Web/UI/AccessControl/EditPermissionsForm.aspx.cs
+++ b/SecurityManager/Clients.Web/UI/AccessControl/EditPermissionsForm.aspx.cs
@@ -53,7 +53,7 @@ namespace Remotion.SecurityManager.Clients.Web.UI.AccessControl
 
     protected override void OnPreRenderComplete (EventArgs e)
     {
-      var title = WebString.CreateFromText(
+      var title = PlainTextString.CreateFromText(
           string.Format(
               GlobalizationService.GetResourceManager(typeof(ResourceIdentifier)).GetString(ResourceIdentifier.Title),
               CurrentSecurableClassDefinition.DisplayName));


### PR DESCRIPTION
https://re-motion.atlassian.net/browse/RM-8435