### PR TITLE
bugfix/RM-8595-BocBooleanValue-displays-the-null-value-text-when-rendered-as-readonly

### DIFF
--- a/Remotion/ObjectBinding/Web.Test/IndividualControlTests/BocBooleanValueUserControl.ascx
+++ b/Remotion/ObjectBinding/Web.Test/IndividualControlTests/BocBooleanValueUserControl.ascx
@@ -22,7 +22,7 @@
     <td colSpan=4><remotion:boctextvalue id=FirstNameField runat="server" PropertyIdentifier="FirstName" ReadOnly="True" datasourcecontrol="CurrentObject"></remotion:boctextvalue>&nbsp;<remotion:boctextvalue id=LastNameField runat="server" PropertyIdentifier="LastName" ReadOnly="True" datasourcecontrol="CurrentObject"></remotion:boctextvalue></td></tr>
   <tr>
     <td></td>
-    <td><remotion:bocbooleanvalue id="DeceasedField" runat="server" datasourcecontrol="CurrentObject" propertyidentifier="Deceased" FalseDescription="nope" NullDescription="häh?" TrueDescription="sicha" AutoPostBack="true" ></remotion:bocbooleanvalue></td>
+    <td><remotion:bocbooleanvalue id="DeceasedField" runat="server" datasourcecontrol="CurrentObject" propertyidentifier="Deceased" FalseDescription="nay" NullDescription="mu" TrueDescription="aye" AutoPostBack="true" ></remotion:bocbooleanvalue></td>
     <td>bound, AutoPostBack</td>
     <td style="WIDTH: 20%"><asp:label id="DeceasedFieldValueLabel" runat="server" enableviewstate="False">#</asp:label></td>
   </tr>

--- a/Remotion/ObjectBinding/Web.UnitTests/UI/Controls/BocBooleanValueImplementation/Rendering/BocBooleanValueRendererTest.cs
+++ b/Remotion/ObjectBinding/Web.UnitTests/UI/Controls/BocBooleanValueImplementation/Rendering/BocBooleanValueRendererTest.cs
@@ -409,7 +409,9 @@ namespace Remotion.ObjectBinding.Web.UnitTests.UI.Controls.BocBooleanValueImplem
       Html.AssertAttribute(label, "id", c_clientID + "_Description");
       Html.AssertAttribute(label, "class", "description");
       Html.AssertTextNode(label, description.ToString(WebStringEncoding.HtmlWithTransformedLineBreaks), 0);
-      if (_booleanValue.Object.ShowDescription || _booleanValue.Object.IsReadOnly)
+      var isDescriptionVisible = (_booleanValue.Object.IsReadOnly && _booleanValue.Object.Value.HasValue)
+                                 || (!_booleanValue.Object.IsReadOnly && _booleanValue.Object.ShowDescription);
+      if (isDescriptionVisible)
       {
         Html.AssertNoAttribute(label, "hidden");
         Html.AssertAttribute(label, "aria-hidden", "true");

--- a/Remotion/ObjectBinding/Web/Res/Themes/NovaGray/Html/BocBooleanValue.css
+++ b/Remotion/ObjectBinding/Web/Res/Themes/NovaGray/Html/BocBooleanValue.css
@@ -21,6 +21,14 @@
   margin-left: 4px;
 }
 
+.bocBooleanValue.readOnly span.description[hidden]
+{
+  display: inline-block;
+  width: 0;
+  overflow: hidden;
+  padding-left: 1em;
+}
+
 .bocBooleanValue.readOnly span[role=checkbox]:focus ~ span.description
 {
   outline: dotted black 1px;

--- a/Remotion/ObjectBinding/Web/Res/Themes/NovaViso/HTML/BocBooleanValue.css
+++ b/Remotion/ObjectBinding/Web/Res/Themes/NovaViso/HTML/BocBooleanValue.css
@@ -28,16 +28,28 @@
   cursor: default;
 }
 
-.bocBooleanValue span.description:not([hidden])
+.bocBooleanValue span.description
 {
-  display: inline-flex;
   align-items: center;
   margin-right: var(--remotion-themed-spacing);
 }
 
-.bocBooleanValue.readOnly span.description:not([hidden])
+.bocBooleanValue span.description:not([hidden])
+{
+  display: inline-flex;
+}
+
+.bocBooleanValue.readOnly span.description
 {
   margin-left: var(--remotion-themed-spacing);
+}
+
+.bocBooleanValue.readOnly span.description[hidden]
+{
+  display: inline;
+  overflow: hidden;
+  width: 0;
+  padding-left: var(--remotion-themed-spacing-large);
 }
 
 .bocBooleanValue img

--- a/Remotion/ObjectBinding/Web/UI/Controls/BocBooleanValueImplementation/Rendering/BocBooleanValueRenderer.cs
+++ b/Remotion/ObjectBinding/Web/UI/Controls/BocBooleanValueImplementation/Rendering/BocBooleanValueRenderer.cs
@@ -324,7 +324,14 @@ namespace Remotion.ObjectBinding.Web.UI.Controls.BocBooleanValueImplementation.R
       imageControl.GenerateEmptyAlternateText = true;
 
       labelControl.Text = description.ToString(WebStringEncoding.HtmlWithTransformedLineBreaks);
-      if (renderingContext.Control.ShowDescription || renderingContext.Control.IsReadOnly)
+      if (renderingContext.Control.IsReadOnly)
+      {
+        if (renderingContext.Control.Value.HasValue)
+          labelControl.Attributes.Add(HtmlTextWriterAttribute2.AriaHidden, HtmlAriaHiddenAttributeValue.True);
+        else
+          labelControl.Attributes.Add(HtmlTextWriterAttribute2.Hidden, HtmlHiddenAttributeValue.Hidden);
+      }
+      else if (renderingContext.Control.ShowDescription)
       {
         labelControl.Attributes.Add(HtmlTextWriterAttribute2.AriaHidden, HtmlAriaHiddenAttributeValue.True);
       }


### PR DESCRIPTION
https://re-motion.atlassian.net/browse/RM-8595