### PR TITLE
RM-8536 Remotion Web resources are no longer packaged by default in consuming projects

### DIFF
--- a/Build/NuSpec/Web.targets
+++ b/Build/NuSpec/Web.targets
@@ -29,11 +29,6 @@
   </PropertyGroup>
 
   <ItemGroup Condition="'$(RemotionWebResource_IsWebApplication)' == 'true' AND '$(_useSymlink)' == 'false'">
-    <_remotionWebResourcesToCopy Remove="@(_remotionWebResourcesToCopy)" />
-    <_remotionWebResourcesToCopy Include="$(MSBuildThisFileDirectory)..\res\**\*" />
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(RemotionWebResource_IsWebApplication)' == 'true' AND '$(_useSymlink)' == 'false'">
     <Content Include="$(MSBuildThisFileDirectory)..\res\**\*" CopyToOutputDirectory="PreserveNewest" Visible="true" Link="$(RemotionWebResource_TargetPath)\$(MSBuildThisFileName)\%(RecursiveDir)%(Filename)%(Extension)" Pack="false" />
   </ItemGroup>
 

--- a/Build/NuSpec/Web.targets
+++ b/Build/NuSpec/Web.targets
@@ -34,7 +34,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(RemotionWebResource_IsWebApplication)' == 'true' AND '$(_useSymlink)' == 'false'">
-    <Content Include="$(MSBuildThisFileDirectory)..\res\**\*" CopyToOutputDirectory="PreserveNewest" Visible="true" Link="$(RemotionWebResource_TargetPath)\$(MSBuildThisFileName)\%(RecursiveDir)%(Filename)%(Extension)" />
+    <Content Include="$(MSBuildThisFileDirectory)..\res\**\*" CopyToOutputDirectory="PreserveNewest" Visible="true" Link="$(RemotionWebResource_TargetPath)\$(MSBuildThisFileName)\%(RecursiveDir)%(Filename)%(Extension)" Pack="false" />
   </ItemGroup>
 
   <Target Name="RemotionWebResource_DeleteResFolder" Condition="'$(RemotionWebResource_IsWebApplication)' == 'true' AND '$(_useSymlink)' == 'true'">


### PR DESCRIPTION
https://re-motion.atlassian.net/browse/RM-8536

 - Added `Pack="true"`
 - Removed dead code