### PR TITLE
 bugfix/RM-8615-DictionaryExtensions.GetOrCreateValue-Is-Incompatible-With-ConcurrentDictionary-v3.1

### DIFF
--- a/Remotion/Core/Core/Collections/DictionaryExtensions.cs
+++ b/Remotion/Core/Core/Collections/DictionaryExtensions.cs
@@ -16,6 +16,7 @@
 // 
 using System;
 using System.Collections;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Diagnostics.CodeAnalysis;
@@ -108,11 +109,20 @@ namespace Remotion.Collections
       return ((IReadOnlyDictionary<TKey, TValue>)dictionary).GetValueOrDefault<TKey, TValue>(key, defaultValue);
     }
 
+    [Obsolete("ConcurrentDictionary is not supported for GetOrCreateValue(...). (Version: 3.0)", true)]
+    public static TValue GetOrCreateValue<TKey, TValue> (this ConcurrentDictionary<TKey, TValue> dictionary, TKey key, Func<TKey, TValue> valueFactory)
+        where TKey : notnull
+    {
+      throw new NotSupportedException("ConcurrentDictionary is not supported for GetOrCreateValue(...).");
+    }
+
     public static TValue GetOrCreateValue<TKey, TValue> (this IDictionary<TKey, TValue> dictionary, TKey key, Func<TKey, TValue> valueFactory)
         where TKey : notnull
     {
       ArgumentUtility.CheckNotNull("dictionary", dictionary);
       // Implementations of IDictionary<TKey, TValue> are free to allow null keys.
+      if (dictionary is ConcurrentDictionary<TKey, TValue>)
+        throw new ArgumentException("ConcurrentDictionary is not supported for GetOrCreateValue(...).", "dictionary");
 
       if (dictionary.TryGetValue(key, out var value))
         return value;

--- a/Remotion/Core/UnitTests/Collections/DictionaryExtensionsTest.cs
+++ b/Remotion/Core/UnitTests/Collections/DictionaryExtensionsTest.cs
@@ -15,11 +15,13 @@
 // along with re-motion; if not, see http://www.gnu.org/licenses.
 // 
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using Moq;
 using NUnit.Framework;
 using Remotion.Collections;
+using Remotion.Development.UnitTesting.NUnit;
 
 namespace Remotion.UnitTests.Collections
 {
@@ -195,6 +197,15 @@ namespace Remotion.UnitTests.Collections
 
       var foundValue = dictionaryStub.Object.GetOrCreateValue(null, key => throw new InvalidOperationException());
       Assert.That(foundValue, Is.EqualTo("out"));
+    }
+
+    [Test]
+    public void GetOrCreateValue_WithConcurrentDictionary ()
+    {
+      IDictionary<string, string> dictionary = new ConcurrentDictionary<string, string>();
+      Assert.That(
+          () => dictionary.GetOrCreateValue("a", key => throw new InvalidOperationException()),
+          Throws.ArgumentException.With.ArgumentExceptionMessageEqualTo("ConcurrentDictionary is not supported for GetOrCreateValue(...).", "dictionary"));
     }
 
     [Test]


### PR DESCRIPTION
https://re-motion.atlassian.net/browse/RM-8615