### PR TITLE
RM-8355 - bugfix/RM-8355-WebTreeView-Badges-Overlap-Focus-Shadow-in-NovaViso

### DIFF
--- a/Remotion/Web/Core/Res/Themes/NovaViso/HTML/TreeView.css
+++ b/Remotion/Web/Core/Res/Themes/NovaViso/HTML/TreeView.css
@@ -160,6 +160,15 @@ ul.treeViewRoot span.treeViewNode span.treeViewNodeBadge
   align-self: start;
 }
 
+ul.treeViewRoot li:focus > ul > li:first-of-type span.treeViewNode:not(:hover) span.treeViewNodeBadge,
+ul.treeViewRoot li:focus + li span.treeViewNode:not(:hover) span.treeViewNodeBadge
+{
+  /* Simulate continued box-shadow from previous element due to the badge-element hiding the shadow-effect. */
+  --rounding-value: 0.5px;
+  /* box-shadow based on --remotion-themed-box-shadow-focus */
+  box-shadow: inset 0 calc(1px + var(--treeview-node-padding-vertical) + var(--rounding-value)) 5px -5px rgba(0, 0, 0, 0.3);
+}
+
 ul.treeViewRoot li[aria-selected=true] > span.treeViewNode span.treeViewNodeBadge,
 ul.treeViewRoot li[aria-selected=true]:focus > span.treeViewNode span.treeViewNodeBadge
 {


### PR DESCRIPTION
https://re-motion.atlassian.net/browse/RM-8355