### PR TITLE
bugfix/RM-8669-BocAutoCompleteReferenceValue-popup-allows-table-cell-separation-to-be-inherrited-from-parent-element

### DIFF
--- a/Remotion/ObjectBinding/Web/Res/Themes/NovaGray/Html/BocAutoCompleteReferenceValue.UI.css
+++ b/Remotion/ObjectBinding/Web/Res/Themes/NovaGray/Html/BocAutoCompleteReferenceValue.UI.css
@@ -29,6 +29,7 @@
   margin: 0;
   width: 100%;
   display: table;
+  border-collapse: collapse;
 }
 
 .ac_results li

--- a/Remotion/ObjectBinding/Web/Res/Themes/NovaViso/HTML/BocAutoCompleteReferenceValue.UI.css
+++ b/Remotion/ObjectBinding/Web/Res/Themes/NovaViso/HTML/BocAutoCompleteReferenceValue.UI.css
@@ -43,6 +43,7 @@
   margin: 0;
   width: 100%;
   display: table;
+  border-collapse: collapse;
 }
 
 .ac_results li


### PR DESCRIPTION
https://re-motion.atlassian.net/browse/RM-8669