### PR TITLE
RM-8687 Use TimeSpan.TotalMilliseconds when waiting for the docker process exit

### DIFF
--- a/Remotion/Web/Development.WebTesting/HostingStrategies/DockerHosting/DockerCommandLineClient.cs
+++ b/Remotion/Web/Development.WebTesting/HostingStrategies/DockerHosting/DockerCommandLineClient.cs
@@ -201,7 +201,7 @@ namespace Remotion.Web.Development.WebTesting.HostingStrategies.DockerHosting
 
       while (!dockerProcess.HasExited)
       {
-        dockerProcess.WaitForExit(timeout.Milliseconds);
+        dockerProcess.WaitForExit((int)timeout.TotalMilliseconds);
 
         if (stopwatch.ElapsedMilliseconds > timeout.TotalMilliseconds)
           throw new TimeoutException($"Docker command '{dockerCommand}' ran longer than the configured timeout of '{timeout}'.");


### PR DESCRIPTION
https://re-motion.atlassian.net/browse/RM-8687

backport of #553 