### PR TITLE
RM-8590 Rewrite CommandInfo.IsTriggeringNavigation

### DIFF
--- a/Remotion/Web/Core/UI/Controls/CommandInfo.cs
+++ b/Remotion/Web/Core/UI/Controls/CommandInfo.cs
@@ -157,12 +157,26 @@ namespace Remotion.Web.UI.Controls
 
     private bool IsTriggeringNavigation ()
     {
-      return _href != "#";
+      if (_href == null)
+        return false;
+      else if (_href.StartsWith("#"))
+        return false;
+      else if (_onClick == null)
+        return true;
+      else if (_onClick.Contains("__doPostBack"))
+        return false;
+      else
+        return true;
     }
 
     private bool IsTriggeringPostBack ()
     {
-      return !IsTriggeringNavigation() && _onClick!.Contains("__doPostBack"); // TODO RM-8104: Guard _onClick
+      if (_onClick == null)
+        return false;
+      else if (_onClick.Contains("__doPostBack"))
+        return true;
+      else
+        return false;
     }
   }
 }

--- a/Remotion/Web/UnitTests/Core/UI/Controls/CommandInfoTest.cs
+++ b/Remotion/Web/UnitTests/Core/UI/Controls/CommandInfoTest.cs
@@ -330,6 +330,25 @@ namespace Remotion.Web.UnitTests.Core.UI.Controls
     }
 
     [Test]
+    public void AddDiagnosticMetadataAttributes_FromCreateForLink_WithDoPostBackAndUrl ()
+    {
+      var commandInfo = CommandInfo.CreateForLink("TheTitle", null, "TheUrl", "TheTarget", "FrontGarbage__doPostBackBackGarbage");
+
+      var stringWriter = new StringWriter();
+      var htmlTextWriter = new HtmlTextWriter(stringWriter);
+      commandInfo.AddAttributesToRender(htmlTextWriter, RenderingFeatures.WithDiagnosticMetadata);
+
+      htmlTextWriter.RenderBeginTag(HtmlTextWriterTag.A);
+      htmlTextWriter.RenderEndTag();
+
+      var result = stringWriter.ToString();
+
+      Assert.That(result, Does.Contain(DiagnosticMetadataAttributes.ControlType + "=\"Command\""));
+      Assert.That(result, Does.Contain(DiagnosticMetadataAttributes.TriggersPostBack + "=\"true\""));
+      Assert.That(result, Does.Contain(DiagnosticMetadataAttributes.TriggersNavigation + "=\"false\""));
+    }
+
+    [Test]
     public void AddDiagnosticMetadataAttributes_FromCreateForLink_WithPureJavaScript ()
     {
       var commandInfo = CommandInfo.CreateForLink("TheTitle", null, "#", "TheTarget", "javascript:Foo();");


### PR DESCRIPTION
[Rewrite CommandInfo.IsTriggeringNavigation](https://re-motion.atlassian.net/browse/RM-8590)

Mike said that there would be some kind of hidden special case we missed in an earlier implementation. Please take a look at the unit tests for this and make sure we didnt do stupid things: 

https://github.com/re-motion/Framework/blob/develop/Remotion/Web/UnitTests/Core/UI/Controls/CommandInfoTest.cs