### PR TITLE
RM-8857 Remove dual-targeting from WebApplication projects

### DIFF
--- a/Build/ProjectTypes/WebApplication.props
+++ b/Build/ProjectTypes/WebApplication.props
@@ -4,7 +4,7 @@
 
   <PropertyGroup>
     <UseWebForms>true</UseWebForms>
-    <UseNetOnly>true</UseNetOnly>
+    <TargetFrameworks>net6.0-windows</TargetFrameworks>
     <OutputPath>bin</OutputPath>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <IsPackable>false</IsPackable>


### PR DESCRIPTION
https://re-motion.atlassian.net/browse/RM-8857

Had to target `net6.0` instead of `net7.0` as we have other `net6.0` projects that reference the web projects which would not be possible if we targeted `net7.0` instead