### PR TITLE
RM-8897 WebTreeView expander link has no discernable text

### DIFF
--- a/Remotion/Web/Core/UI/Controls/WebTreeView.cs
+++ b/Remotion/Web/Core/UI/Controls/WebTreeView.cs
@@ -772,7 +772,7 @@ namespace Remotion.Web.UI.Controls
           writer.AddAttribute(DiagnosticMetadataAttributes.TriggersPostBack, "true");
       }
       writer.AddAttribute("tabindex", "-1");
-      writer.AddAttribute(HtmlTextWriterAttribute2.Role, HtmlRoleAttributeValue.None);
+      writer.AddAttribute(HtmlTextWriterAttribute2.AriaHidden, HtmlAriaHiddenAttributeValue.True);
       writer.RenderBeginTag(HtmlTextWriterTag.A);
 
       nodeIcon.Render(writer, this);

--- a/Remotion/Web/IntegrationTests/WebTreeView/AccessibilityWebTreeViewTest.cs
+++ b/Remotion/Web/IntegrationTests/WebTreeView/AccessibilityWebTreeViewTest.cs
@@ -27,7 +27,7 @@ namespace Remotion.Web.IntegrationTests.WebTreeView
   public class AccessibilityWebTreeViewTest : IntegrationTest
   {
     [Test]
-    public void WebTreeView ()
+    public void WebTreeView_WithNoChildren ()
     {
       var home = Start();
       var webTreeView = home.WebTreeViews().GetByLocalID("MyWebTreeView");
@@ -36,6 +36,20 @@ namespace Remotion.Web.IntegrationTests.WebTreeView
       var result = analyzer.Analyze(webTreeView);
       // TODO RM-7340 remove ignore once issue is resolved
       var violations = result.Violations.IgnoreByRuleIDAndXPath(AccessibilityRuleID.AriaRequiredChildren, "/div[@id='body_MyWebTreeView']/ul");
+
+      Assert.That(violations, Is.Empty);
+    }
+
+    [Test]
+    public void WebTreeView_WithChildren ()
+    {
+      var home = Start();
+      var webTreeView = home.WebTreeViews().GetByLocalID("MyWebTreeView3");
+      var analyzer = Helper.CreateAccessibilityAnalyzer();
+
+      var result = analyzer.Analyze(webTreeView);
+      // TODO RM-7340 remove ignore once issue is resolved
+      var violations = result.Violations.IgnoreByRuleIDAndXPath(AccessibilityRuleID.AriaRequiredChildren, "/div[@id='body_MyWebTreeView3']/ul");
 
       Assert.That(violations, Is.Empty);
     }


### PR DESCRIPTION
https://re-motion.atlassian.net/browse/RM-8897

@MichaelKetting the ticket did not specify what the expected solution was so I used `aria-hidden` on the expander node. I assume that the expander node is not necessary for screen reader at all since keyboard navigation of the tree is supported. If this assumption is incorrect please tell me the desired solution :D