### PR TITLE
RM-8419 TreeNode only clickable on the text

### DIFF
--- a/Remotion/Web/ClientScript/Scripts/TreeView.ts
+++ b/Remotion/Web/ClientScript/Scripts/TreeView.ts
@@ -27,6 +27,40 @@ class WebTreeView
       WebTreeView.OnKeyDown (event, treeView);
     });
 
+    // The following code is responsible for making the whole tree view node clickable
+    // Nodes in NovaGray are not full-width so we do this handling only in NovaViso
+    if (!StyleUtility.IsNovaGray)
+    {
+      const nodes = [...treeView.querySelectorAll ('.treeViewNode')];
+      for (const node of nodes)
+      {
+        const linkElement = node.querySelector (':scope > .treeViewNodeHead > a[onclick], :scope > .treeViewNodeHeadSelected > a[onclick]') as Nullable<HTMLElement>;
+        if (linkElement)
+        {
+          node.addEventListener ('click', ev =>
+          {
+            // Prevent recursion through bubbling
+            if (!ev.isTrusted)
+              return;
+
+            linkElement.dispatchEvent (new MouseEvent (ev.type, ev));
+            ev.preventDefault();
+            ev.stopPropagation();
+          });
+          node.addEventListener('contextmenu', ev =>
+          {
+            // Prevent recursion through bubbling
+            if (!ev.isTrusted)
+              return;
+
+            linkElement.dispatchEvent (new PointerEvent (ev.type, ev));
+            ev.preventDefault();
+            ev.stopPropagation();
+          });
+        }
+      }
+    }
+
     var focusableTreeNode = treeView.querySelector ('li[tabindex="0"][role=treeitem]');
     if (focusableTreeNode === null)
     {

--- a/Remotion/Web/ClientScript/Scripts/typings/common.d.ts
+++ b/Remotion/Web/ClientScript/Scripts/typings/common.d.ts
@@ -42,6 +42,12 @@ type PartialWithRequiredProperties<T, K extends keyof T> = Omit<T, Exclude<keyof
 
 type OutBox<T> = { Value: Nullable<T> };
 
+// StyleUtility
+declare var StyleUtility:
+{
+  IsNovaGray?: boolean;
+};
+
 // Enhance the ASP.NET typings
 declare namespace Sys.WebForms
 { 

--- a/Remotion/Web/Core/Res/Themes/NovaGray/HTML/StyleUtility.js
+++ b/Remotion/Web/Core/Res/Themes/NovaGray/HTML/StyleUtility.js
@@ -18,6 +18,8 @@ function StyleUtility()
 {
 }
 
+StyleUtility.IsNovaGray = true;
+
 StyleUtility.CreateBorderSpans = function (selector)
 {
 };

--- a/Remotion/Web/Core/Res/Themes/NovaViso/HTML/TreeView.css
+++ b/Remotion/Web/Core/Res/Themes/NovaViso/HTML/TreeView.css
@@ -101,6 +101,12 @@ ul.treeViewRoot li[aria-selected=true]:focus > span.treeViewNode:hover
   box-shadow: var(--remotion-themed-box-shadow-focus-hover);
 }
 
+ul.treeViewRoot span.treeViewNodeHead,
+ul.treeViewRoot span.treeViewNodeHeadSelected
+{
+  flex-grow: 1;
+}
+
 ul.treeViewRoot span.treeViewNode,
 ul.treeViewRoot span.treeViewNodeHead > a,
 ul.treeViewRoot span.treeViewNodeHeadSelected > a

--- a/Remotion/Web/Core/UI/Controls/WebTreeView.cs
+++ b/Remotion/Web/Core/UI/Controls/WebTreeView.cs
@@ -366,6 +366,8 @@ namespace Remotion.Web.UI.Controls
         _isLoadControlStateCompleted = true;
 
       RegisterHtmlHeadContents(HtmlHeadAppender.Current, Context);
+
+      ScriptUtility.Instance.RegisterJavaScriptInclude(this, HtmlHeadAppender.Current);
     }
 
 


### PR DESCRIPTION
https://re-motion.atlassian.net/browse/RM-8419

Notes:
 - Left and right click are now re-dispatched to the correct element
 - `flex-grow: 1` is still necessary since the dropdownmenu restricts the position according to the element