### PR TITLE
RM-8912 Do not show error in BocList validation summary if all errors are displayed inline

### DIFF
--- a/Remotion/ObjectBinding/Web.Test/IndividualControlTests/BocListAsGridUserControl.ascx
+++ b/Remotion/ObjectBinding/Web.Test/IndividualControlTests/BocListAsGridUserControl.ascx
@@ -93,6 +93,14 @@
 </p>
 <p>
   <asp:CheckBox id="EnableValidationErrorsCheckBox" runat="server" AutoPostBack="True" Text="Enable validation errors" />
+  <asp:DropDownList id="ValidationErrorsScenarioListbox" AutoPostBack="True" runat="server">
+    <Items>
+      <asp:ListItem Text="All validation errors" Selected="True" Value="all" />
+      <asp:ListItem Text="Cell validation errors" Value="cell" />
+      <asp:ListItem Text="Row validation errors" Value="row" />
+      <asp:ListItem Text="List validation errors" Value="list" />
+    </Items>
+  </asp:DropDownList>
 </p>
 <p><asp:checkbox id=ChildrenListEventCheckBox runat="server" Text="ChildrenList Event raised" enableviewstate="False" Enabled="False"></asp:checkbox></p>
 <p>

--- a/Remotion/ObjectBinding/Web.Test/IndividualControlTests/BocListAsGridUserControl.ascx.cs
+++ b/Remotion/ObjectBinding/Web.Test/IndividualControlTests/BocListAsGridUserControl.ascx.cs
@@ -54,6 +54,7 @@ public class BocListAsGridUserControl : BaseUserControl
   protected TestBocList ChildrenList;
   protected TestBocList EmptyList;
   protected CheckBox EnableValidationErrorsCheckBox;
+  protected DropDownList ValidationErrorsScenarioListbox;
   protected CheckBox ChildrenListEventCheckBox;
   protected Label ChildrenListEventArgsLabel;
   protected Label UnhandledValidationErrorsLabel;
@@ -320,137 +321,154 @@ public class BocListAsGridUserControl : BaseUserControl
 
     var firstNameProperty = PropertyInfoAdapter.Create(MemberInfoFromExpressionUtility.GetProperty((Person _) => _.FirstName));
 
-    var validationResult = BusinessObjectValidationResult.Create(
-        new ValidationResult(
-            new ValidationFailure[]
-            {
-                // Jobs property failures
-                ValidationFailure.CreatePropertyValidationFailure(
-                    person,
-                    jobsProperty,
-                    person.Jobs,
-                    "Bad jobs",
-                    "Localized bad jobs"),
-                // First job failure (visible)
-                ValidationFailure.CreateObjectValidationFailure(
-                    firstJob,
-                    "Bad first job",
-                    "Localized bad first job"),
-                ValidationFailure.CreatePropertyValidationFailure(
-                    firstJob,
-                    jobTitleProperty,
-                    firstJob.Title,
-                    "Bad first job.Title",
-                    "Localized bad first job.Title"),
-                ValidationFailure.CreateObjectValidationFailure(
-                    firstJob,
-                    new[]
-                    {
-                      new ValidatedProperty(firstJob, jobStartDateProperty),
-                    },
-                    "Bad first job date",
-                    "Localized bad first job dates"),
-                ValidationFailure.CreateObjectValidationFailure(
-                    firstJob,
-                    new[]
-                    {
-                        new ValidatedProperty(firstJob, jobStartDateProperty),
-                        new ValidatedProperty(firstJob, jobEndDateProperty)
-                    },
-                    "Bad first job dates",
-                    "Localized bad first job dates"),
-                // Last job failure (invisible)
-                ValidationFailure.CreateObjectValidationFailure(
-                    lastJob,
-                    "Bad last job",
-                    "Localized bad last job"),
-                ValidationFailure.CreatePropertyValidationFailure(
-                    lastJob,
-                    jobTitleProperty,
-                    lastJob.Title,
-                    "Bad last job.Title",
-                    "Localized bad last job.Title"),
-                ValidationFailure.CreateObjectValidationFailure(
-                    lastJob,
-                    new[]
-                    {
-                        new ValidatedProperty(lastJob, jobStartDateProperty),
-                    },
-                    "Bad last job date",
-                    "Localized bad last job dates"),
-                ValidationFailure.CreateObjectValidationFailure(
-                    lastJob,
-                    new[]
-                    {
-                        new ValidatedProperty(lastJob, jobStartDateProperty),
-                        new ValidatedProperty(lastJob, jobEndDateProperty)
-                    },
-                    "Bad last job dates",
-                    "Localized bad last job dates"),
-                // Children property failures
-                ValidationFailure.CreatePropertyValidationFailure(
-                    person,
-                    childrenProperty,
-                    person.Children,
-                    "Bad children",
-                    "Localized bad children"),
-                // First child failure (visible)
-                ValidationFailure.CreateObjectValidationFailure(
-                    firstChild,
-                    "Bad first child",
-                    "Localized bad first child"),
-                ValidationFailure.CreatePropertyValidationFailure(
-                    firstChild,
-                    personPartnerProperty,
-                    firstChild.Partner,
-                    "Bad first child.Partner",
-                    "Localized bad first child.Partner"),
-                ValidationFailure.CreateObjectValidationFailure(
-                    firstChild,
-                    new[]
-                    {
-                        new ValidatedProperty(firstChild, personLastNameProperty),
-                    },
-                    "Bad first child name",
-                    "Localized bad first child names"),
-                ValidationFailure.CreateObjectValidationFailure(
-                    firstChild,
-                    new[]
-                    {
-                        new ValidatedProperty(firstChild, personLastNameProperty),
-                        new ValidatedProperty(firstChild, personFullNameProperty)
-                    },
-                    "Bad first child names",
-                    "Localized bad first child names"),
-                // Last child failure (invisible)
-                ValidationFailure.CreateObjectValidationFailure(
-                    lastChild,
-                    "Bad last child",
-                    "Localized bad last child"),
-                ValidationFailure.CreatePropertyValidationFailure(
-                    lastChild,
-                    personPartnerProperty,
-                    lastChild.Partner,
-                    "Bad last child.Partner",
-                    "Localized bad last child.Partner"),
-                ValidationFailure.CreateObjectValidationFailure(
-                    lastChild,
-                    new[]
-                    {
-                        new ValidatedProperty(lastChild, personLastNameProperty),
-                    },
-                    "Bad last child name",
-                    "Localized bad last child name"),
-                ValidationFailure.CreateObjectValidationFailure(
-                    lastChild,
-                    new[]
-                    {
-                        new ValidatedProperty(lastChild, personLastNameProperty),
-                        new ValidatedProperty(lastChild, personFullNameProperty)
-                    },
-                    "Bad last child names",
-                    "Localized bad last child names"),
-            }));
+    var allValidationFailures = new ValidationFailure[]
+                                {
+                                    // Jobs property failures
+                                    ValidationFailure.CreatePropertyValidationFailure(
+                                        person,
+                                        jobsProperty,
+                                        person.Jobs,
+                                        "Bad jobs",
+                                        "Localized bad jobs"),
+                                    // First job failure (visible)
+                                    ValidationFailure.CreateObjectValidationFailure(
+                                        firstJob,
+                                        "Bad first job",
+                                        "Localized bad first job"),
+                                    ValidationFailure.CreatePropertyValidationFailure(
+                                        firstJob,
+                                        jobTitleProperty,
+                                        firstJob.Title,
+                                        "Bad first job.Title",
+                                        "Localized bad first job.Title"),
+                                    ValidationFailure.CreateObjectValidationFailure(
+                                        firstJob,
+                                        new[]
+                                        {
+                                            new ValidatedProperty(firstJob, jobStartDateProperty),
+                                        },
+                                        "Bad first job date",
+                                        "Localized bad first job dates"),
+                                    ValidationFailure.CreateObjectValidationFailure(
+                                        firstJob,
+                                        new[]
+                                        {
+                                            new ValidatedProperty(firstJob, jobStartDateProperty),
+                                            new ValidatedProperty(firstJob, jobEndDateProperty)
+                                        },
+                                        "Bad first job dates",
+                                        "Localized bad first job dates"),
+                                    // Last job failure (invisible)
+                                    ValidationFailure.CreateObjectValidationFailure(
+                                        lastJob,
+                                        "Bad last job",
+                                        "Localized bad last job"),
+                                    ValidationFailure.CreatePropertyValidationFailure(
+                                        lastJob,
+                                        jobTitleProperty,
+                                        lastJob.Title,
+                                        "Bad last job.Title",
+                                        "Localized bad last job.Title"),
+                                    ValidationFailure.CreateObjectValidationFailure(
+                                        lastJob,
+                                        new[]
+                                        {
+                                            new ValidatedProperty(lastJob, jobStartDateProperty),
+                                        },
+                                        "Bad last job date",
+                                        "Localized bad last job dates"),
+                                    ValidationFailure.CreateObjectValidationFailure(
+                                        lastJob,
+                                        new[]
+                                        {
+                                            new ValidatedProperty(lastJob, jobStartDateProperty),
+                                            new ValidatedProperty(lastJob, jobEndDateProperty)
+                                        },
+                                        "Bad last job dates",
+                                        "Localized bad last job dates"),
+                                    // Children property failures
+                                    ValidationFailure.CreatePropertyValidationFailure(
+                                        person,
+                                        childrenProperty,
+                                        person.Children,
+                                        "Bad children",
+                                        "Localized bad children"),
+                                    // First child failure (visible)
+                                    ValidationFailure.CreateObjectValidationFailure(
+                                        firstChild,
+                                        "Bad first child",
+                                        "Localized bad first child"),
+                                    ValidationFailure.CreatePropertyValidationFailure(
+                                        firstChild,
+                                        personPartnerProperty,
+                                        firstChild.Partner,
+                                        "Bad first child.Partner",
+                                        "Localized bad first child.Partner"),
+                                    ValidationFailure.CreateObjectValidationFailure(
+                                        firstChild,
+                                        new[]
+                                        {
+                                            new ValidatedProperty(firstChild, personLastNameProperty),
+                                        },
+                                        "Bad first child name",
+                                        "Localized bad first child names"),
+                                    ValidationFailure.CreateObjectValidationFailure(
+                                        firstChild,
+                                        new[]
+                                        {
+                                            new ValidatedProperty(firstChild, personLastNameProperty),
+                                            new ValidatedProperty(firstChild, personFullNameProperty)
+                                        },
+                                        "Bad first child names",
+                                        "Localized bad first child names"),
+                                    // Last child failure (invisible)
+                                    ValidationFailure.CreateObjectValidationFailure(
+                                        lastChild,
+                                        "Bad last child",
+                                        "Localized bad last child"),
+                                    ValidationFailure.CreatePropertyValidationFailure(
+                                        lastChild,
+                                        personPartnerProperty,
+                                        lastChild.Partner,
+                                        "Bad last child.Partner",
+                                        "Localized bad last child.Partner"),
+                                    ValidationFailure.CreateObjectValidationFailure(
+                                        lastChild,
+                                        new[]
+                                        {
+                                            new ValidatedProperty(lastChild, personLastNameProperty),
+                                        },
+                                        "Bad last child name",
+                                        "Localized bad last child name"),
+                                    ValidationFailure.CreateObjectValidationFailure(
+                                        lastChild,
+                                        new[]
+                                        {
+                                            new ValidatedProperty(lastChild, personLastNameProperty),
+                                            new ValidatedProperty(lastChild, personFullNameProperty)
+                                        },
+                                        "Bad last child names",
+                                        "Localized bad last child names"),
+                                };
+
+    var selectedValidationFailures = ValidationErrorsScenarioListbox.SelectedValue switch
+    {
+        "cell" => allValidationFailures
+            .Where(e => e.ValidatedObject is Person && e.ValidatedProperties.Count == 2)
+            .Take(1)
+            .Concat(allValidationFailures.Where(e => e.ValidatedObject is Job && e.ValidatedProperties.Count == 2).Take(1))
+            .ToArray(),
+        "row" => allValidationFailures
+            .Where(e => e.ValidatedObject is Person && e.ValidatedProperties.Count == 0)
+            .Take(1)
+            .Concat(allValidationFailures.Where(e => e.ValidatedObject is Job && e.ValidatedProperties.Count == 0).Take(1))
+            .ToArray(),
+        "list" => allValidationFailures
+            .Where(e => e.ValidatedProperties.Count == 1 && e.ValidatedProperties[0].Property.Name is "Jobs" or "Children")
+            .ToArray(),
+        _ => allValidationFailures
+    };
+    var validationResult = BusinessObjectValidationResult.Create(new ValidationResult(selectedValidationFailures));
 
     PrepareValidation();
     FormGridManager.PrepareValidation();

--- a/Remotion/ObjectBinding/Web.Test/IndividualControlTests/BocListUserControl.ascx
+++ b/Remotion/ObjectBinding/Web.Test/IndividualControlTests/BocListUserControl.ascx
@@ -224,6 +224,14 @@
 </p>
 <p>
   <asp:CheckBox id="EnableValidationErrorsCheckbox" runat="server" AutoPostBack="True" Text="Enable validation errors" />
+  <asp:DropDownList id="ValidationErrorsScenarioListbox" AutoPostBack="True" runat="server">
+    <Items>
+      <asp:ListItem Text="All validation errors" Selected="True" Value="all" />
+      <asp:ListItem Text="Cell validation errors" Value="cell" />
+      <asp:ListItem Text="Row validation errors" Value="row" />
+      <asp:ListItem Text="List validation errors" Value="list" />
+    </Items>
+  </asp:DropDownList>
 </p>
 <p>
   <asp:checkbox id=ChildrenListEventCheckBox runat="server" Text="ChildrenList Event raised" enableviewstate="False" Enabled="False"></asp:checkbox>

--- a/Remotion/ObjectBinding/Web.Test/IndividualControlTests/BocListUserControl.ascx.cs
+++ b/Remotion/ObjectBinding/Web.Test/IndividualControlTests/BocListUserControl.ascx.cs
@@ -51,6 +51,7 @@ public class BocListUserControl : BaseUserControl
   protected Button ChildrenListAddRowButton;
   protected Button ChildrenListRemoveRowsButton;
   protected CheckBox EnableValidationErrorsCheckbox;
+  protected DropDownList ValidationErrorsScenarioListbox;
   protected CheckBox ChildrenListEventCheckBox;
   protected Label ChildrenListEventArgsLabel;
   protected Label UnhandledValidationErrorsLabel;
@@ -428,137 +429,154 @@ public class BocListUserControl : BaseUserControl
 
     var firstNameProperty = PropertyInfoAdapter.Create(MemberInfoFromExpressionUtility.GetProperty((Person _) => _.FirstName));
 
-    var validationResult = BusinessObjectValidationResult.Create(
-        new ValidationResult(
-            new ValidationFailure[]
-            {
-                // Jobs property failures
-                ValidationFailure.CreatePropertyValidationFailure(
-                    person,
-                    jobsProperty,
-                    person.Jobs,
-                    "Bad jobs",
-                    "Localized bad jobs"),
-                // First job failure (visible)
-                ValidationFailure.CreateObjectValidationFailure(
-                    firstJob,
-                    "Bad first job",
-                    "Localized bad first job"),
-                ValidationFailure.CreatePropertyValidationFailure(
-                    firstJob,
-                    jobTitleProperty,
-                    firstJob.Title,
-                    "Bad first job.Title",
-                    "Localized bad first job.Title"),
-                ValidationFailure.CreateObjectValidationFailure(
-                    firstJob,
-                    new[]
-                    {
-                      new ValidatedProperty(firstJob, jobStartDateProperty),
-                    },
-                    "Bad first job date",
-                    "Localized bad first job dates"),
-                ValidationFailure.CreateObjectValidationFailure(
-                    firstJob,
-                    new[]
-                    {
-                        new ValidatedProperty(firstJob, jobStartDateProperty),
-                        new ValidatedProperty(firstJob, jobEndDateProperty)
-                    },
-                    "Bad first job dates",
-                    "Localized bad first job dates"),
-                // Last job failure (invisible)
-                ValidationFailure.CreateObjectValidationFailure(
-                    lastJob,
-                    "Bad last job",
-                    "Localized bad last job"),
-                ValidationFailure.CreatePropertyValidationFailure(
-                    lastJob,
-                    jobTitleProperty,
-                    lastJob.Title,
-                    "Bad last job.Title",
-                    "Localized bad last job.Title"),
-                ValidationFailure.CreateObjectValidationFailure(
-                    lastJob,
-                    new[]
-                    {
-                        new ValidatedProperty(lastJob, jobStartDateProperty),
-                    },
-                    "Bad last job date",
-                    "Localized bad last job dates"),
-                ValidationFailure.CreateObjectValidationFailure(
-                    lastJob,
-                    new[]
-                    {
-                        new ValidatedProperty(lastJob, jobStartDateProperty),
-                        new ValidatedProperty(lastJob, jobEndDateProperty)
-                    },
-                    "Bad last job dates",
-                    "Localized bad last job dates"),
-                // Children property failures
-                ValidationFailure.CreatePropertyValidationFailure(
-                    person,
-                    childrenProperty,
-                    person.Children,
-                    "Bad children",
-                    "Localized bad children"),
-                // First child failure (visible)
-                ValidationFailure.CreateObjectValidationFailure(
-                    firstChild,
-                    "Bad first child",
-                    "Localized bad first child"),
-                ValidationFailure.CreatePropertyValidationFailure(
-                    firstChild,
-                    personPartnerProperty,
-                    firstChild.Partner,
-                    "Bad first child.Partner",
-                    "Localized bad first child.Partner"),
-                ValidationFailure.CreateObjectValidationFailure(
-                    firstChild,
-                    new[]
-                    {
-                        new ValidatedProperty(firstChild, personLastNameProperty),
-                    },
-                    "Bad first child name",
-                    "Localized bad first child name"),
-                ValidationFailure.CreateObjectValidationFailure(
-                    firstChild,
-                    new[]
-                    {
-                        new ValidatedProperty(firstChild, personLastNameProperty),
-                        new ValidatedProperty(firstChild, personFullNameProperty)
-                    },
-                    "Bad first child names",
-                    "Localized bad first child names"),
-                // Last child failure (invisible)
-                ValidationFailure.CreateObjectValidationFailure(
-                    lastChild,
-                    "Bad last child",
-                    "Localized bad last child"),
-                ValidationFailure.CreatePropertyValidationFailure(
-                    lastChild,
-                    personPartnerProperty,
-                    lastChild.Partner,
-                    "Bad last child.Partner",
-                    "Localized bad last child.Partner"),
-                ValidationFailure.CreateObjectValidationFailure(
-                    lastChild,
-                    new[]
-                    {
-                        new ValidatedProperty(lastChild, personLastNameProperty),
-                    },
-                    "Bad last child name",
-                    "Localized bad last child name"),
-                ValidationFailure.CreateObjectValidationFailure(
-                    lastChild,
-                    new[]
-                    {
-                        new ValidatedProperty(lastChild, personLastNameProperty),
-                        new ValidatedProperty(lastChild, personFullNameProperty)
-                    },
-                    "Bad last child names",
-                    "Localized bad last child names is a very long message so yeah about that"),
-            }));
+    var allValidationFailures = new ValidationFailure[]
+                                {
+                                    // Jobs property failures
+                                    ValidationFailure.CreatePropertyValidationFailure(
+                                        person,
+                                        jobsProperty,
+                                        person.Jobs,
+                                        "Bad jobs",
+                                        "Localized bad jobs"),
+                                    // First job failure (visible)
+                                    ValidationFailure.CreateObjectValidationFailure(
+                                        firstJob,
+                                        "Bad first job",
+                                        "Localized bad first job"),
+                                    ValidationFailure.CreatePropertyValidationFailure(
+                                        firstJob,
+                                        jobTitleProperty,
+                                        firstJob.Title,
+                                        "Bad first job.Title",
+                                        "Localized bad first job.Title"),
+                                    ValidationFailure.CreateObjectValidationFailure(
+                                        firstJob,
+                                        new[]
+                                        {
+                                            new ValidatedProperty(firstJob, jobStartDateProperty),
+                                        },
+                                        "Bad first job date",
+                                        "Localized bad first job dates"),
+                                    ValidationFailure.CreateObjectValidationFailure(
+                                        firstJob,
+                                        new[]
+                                        {
+                                            new ValidatedProperty(firstJob, jobStartDateProperty),
+                                            new ValidatedProperty(firstJob, jobEndDateProperty)
+                                        },
+                                        "Bad first job dates",
+                                        "Localized bad first job dates"),
+                                    // Last job failure (invisible)
+                                    ValidationFailure.CreateObjectValidationFailure(
+                                        lastJob,
+                                        "Bad last job",
+                                        "Localized bad last job"),
+                                    ValidationFailure.CreatePropertyValidationFailure(
+                                        lastJob,
+                                        jobTitleProperty,
+                                        lastJob.Title,
+                                        "Bad last job.Title",
+                                        "Localized bad last job.Title"),
+                                    ValidationFailure.CreateObjectValidationFailure(
+                                        lastJob,
+                                        new[]
+                                        {
+                                            new ValidatedProperty(lastJob, jobStartDateProperty),
+                                        },
+                                        "Bad last job date",
+                                        "Localized bad last job dates"),
+                                    ValidationFailure.CreateObjectValidationFailure(
+                                        lastJob,
+                                        new[]
+                                        {
+                                            new ValidatedProperty(lastJob, jobStartDateProperty),
+                                            new ValidatedProperty(lastJob, jobEndDateProperty)
+                                        },
+                                        "Bad last job dates",
+                                        "Localized bad last job dates"),
+                                    // Children property failures
+                                    ValidationFailure.CreatePropertyValidationFailure(
+                                        person,
+                                        childrenProperty,
+                                        person.Children,
+                                        "Bad children",
+                                        "Localized bad children"),
+                                    // First child failure (visible)
+                                    ValidationFailure.CreateObjectValidationFailure(
+                                        firstChild,
+                                        "Bad first child",
+                                        "Localized bad first child"),
+                                    ValidationFailure.CreatePropertyValidationFailure(
+                                        firstChild,
+                                        personPartnerProperty,
+                                        firstChild.Partner,
+                                        "Bad first child.Partner",
+                                        "Localized bad first child.Partner"),
+                                    ValidationFailure.CreateObjectValidationFailure(
+                                        firstChild,
+                                        new[]
+                                        {
+                                            new ValidatedProperty(firstChild, personLastNameProperty),
+                                        },
+                                        "Bad first child name",
+                                        "Localized bad first child name"),
+                                    ValidationFailure.CreateObjectValidationFailure(
+                                        firstChild,
+                                        new[]
+                                        {
+                                            new ValidatedProperty(firstChild, personLastNameProperty),
+                                            new ValidatedProperty(firstChild, personFullNameProperty)
+                                        },
+                                        "Bad first child names",
+                                        "Localized bad first child names"),
+                                    // Last child failure (invisible)
+                                    ValidationFailure.CreateObjectValidationFailure(
+                                        lastChild,
+                                        "Bad last child",
+                                        "Localized bad last child"),
+                                    ValidationFailure.CreatePropertyValidationFailure(
+                                        lastChild,
+                                        personPartnerProperty,
+                                        lastChild.Partner,
+                                        "Bad last child.Partner",
+                                        "Localized bad last child.Partner"),
+                                    ValidationFailure.CreateObjectValidationFailure(
+                                        lastChild,
+                                        new[]
+                                        {
+                                            new ValidatedProperty(lastChild, personLastNameProperty),
+                                        },
+                                        "Bad last child name",
+                                        "Localized bad last child name"),
+                                    ValidationFailure.CreateObjectValidationFailure(
+                                        lastChild,
+                                        new[]
+                                        {
+                                            new ValidatedProperty(lastChild, personLastNameProperty),
+                                            new ValidatedProperty(lastChild, personFullNameProperty)
+                                        },
+                                        "Bad last child names",
+                                        "Localized bad last child names is a very long message so yeah about that"),
+                                };
+
+    var selectedValidationFailures = ValidationErrorsScenarioListbox.SelectedValue switch
+    {
+        "cell" => allValidationFailures
+            .Where(e => e.ValidatedObject is Person && e.ValidatedProperties.Count == 2)
+            .Take(1)
+            .Concat(allValidationFailures.Where(e => e.ValidatedObject is Job && e.ValidatedProperties.Count == 2).Take(1))
+            .ToArray(),
+        "row" => allValidationFailures
+            .Where(e => e.ValidatedObject is Person && e.ValidatedProperties.Count == 0)
+            .Take(1)
+            .Concat(allValidationFailures.Where(e => e.ValidatedObject is Job && e.ValidatedProperties.Count == 0).Take(1))
+            .ToArray(),
+        "list" => allValidationFailures
+            .Where(e => e.ValidatedProperties.Count == 1 && e.ValidatedProperties[0].Property.Name is "Jobs" or "Children")
+            .ToArray(),
+        _ => allValidationFailures
+    };
+    var validationResult = BusinessObjectValidationResult.Create(new ValidationResult(selectedValidationFailures));
 
     ((SmartPage)Page).PrepareValidation();
 

--- a/Remotion/ObjectBinding/Web.UnitTests/UI/Controls/Validation/BocListValidationResultDispatchingValidatorTest.cs
+++ b/Remotion/ObjectBinding/Web.UnitTests/UI/Controls/Validation/BocListValidationResultDispatchingValidatorTest.cs
@@ -177,13 +177,16 @@ namespace Remotion.ObjectBinding.Web.UnitTests.UI.Controls.Validation
                                          };
 
       validationFailureRepoStub
-          .SetupSequence(_ => _.GetUnhandledValidationFailuresForBocListAndContainingDataRowsAndDataCells(true))
-          .Returns(Array.Empty<BocListValidationFailureWithLocationInformation>())
+          .Setup(_ => _.GetUnhandledValidationFailuresForDataRowsAndContainingDataCells(true))
+          .Returns(Array.Empty<BocListValidationFailureWithLocationInformation>());
+
+      validationFailureRepoStub
+          .Setup(_ => _.GetUnhandledValidationFailuresForBocListAndContainingDataRowsAndDataCells(true))
           .Returns(validationFailuresForBocList);
 
       var error = "New error just arrived";
       var resourceManagerStub = new Mock<IResourceManager>();
-      resourceManagerStub.Setup(_ => _.TryGetString("Remotion.ObjectBinding.Web.UI.Controls.BocList.ValidationFailuresFoundInListErrorMessage", out error)).Returns(true);
+      resourceManagerStub.Setup(_ => _.TryGetString("Remotion.ObjectBinding.Web.UI.Controls.BocList.UnhandledValidationFailuresFoundErrorMessage", out error)).Returns(true);
 
       var bocListMock = new Mock<Control> { CallBase = true };
       bocListMock.As<IBocList>().Setup(_ => _.ValidationFailureRepository).Returns(validationFailureRepoStub.Object);
@@ -205,25 +208,15 @@ namespace Remotion.ObjectBinding.Web.UnitTests.UI.Controls.Validation
     [Test]
     public void RefreshErrorMessage_WithBocListValidationFailures_ReturnsFailuresOfBocList ()
     {
-      var validationFailureRepoStub = new Mock<IBocListValidationFailureRepository>();
+      var validationFailureRepository = new BocListValidationFailureRepository();
+      validationFailureRepository.AddValidationFailuresForBocList(new [] { BusinessObjectValidationFailure.Create("Errors on BocList") });
+
       var resourceManagerStub = new Mock<IResourceManager>();
 
       var bocListMock = new Mock<Control> { CallBase = true };
-      bocListMock.As<IBocList>().Setup(_ => _.ValidationFailureRepository).Returns(validationFailureRepoStub.Object);
+      bocListMock.As<IBocList>().Setup(_ => _.ValidationFailureRepository).Returns(validationFailureRepository);
       bocListMock.As<IBocList>().Setup(_ => _.GetResourceManager()).Returns(resourceManagerStub.Object);
       bocListMock.Object.ID = "someBocList";
-
-      var validationFailuresForBocList = new[]
-                                         {
-                                           BocListValidationFailureWithLocationInformation.CreateFailure(BusinessObjectValidationFailure.Create("Errors on BocList"))
-                                         };
-
-      validationFailureRepoStub
-          .Setup(_ => _.GetUnhandledValidationFailuresForBocList(true))
-          .Returns(validationFailuresForBocList);
-      validationFailureRepoStub
-          .Setup(_ => _.GetUnhandledValidationFailuresForBocListAndContainingDataRowsAndDataCells(true))
-          .Returns(Array.Empty<BocListValidationFailureWithLocationInformation>());
 
       var validator = new BocListValidationResultDispatchingValidator();
       validator.ErrorMessage = "This should not be output.";
@@ -240,20 +233,8 @@ namespace Remotion.ObjectBinding.Web.UnitTests.UI.Controls.Validation
     [Test]
     public void RefreshErrorMessage_WithValidationFailuresForBoundProperty_ReturnsLocalizedInfo ()
     {
-      var validationFailuresForBocListRows = new[]
-                                             {
-                                               BocListValidationFailureWithLocationInformation.CreateFailure(BusinessObjectValidationFailure.Create("Errors on BocList rows"))
-                                             };
-
-      var validationFailureRepoStub = new Mock<IBocListValidationFailureRepository>();
-      validationFailureRepoStub
-          .Setup(_ => _.GetUnhandledValidationFailuresForBocList(true))
-          .Returns(Array.Empty<BocListValidationFailureWithLocationInformation>());
-
-      validationFailureRepoStub
-          .SetupSequence(_ => _.GetUnhandledValidationFailuresForBocListAndContainingDataRowsAndDataCells(true))
-          .Returns(validationFailuresForBocListRows)
-          .Returns(Array.Empty<BocListValidationFailureWithLocationInformation>());
+      var validationFailureRepository = new BocListValidationFailureRepository();
+      validationFailureRepository.AddValidationFailuresForDataRow(Mock.Of<IBusinessObject>(), new [] { BusinessObjectValidationFailure.Create("Errors on BocList rows") });
 
       var error = "Errors on rows in BocList";
 
@@ -263,7 +244,7 @@ namespace Remotion.ObjectBinding.Web.UnitTests.UI.Controls.Validation
       var businessObjectStub = new Mock<IBusinessObject>();
 
       var bocListMock = new Mock<Control> { CallBase = true };
-      bocListMock.As<IBocList>().Setup(_ => _.ValidationFailureRepository).Returns(validationFailureRepoStub.Object);
+      bocListMock.As<IBocList>().Setup(_ => _.ValidationFailureRepository).Returns(validationFailureRepository);
       bocListMock.As<IBocList>().Setup(_ => _.GetResourceManager()).Returns(resourceManagerStub.Object);
       bocListMock.As<IBocList>().Setup(_ => _.Value).Returns(new[] { businessObjectStub.Object });
       bocListMock.Object.ID = "someBocList";
@@ -283,25 +264,17 @@ namespace Remotion.ObjectBinding.Web.UnitTests.UI.Controls.Validation
     [Test]
     public void RefreshErrorMessage_WithoutErrors_ReturnsLocalizedInfo ()
     {
-      var validationFailureRepoStub = new Mock<IBocListValidationFailureRepository>();
-      validationFailureRepoStub
-          .Setup(_ => _.GetUnhandledValidationFailuresForBocList(true))
-          .Returns(Array.Empty<BocListValidationFailureWithLocationInformation>());
-
-      validationFailureRepoStub
-          .Setup(_ => _.GetUnhandledValidationFailuresForBocListAndContainingDataRowsAndDataCells(true))
-          .Returns(Array.Empty<BocListValidationFailureWithLocationInformation>());
-
+      var validationFailureRepository = new BocListValidationFailureRepository();
 
       var error = "Errors on rows in BocList";
 
       var resourceManagerStub = new Mock<IResourceManager>();
-      resourceManagerStub.Setup(_ => _.TryGetString("Remotion.ObjectBinding.Web.UI.Controls.BocList.ValidationFailuresFoundInListErrorMessage", out error)).Returns(true);
+      resourceManagerStub.Setup(_ => _.TryGetString("Remotion.ObjectBinding.Web.UI.Controls.BocList.UnhandledValidationFailuresFoundErrorMessage", out error)).Returns(true);
 
       var businessObjectStub = new Mock<IBusinessObject>();
 
       var bocListMock = new Mock<Control> { CallBase = true };
-      bocListMock.As<IBocList>().Setup(_ => _.ValidationFailureRepository).Returns(validationFailureRepoStub.Object);
+      bocListMock.As<IBocList>().Setup(_ => _.ValidationFailureRepository).Returns(validationFailureRepository);
       bocListMock.As<IBocList>().Setup(_ => _.GetResourceManager()).Returns(resourceManagerStub.Object);
       bocListMock.As<IBocList>().Setup(_ => _.Value).Returns(new[] { businessObjectStub.Object });
       bocListMock.Object.ID = "someBocList";
@@ -321,26 +294,9 @@ namespace Remotion.ObjectBinding.Web.UnitTests.UI.Controls.Validation
     [Test]
     public void RefreshErrorMessage_WithValidationFailuresForBoundPropertyAndRowFailures_ReturnsAppendedMessageText ()
     {
-      var validationFailuresForBocList = new[]
-                                         {
-                                           BocListValidationFailureWithLocationInformation.CreateFailure(BusinessObjectValidationFailure.Create("Errors on BocList"))
-                                         };
-
-      var validationFailuresForBocListRows = new[]
-                                             {
-                                               BocListValidationFailureWithLocationInformation.CreateFailure(BusinessObjectValidationFailure.Create("Errors on BocList rows"))
-                                             };
-
-      var validationFailureRepoStub = new Mock<IBocListValidationFailureRepository>();
-      validationFailureRepoStub
-          .Setup(_ => _.GetUnhandledValidationFailuresForBocList(true))
-          .Returns(validationFailuresForBocList);
-
-      validationFailureRepoStub
-          .SetupSequence(_ => _.GetUnhandledValidationFailuresForBocListAndContainingDataRowsAndDataCells(true))
-          .Returns(validationFailuresForBocListRows)
-          .Returns(Array.Empty<BocListValidationFailureWithLocationInformation>());
-
+      var validationFailureRepository = new BocListValidationFailureRepository();
+      validationFailureRepository.AddValidationFailuresForBocList(new [] { BusinessObjectValidationFailure.Create("A list error") });
+      validationFailureRepository.AddValidationFailuresForDataRow(Mock.Of<IBusinessObject>(), new [] { BusinessObjectValidationFailure.Create("A row error") });
 
       var error = "Errors on rows in BocList";
 
@@ -350,7 +306,7 @@ namespace Remotion.ObjectBinding.Web.UnitTests.UI.Controls.Validation
       var businessObjectStub = new Mock<IBusinessObject>();
 
       var bocListMock = new Mock<Control> { CallBase = true };
-      bocListMock.As<IBocList>().Setup(_ => _.ValidationFailureRepository).Returns(validationFailureRepoStub.Object);
+      bocListMock.As<IBocList>().Setup(_ => _.ValidationFailureRepository).Returns(validationFailureRepository);
       bocListMock.As<IBocList>().Setup(_ => _.GetResourceManager()).Returns(resourceManagerStub.Object);
       bocListMock.As<IBocList>().Setup(_ => _.Value).Returns(new[] { businessObjectStub.Object });
       bocListMock.Object.ID = "someBocList";
@@ -364,23 +320,59 @@ namespace Remotion.ObjectBinding.Web.UnitTests.UI.Controls.Validation
 
       ((IValidatorWithDynamicErrorMessage)validator).RefreshErrorMessage();
 
-      Assert.That(validator.ErrorMessage, Is.EqualTo("Errors on BocList\r\nErrors on rows in BocList\r\n"));
+      Assert.That(validator.ErrorMessage, Is.EqualTo("Errors on rows in BocList\r\nA list error\r\n"));
+    }
+
+    [Test]
+    public void RefreshErrorMessage_WithAllKindsOfFailures_ReturnsMessagesFromAllHandlers ()
+    {
+      var validationFailureRepository = new BocListValidationFailureRepository();
+      validationFailureRepository.AddValidationFailuresForBocList(new [] { BusinessObjectValidationFailure.Create("A list error") });
+
+      var rowObject = Mock.Of<IBusinessObject>();
+      validationFailureRepository.AddValidationFailuresForDataRow(rowObject, new [] { BusinessObjectValidationFailure.Create("A handled row error") });
+      validationFailureRepository.GetUnhandledValidationFailuresForDataRow(rowObject, true);
+
+      validationFailureRepository.AddValidationFailuresForDataRow(Mock.Of<IBusinessObject>(), new [] { BusinessObjectValidationFailure.Create("An unhandled row error") });
+
+
+      var resourceManagerStub = new Mock<IResourceManager>();
+      var error1 = "Error details in rows";
+      resourceManagerStub.Setup(_ => _.TryGetString("Remotion.ObjectBinding.Web.UI.Controls.BocList.ValidationFailuresFoundInListErrorMessage", out error1)).Returns(true);
+      var error2 = "Errors on other page";
+      resourceManagerStub.Setup(_ => _.TryGetString("Remotion.ObjectBinding.Web.UI.Controls.BocList.ValidationFailuresFoundInOtherListPagesErrorMessage", out error2)).Returns(true);
+
+      var businessObjectStub = new Mock<IBusinessObject>();
+
+      var bocListMock = new Mock<Control> { CallBase = true };
+      bocListMock.As<IBocList>().Setup(_ => _.ValidationFailureRepository).Returns(validationFailureRepository);
+      bocListMock.As<IBocList>().Setup(_ => _.GetResourceManager()).Returns(resourceManagerStub.Object);
+      bocListMock.As<IBocList>().Setup(_ => _.Value).Returns(new[] { businessObjectStub.Object });
+      bocListMock.Object.ID = "someBocList";
+
+      var validator = new BocListValidationResultDispatchingValidator();
+      validator.ErrorMessage = "This should not be output.";
+      validator.ControlToValidate = "someBocList";
+
+      NamingContainer.Controls.Add(bocListMock.Object);
+      NamingContainer.Controls.Add(validator);
+
+      ((IValidatorWithDynamicErrorMessage)validator).RefreshErrorMessage();
+
+      Assert.That(validator.ErrorMessage, Is.EqualTo("Error details in rows\r\nErrors on other page\r\nA list error\r\n"));
     }
 
     [Test]
     public void EvaluateIsValid_WithoutFailures_EmptyErrorMessageAndValid ()
     {
-      var validationFailureRepoStub = new Mock<IBocListValidationFailureRepository>();
-      validationFailureRepoStub
-          .Setup(_ => _.GetUnhandledValidationFailuresForBocListAndContainingDataRowsAndDataCells(false))
-          .Returns(Array.Empty<BocListValidationFailureWithLocationInformation>());
+      var validationFailureRepository = new BocListValidationFailureRepository();
 
       var error = "BocList has validation errors.";
       var resourceManagerStub = new Mock<IResourceManager>();
       resourceManagerStub.Setup(_ => _.TryGetString("Remotion.ObjectBinding.Web.UI.Controls.BocList.RemainingValidationFailureText", out error)).Returns(true);
 
       var bocListMock = new Mock<Control> { CallBase = true };
-      bocListMock.As<IBocList>().Setup(_ => _.ValidationFailureRepository).Returns(validationFailureRepoStub.Object);
+      bocListMock.As<IBocList>().Setup(_ => _.ValidationFailureRepository).Returns(validationFailureRepository);
       bocListMock.As<IBocList>().Setup(_ => _.GetResourceManager()).Returns(resourceManagerStub.Object);
       bocListMock.Object.ID = "someBocList";
 
@@ -400,22 +392,15 @@ namespace Remotion.ObjectBinding.Web.UnitTests.UI.Controls.Validation
     [Test]
     public void EvaluateIsValid_WithFailures_ErrorMessageFromResourceManagerAndInvalid ()
     {
-      var validationFailuresForBocListRows = new[]
-                                             {
-                                               BocListValidationFailureWithLocationInformation.CreateFailure(BusinessObjectValidationFailure.Create("Errors on BocList rows."))
-                                             };
-
-      var validationFailureRepoStub = new Mock<IBocListValidationFailureRepository>();
-      validationFailureRepoStub
-          .Setup(_ => _.GetUnhandledValidationFailuresForBocListAndContainingDataRowsAndDataCells(false))
-          .Returns(validationFailuresForBocListRows);
+      var validationFailureRepository = new BocListValidationFailureRepository();
+      validationFailureRepository.AddValidationFailuresForBocList(new [] { BusinessObjectValidationFailure.Create("A list error") });
 
       var error = "BocList has validation errors.";
       var resourceManagerStub = new Mock<IResourceManager>();
-      resourceManagerStub.Setup(_ => _.TryGetString("Remotion.ObjectBinding.Web.UI.Controls.BocList.ValidationFailuresFoundInListErrorMessage", out error)).Returns(true);
+      resourceManagerStub.Setup(_ => _.TryGetString("Remotion.ObjectBinding.Web.UI.Controls.BocList.UnhandledValidationFailuresFoundErrorMessage", out error)).Returns(true);
 
       var bocListMock = new Mock<Control> { CallBase = true };
-      bocListMock.As<IBocList>().Setup(_ => _.ValidationFailureRepository).Returns(validationFailureRepoStub.Object);
+      bocListMock.As<IBocList>().Setup(_ => _.ValidationFailureRepository).Returns(validationFailureRepository);
       bocListMock.As<IBocList>().Setup(_ => _.GetResourceManager()).Returns(resourceManagerStub.Object);
       bocListMock.Object.ID = "someBocList";
 

--- a/Remotion/ObjectBinding/Web.UnitTests/UI/Controls/Validation/CompoundBocListValidationFailureHandlerTest.cs
+++ b/Remotion/ObjectBinding/Web.UnitTests/UI/Controls/Validation/CompoundBocListValidationFailureHandlerTest.cs
@@ -2,6 +2,7 @@
 using NUnit.Framework;
 using Remotion.ObjectBinding.Web.UI.Controls.BocListImplementation;
 using Remotion.ObjectBinding.Web.UI.Controls.BocListImplementation.Validation;
+using Remotion.ObjectBinding.Web.UI.Controls.Validation;
 
 namespace Remotion.ObjectBinding.Web.UnitTests.UI.Controls.Validation
 {
@@ -14,8 +15,10 @@ namespace Remotion.ObjectBinding.Web.UnitTests.UI.Controls.Validation
       var handler1Mock = new Mock<IBocListValidationFailureHandler>();
       var handler2Mock = new Mock<IBocListValidationFailureHandler>();
 
+      var bocListMock = new BocListMock();
+
       var validationFailureHandler = new CompoundBocListValidationFailureHandler(new[] { handler1Mock.Object, handler2Mock.Object });
-      var context = new ValidationFailureHandlingContext(new Mock<IBocList>().Object);
+      var context = new ValidationFailureHandlingContext(bocListMock);
 
       var sequence = new VerifiableSequence();
       handler1Mock

--- a/Remotion/ObjectBinding/Web.UnitTests/UI/Controls/Validation/IBocListValidationFailureHandlerTest.cs
+++ b/Remotion/ObjectBinding/Web.UnitTests/UI/Controls/Validation/IBocListValidationFailureHandlerTest.cs
@@ -29,8 +29,9 @@ namespace Remotion.ObjectBinding.Web.UnitTests.UI.Controls.Validation
           Is.EqualTo(
               new[]
               {
-                typeof(BocListListValidationFailureHandler),
-                typeof(BocListRowAndCellValidationFailureHandler)
+                  typeof(CheckRowsBocListValidationFailureHandler),
+                  typeof(BocListRowAndCellValidationFailureHandler),
+                  typeof(BocListListValidationFailureHandler)
               }));
     }
 

--- a/Remotion/ObjectBinding/Web.UnitTests/UI/Controls/Validation/ValidationFailureHandlingContextTest.cs
+++ b/Remotion/ObjectBinding/Web.UnitTests/UI/Controls/Validation/ValidationFailureHandlingContextTest.cs
@@ -19,6 +19,7 @@ using System;
 using System.Text;
 using Moq;
 using NUnit.Framework;
+using Remotion.ObjectBinding.Web.UI.Controls;
 using Remotion.ObjectBinding.Web.UI.Controls.BocListImplementation;
 using Remotion.ObjectBinding.Web.UI.Controls.BocListImplementation.Validation;
 using Remotion.ObjectBinding.Web.UI.Controls.Validation;
@@ -28,18 +29,18 @@ namespace Remotion.ObjectBinding.Web.UnitTests.UI.Controls.Validation
   [TestFixture]
   public class ValidationFailureHandlingContextTest
   {
-    private Mock<IBocList> _bocListStub;
+    private BocListMock _bocListStub;
 
     [SetUp]
     public void Setup ()
     {
-      _bocListStub = new Mock<IBocList>();
+      _bocListStub = new BocListMock();
     }
 
     [Test]
     public void AppendErrorMessage_AppendsReportedMessagesToStringBuilder ()
     {
-      var context = new ValidationFailureHandlingContext(_bocListStub.Object);
+      var context = new ValidationFailureHandlingContext(_bocListStub);
 
       context.ReportErrorMessage("First error message.");
       context.ReportErrorMessage("Second error message.");
@@ -54,7 +55,7 @@ namespace Remotion.ObjectBinding.Web.UnitTests.UI.Controls.Validation
     [Test]
     public void AppendErrorMessages_WithExistingContentInStringBuilder_AppendsNewLineAndReportedMessagesToStringBuilder ()
     {
-      var context = new ValidationFailureHandlingContext(_bocListStub.Object);
+      var context = new ValidationFailureHandlingContext(_bocListStub);
 
       context.ReportErrorMessage("First error message.");
       context.ReportErrorMessage("Second error message.");
@@ -70,7 +71,7 @@ namespace Remotion.ObjectBinding.Web.UnitTests.UI.Controls.Validation
     [Test]
     public void AppendErrorMessages_WithTrailingNewLineInStringBuilder_AppendsReportedMessagesToStringBuilder ()
     {
-      var context = new ValidationFailureHandlingContext(_bocListStub.Object);
+      var context = new ValidationFailureHandlingContext(_bocListStub);
 
       context.ReportErrorMessage("First error message.");
       context.ReportErrorMessage("Second error message.");
@@ -86,7 +87,7 @@ namespace Remotion.ObjectBinding.Web.UnitTests.UI.Controls.Validation
     [Test]
     public void AppendErrorMessage_WithMessagesAfterReporting_AppendsReportedMessagesToStringBuilder ()
     {
-      var context = new ValidationFailureHandlingContext(_bocListStub.Object);
+      var context = new ValidationFailureHandlingContext(_bocListStub);
 
       context.ReportErrorMessage("First error message.");
       context.ReportErrorMessage("Second error message.");
@@ -107,21 +108,17 @@ namespace Remotion.ObjectBinding.Web.UnitTests.UI.Controls.Validation
     [Test]
     public void BocList_ReturnsBocListSuppliedInCtor ()
     {
-      var context = new ValidationFailureHandlingContext(_bocListStub.Object);
+      var context = new ValidationFailureHandlingContext(_bocListStub);
 
-      Assert.That(context.BocList, Is.SameAs(_bocListStub.Object));
+      Assert.That(context.BocList, Is.SameAs(_bocListStub));
     }
 
     [Test]
     public void ValidationFailureRepository_ReturnsValidationFailureRepositoryOfBocList ()
     {
-      var context = new ValidationFailureHandlingContext(_bocListStub.Object);
+      var context = new ValidationFailureHandlingContext(_bocListStub);
 
-      var repository = new BocListValidationFailureRepository();
-
-      _bocListStub.Setup(_ => _.ValidationFailureRepository).Returns(repository);
-
-      Assert.That(context.ValidationFailureRepository, Is.SameAs(repository));
+      Assert.That(context.ValidationFailureRepository, Is.SameAs(_bocListStub.ValidationFailureRepository));
     }
   }
 }

--- a/Remotion/ObjectBinding/Web/Globalization/BocList.de.resx
+++ b/Remotion/ObjectBinding/Web/Globalization/BocList.de.resx
@@ -180,7 +180,10 @@
   <data name="Remotion.ObjectBinding.Web.UI.Controls.BocList.ValidationColumnTitleText" xml:space="preserve">
     <value>Meldung</value>
   </data>
-  <data name="Remotion.ObjectBinding.Web.UI.Controls.BocList.ValidationFailuresFoundInListErrorMessage" xml:space="preserve">
+  <data name="Remotion.ObjectBinding.Web.UI.Controls.BocList.UnhandledValidationFailuresFoundErrorMessage" xml:space="preserve">
     <value>Ungültige Eingabe in zumindest einer ausgeblendeten Zeile.</value>
+  </data>
+  <data name="Remotion.ObjectBinding.Web.UI.Controls.BocList.ValidationFailuresFoundInListErrorMessage" xml:space="preserve">
+    <value>Ungültige Eingabe in zumindest einer Zeile. Prüfen Sie die Zeilen auf weitere Details.</value>
   </data>
 </root>

--- a/Remotion/ObjectBinding/Web/Globalization/BocList.fr.resx
+++ b/Remotion/ObjectBinding/Web/Globalization/BocList.fr.resx
@@ -180,7 +180,10 @@
   <data name="Remotion.ObjectBinding.Web.UI.Controls.BocList.ValidationColumnTitleText" xml:space="preserve">
     <value>Message</value>
   </data>
-  <data name="Remotion.ObjectBinding.Web.UI.Controls.BocList.ValidationFailuresFoundInListErrorMessage" xml:space="preserve">
+  <data name="Remotion.ObjectBinding.Web.UI.Controls.BocList.UnhandledValidationFailuresFoundErrorMessage" xml:space="preserve">
     <value>Saisie non valable dans un moins une ligne masquée.</value>
+  </data>
+  <data name="Remotion.ObjectBinding.Web.UI.Controls.BocList.ValidationFailuresFoundInListErrorMessage" xml:space="preserve">
+    <value>Saisie non valable dans un moins une ligne. Vérifiez les lignes pour plus de détails.</value>
   </data>
 </root>

--- a/Remotion/ObjectBinding/Web/Globalization/BocList.it.resx
+++ b/Remotion/ObjectBinding/Web/Globalization/BocList.it.resx
@@ -180,7 +180,10 @@
   <data name="Remotion.ObjectBinding.Web.UI.Controls.BocList.ValidationColumnTitleText" xml:space="preserve">
     <value>Messaggio</value>
   </data>
-  <data name="Remotion.ObjectBinding.Web.UI.Controls.BocList.ValidationFailuresFoundInListErrorMessage" xml:space="preserve">
+  <data name="Remotion.ObjectBinding.Web.UI.Controls.BocList.UnhandledValidationFailuresFoundErrorMessage" xml:space="preserve">
     <value>Input non valido in almeno una riga nascosta.</value>
+  </data>
+  <data name="Remotion.ObjectBinding.Web.UI.Controls.BocList.ValidationFailuresFoundInListErrorMessage" xml:space="preserve">
+    <value>Input non valido in almeno una riga. Controlla le righe per maggiori dettagli.</value>
   </data>
 </root>

--- a/Remotion/ObjectBinding/Web/Globalization/BocList.resx
+++ b/Remotion/ObjectBinding/Web/Globalization/BocList.resx
@@ -180,7 +180,10 @@
   <data name="Remotion.ObjectBinding.Web.UI.Controls.BocList.ValidationColumnTitleText" xml:space="preserve">
     <value>Message</value>
   </data>
-  <data name="Remotion.ObjectBinding.Web.UI.Controls.BocList.ValidationFailuresFoundInListErrorMessage" xml:space="preserve">
+  <data name="Remotion.ObjectBinding.Web.UI.Controls.BocList.UnhandledValidationFailuresFoundErrorMessage" xml:space="preserve">
     <value>Invalid input in at least one hidden row.</value>
+  </data>
+  <data name="Remotion.ObjectBinding.Web.UI.Controls.BocList.ValidationFailuresFoundInListErrorMessage" xml:space="preserve">
+    <value>Invalid input in at least one row. Check the rows for more details.</value>
   </data>
 </root>

--- a/Remotion/ObjectBinding/Web/UI/Controls/BocList.cs
+++ b/Remotion/ObjectBinding/Web/UI/Controls/BocList.cs
@@ -180,6 +180,7 @@ namespace Remotion.ObjectBinding.Web.UI.Controls
       RowMenuTitle,
       ValidationFailuresFoundInOtherListPagesErrorMessage,
       ValidationColumnTitleText,
+      UnhandledValidationFailuresFoundErrorMessage,
       ValidationFailuresFoundInListErrorMessage
     }
 

--- a/Remotion/ObjectBinding/Web/UI/Controls/BocListImplementation/Validation/BocListListValidationFailureHandler.cs
+++ b/Remotion/ObjectBinding/Web/UI/Controls/BocListImplementation/Validation/BocListListValidationFailureHandler.cs
@@ -22,13 +22,12 @@ using Remotion.Utilities;
 namespace Remotion.ObjectBinding.Web.UI.Controls.BocListImplementation.Validation
 {
   /// <summary>
-  /// Handles all validation failures for the <see cref="IBusinessObjectProperty"/> of the
-  /// <see cref="IBocList"/>. Should always be the first handler to run.
+  /// Handles all validation failures for the <see cref="IBusinessObjectProperty"/> of the <see cref="IBocList"/>.
   /// </summary>
   [ImplementationFor(typeof(IBocListValidationFailureHandler), Lifetime = LifetimeKind.Singleton, RegistrationType = RegistrationType.Multiple, Position = Position)]
   public class BocListListValidationFailureHandler : IBocListValidationFailureHandler
   {
-    public const int Position = -1_000_000_000;
+    public const int Position = 1_000_000_000;
 
     public BocListListValidationFailureHandler ()
     {

--- a/Remotion/ObjectBinding/Web/UI/Controls/BocListImplementation/Validation/ValidationFailureHandlingContext.cs
+++ b/Remotion/ObjectBinding/Web/UI/Controls/BocListImplementation/Validation/ValidationFailureHandlingContext.cs
@@ -39,14 +39,39 @@ namespace Remotion.ObjectBinding.Web.UI.Controls.BocListImplementation.Validatio
     /// </summary>
     public IBocListValidationFailureRepository ValidationFailureRepository => BocList.ValidationFailureRepository;
 
-    private readonly List<string> _errorMessages;
+    /// <summary>
+    /// Returns the number of list failures currently contained in the repository at the time of the context creation.
+    /// </summary>
+    public int InitialListFailureCount { get; }
+
+    /// <summary>
+    /// Returns the number of unhandled list failures currently contained in the repository at the time of the context creation.
+    /// </summary>
+    public int InitialUnhandledListFailureCount { get; }
+
+    /// <summary>
+    /// Returns the number of row and cell failures currently contained in the repository at the time of the context creation.
+    /// </summary>
+    public int InitialRowAndCellFailureCount { get; }
+
+    /// <summary>
+    /// Returns the number of unhandled row and cell failures currently contained in the repository at the time of the context creation.
+    /// </summary>
+    public int InitialUnhandledRowAndCellFailureCount { get; }
+
+    private readonly List<string> _errorMessages = new();
 
     public ValidationFailureHandlingContext (IBocList bocList)
     {
       ArgumentUtility.CheckNotNull("bocList", bocList);
 
       BocList = bocList;
-      _errorMessages = new List<string>();
+
+      var validationFailureRepository = BocList.ValidationFailureRepository;
+      InitialListFailureCount = validationFailureRepository.GetListFailureCount();
+      InitialUnhandledListFailureCount = validationFailureRepository.GetUnhandledListFailureCount();
+      InitialRowAndCellFailureCount = validationFailureRepository.GetRowAndCellFailureCount();
+      InitialUnhandledRowAndCellFailureCount = validationFailureRepository.GetUnhandledRowAndCellFailureCount();
     }
 
     /// <summary>

--- a/Remotion/ObjectBinding/Web/UI/Controls/Validation/BocListValidationResultDispatchingValidator.cs
+++ b/Remotion/ObjectBinding/Web/UI/Controls/Validation/BocListValidationResultDispatchingValidator.cs
@@ -167,7 +167,7 @@ namespace Remotion.ObjectBinding.Web.UI.Controls.Validation
       }
       else
       {
-        ErrorMessage = GetControlToValidate().GetResourceManager().GetString(BocList.ResourceIdentifier.ValidationFailuresFoundInListErrorMessage);
+        ErrorMessage = GetControlToValidate().GetResourceManager().GetString(BocList.ResourceIdentifier.UnhandledValidationFailuresFoundErrorMessage);
         return false;
       }
     }
@@ -263,7 +263,7 @@ namespace Remotion.ObjectBinding.Web.UI.Controls.Validation
 
       if (bocList.ValidationFailureRepository.GetUnhandledValidationFailuresForBocListAndContainingDataRowsAndDataCells(true).Any() || errorMessageBuilder.Length == 0)
       {
-        errorMessageBuilder.Append(bocList.GetResourceManager().GetString(BocList.ResourceIdentifier.ValidationFailuresFoundInListErrorMessage));
+        errorMessageBuilder.Append(bocList.GetResourceManager().GetString(BocList.ResourceIdentifier.UnhandledValidationFailuresFoundErrorMessage));
       }
 
       ErrorMessage = errorMessageBuilder.ToString();

--- a/Remotion/ObjectBinding/Web/UI/Controls/Validation/IBocListValidationFailureRepository.cs
+++ b/Remotion/ObjectBinding/Web/UI/Controls/Validation/IBocListValidationFailureRepository.cs
@@ -32,6 +32,26 @@ namespace Remotion.ObjectBinding.Web.UI.Controls.Validation
     public event EventHandler? ValidationFailureAdded;
 
     /// <summary>
+    /// Gets the number of list failures currently contained in the repository.
+    /// </summary>
+    public int GetListFailureCount ();
+
+    /// <summary>
+    /// Gets the number of unhandled list failures currently contained in the repository.
+    /// </summary>
+    public int GetUnhandledListFailureCount ();
+
+    /// <summary>
+    /// Gets the number of row and cell failures currently contained in the repository.
+    /// </summary>
+    public int GetRowAndCellFailureCount ();
+
+    /// <summary>
+    /// Gets the number of unhandled row and cell failures currently contained in the repository.
+    /// </summary>
+    public int GetUnhandledRowAndCellFailureCount ();
+
+    /// <summary>
     /// Adds <see cref="BusinessObjectValidationFailure"/>s that belong to the <see cref="BocList"/> as a whole.
     /// </summary>
     public void AddValidationFailuresForBocList (IEnumerable<BusinessObjectValidationFailure> validationFailures);
@@ -75,6 +95,14 @@ namespace Remotion.ObjectBinding.Web.UI.Controls.Validation
     /// <param name="markAsHandled">If set to true, validation failures will not be returned again by any of the <c>GetUnhandled*</c> methods of this repository.</param>
     /// <returns><see cref="BusinessObjectValidationFailure"/>s wrapped with positional information inside <see cref="BocListValidationFailureWithLocationInformation"/>s.</returns>
     public IReadOnlyCollection<BocListValidationFailureWithLocationInformation> GetUnhandledValidationFailuresForDataRow (IBusinessObject rowObject, bool markAsHandled);
+
+    /// <summary>
+    /// Returns a collection of all unhandled <see cref="BusinessObjectValidationFailure"/>s that exist for all rows
+    /// and any of the (nested) property values associated with this <see cref="BocList"/> row.
+    /// </summary>
+    /// <param name="markAsHandled">If set to true, validation failures will not be returned again by any of the <c>GetUnhandled*</c> methods of this repository.</param>
+    /// <returns><see cref="BusinessObjectValidationFailure"/>s wrapped with positional information inside <see cref="BocListValidationFailureWithLocationInformation"/>s.</returns>
+    public IReadOnlyCollection<BocListValidationFailureWithLocationInformation> GetUnhandledValidationFailuresForDataRowsAndContainingDataCells (bool markAsHandled);
 
     /// <summary>
     /// Returns a collection of all unhandled <see cref="BusinessObjectValidationFailure"/>s that exist for the <paramref name="rowObject"/> itself


### PR DESCRIPTION
https://re-motion.atlassian.net/browse/RM-8912

@MichaelKetting Martin mentioned that he would prefer no error message to be displayed if all validation errors are already displayed inline in the BocList. The alternative solution would be to replace the error message with better description of "Look at the rows for errors". I prefer this solution over replacing the localization as it feel user friendlier. 

You can test the behavior on the ObjectBinding.Web.Test site using the new drop down menu to select row/cell failures and use the page navigation to switch between pages.