### PR TITLE
RM-8477 Browser Console Warning - Font preload in NovaViso

### DIFF
--- a/Remotion/Web/Core/UI/Controls/FontPreloadLink.cs
+++ b/Remotion/Web/Core/UI/Controls/FontPreloadLink.cs
@@ -51,6 +51,8 @@ namespace Remotion.Web.UI.Controls
       writer.WriteBeginTag(s_tagName);
       writer.WriteAttribute(s_hrefAttribute, _resourceUrl.GetUrl());
       writer.WriteAttribute(s_typeAttribute, _type);
+      // The crossorigin attribute with anonymous-mode is part of the spec for preloading fonts: https://developer.mozilla.org/en-US/docs/Web/HTML/Link_types/preload#cors-enabled_fetches
+      writer.WriteAttribute("crossorigin", "anonymous");
       writer.WriteAttribute(s_relAttribute, "preload");
       writer.WriteAttribute("as", "font");
       writer.Write('>');

--- a/Remotion/Web/UnitTests/Core/UI/Controls/FontPreloadLinkTest.cs
+++ b/Remotion/Web/UnitTests/Core/UI/Controls/FontPreloadLinkTest.cs
@@ -48,6 +48,7 @@ namespace Remotion.Web.UnitTests.Core.UI.Controls
       _htmlHelper.AssertAttribute(element, "as", "font");
       _htmlHelper.AssertAttribute(element, "type", "font-type");
       _htmlHelper.AssertAttribute(element, "href", "myfont.ttf");
+      _htmlHelper.AssertAttribute(element, "crossorigin", "anonymous");
     }
   }
 }


### PR DESCRIPTION
https://re-motion.atlassian.net/browse/RM-8477
Fixed in chrome and edge, bug report in bugzilla for firefox: https://bugzilla.mozilla.org/show_bug.cgi?id=1786483

Already created follow up ticket for firefox, maybe consider taking a look at it, probably needs more information but I'm not quite sure what: https://re-motion.atlassian.net/browse/RM-8573