### PR TITLE
Feature/rm 8918 upgrade ms dependencies v4.10

### DIFF
--- a/Build/ProjectTypes/Test.props
+++ b/Build/ProjectTypes/Test.props
@@ -12,7 +12,7 @@
 
   <ItemGroup>
     <PackageReference Include="JetBrains.Annotations" Version="2022.1.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.1" />
     <PackageReference Include="Moq" Version="4.16.1" PrivateAssets="all" />
     <PackageReference Include="Moq.VerifiableSequence" Version="4.16.1.2" PrivateAssets="all" />
     <PackageReference Include="NUnit" Version="3.13.3" PrivateAssets="all" />

--- a/Build/ProjectTypes/WebApplication.props
+++ b/Build/ProjectTypes/WebApplication.props
@@ -15,7 +15,7 @@
     <PackageReference Include="CoreForms.Web.Infrastructure.MachineConfig" Version="6.0.0" />
     <PackageReference Include="CoreForms.Web.Infrastructure.Roslyn" Version="6.0.0" />
     <PackageReference Include="CoreForms.Web.Infrastructure" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Net.Compilers.Toolset" Version="3.10.0" ExcludeAssets="all" GeneratePathProperty="true" />
+    <PackageReference Include="Microsoft.Net.Compilers.Toolset" Version="4.3.1" ExcludeAssets="all" GeneratePathProperty="true" />
   </ItemGroup>
 
 </Project>

--- a/Remotion/ObjectBinding/Web.Development.WebTesting.TestSite.NetFramework/ObjectBinding.Web.Development.WebTesting.TestSite.NetFramework.csproj
+++ b/Remotion/ObjectBinding/Web.Development.WebTesting.TestSite.NetFramework/ObjectBinding.Web.Development.WebTesting.TestSite.NetFramework.csproj
@@ -59,8 +59,8 @@
     <Reference Include="log4net, Version=2.0.15.0, Culture=neutral, PublicKeyToken=669e0ddf0bb1aa2a, processorArchitecture=MSIL">
       <HintPath>..\..\..\packages\log4net.2.0.15\lib\net45\log4net.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Bcl.AsyncInterfaces, Version=6.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\Microsoft.Bcl.AsyncInterfaces.6.0.0\lib\net461\Microsoft.Bcl.AsyncInterfaces.dll</HintPath>
+    <Reference Include="Microsoft.Bcl.AsyncInterfaces, Version=7.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Microsoft.Bcl.AsyncInterfaces.7.0.0\lib\net462\Microsoft.Bcl.AsyncInterfaces.dll</HintPath>
     </Reference>
     <Reference Include="mscorlib" />
     <Reference Include="System" />
@@ -81,11 +81,11 @@
     <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\..\..\packages\System.Runtime.CompilerServices.Unsafe.6.0.0\lib\net461\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
     </Reference>
-    <Reference Include="System.Text.Encodings.Web, Version=6.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\System.Text.Encodings.Web.6.0.0\lib\net461\System.Text.Encodings.Web.dll</HintPath>
+    <Reference Include="System.Text.Encodings.Web, Version=7.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\System.Text.Encodings.Web.7.0.0\lib\net462\System.Text.Encodings.Web.dll</HintPath>
     </Reference>
-    <Reference Include="System.Text.Json, Version=6.0.0.7, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\System.Text.Json.6.0.7\lib\net461\System.Text.Json.dll</HintPath>
+    <Reference Include="System.Text.Json, Version=7.0.0.3, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\System.Text.Json.7.0.3\lib\net462\System.Text.Json.dll</HintPath>
     </Reference>
     <Reference Include="System.Threading.Tasks.Extensions, Version=4.2.0.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51">
       <HintPath>..\..\..\packages\System.Threading.Tasks.Extensions.4.5.4\lib\net461\System.Threading.Tasks.Extensions.dll</HintPath>

--- a/Remotion/ObjectBinding/Web.Development.WebTesting.TestSite.NetFramework/packages.config
+++ b/Remotion/ObjectBinding/Web.Development.WebTesting.TestSite.NetFramework/packages.config
@@ -3,14 +3,14 @@
   <package id="CommonServiceLocator" version="2.0.6" targetFramework="net48" />
   <package id="JetBrains.Annotations" version="2022.1.0" targetFramework="net48" />
   <package id="log4net" version="2.0.15" targetFramework="net48" />
-  <package id="Microsoft.Bcl.AsyncInterfaces" version="6.0.0" targetFramework="net48" />
+  <package id="Microsoft.Bcl.AsyncInterfaces" version="7.0.0" targetFramework="net48" />
   <package id="Remotion.Infrastructure.Styles.Analyzer" version="1.1.3" targetFramework="net48" developmentDependency="true" />
   <package id="System.Buffers" version="4.5.1" targetFramework="net48" />
   <package id="System.Memory" version="4.5.5" targetFramework="net48" />
   <package id="System.Numerics.Vectors" version="4.5.0" targetFramework="net48" />
   <package id="System.Runtime.CompilerServices.Unsafe" version="6.0.0" targetFramework="net48" />
-  <package id="System.Text.Encodings.Web" version="6.0.0" targetFramework="net48" />
-  <package id="System.Text.Json" version="6.0.7" targetFramework="net48" />
+  <package id="System.Text.Encodings.Web" version="7.0.0" targetFramework="net48" />
+  <package id="System.Text.Json" version="7.0.3" targetFramework="net48" />
   <package id="System.Threading.Tasks.Extensions" version="4.5.4" targetFramework="net48" />
   <package id="System.ValueTuple" version="4.5.0" targetFramework="net48" />
 </packages>

--- a/Remotion/Web/Development.WebTesting.IntegrationTests.Infrastructure/Web.Development.WebTesting.IntegrationTests.Infrastructure.csproj
+++ b/Remotion/Web/Development.WebTesting.IntegrationTests.Infrastructure/Web.Development.WebTesting.IntegrationTests.Infrastructure.csproj
@@ -16,7 +16,7 @@
     <ProjectReference Include="..\..\Web\Development.WebTesting\Web.Development.WebTesting.csproj" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net48'">
-    <PackageReference Include="System.Text.Json" Version="6.0.7" />
+    <PackageReference Include="System.Text.Json" Version="7.0.3" />
   </ItemGroup>
   <Import Project="..\..\..\Build\Shared.build.targets" />
 </Project>

--- a/Remotion/Web/Development.WebTesting.TestSite.Infrastructure/Web.Development.WebTesting.TestSite.Infrastructure.csproj
+++ b/Remotion/Web/Development.WebTesting.TestSite.Infrastructure/Web.Development.WebTesting.TestSite.Infrastructure.csproj
@@ -25,7 +25,7 @@
     <ProjectReference Include="..\Core\Web.Core.csproj" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net48'">
-    <PackageReference Include="System.Text.Json" Version="6.0.7" />
+    <PackageReference Include="System.Text.Json" Version="7.0.3" />
   </ItemGroup>
   <Import Project="..\..\..\Build\Shared.build.targets" />
 </Project>

--- a/Remotion/Web/Development.WebTesting.TestSite.NetFramework/Web.Development.WebTesting.TestSite.NetFramework.csproj
+++ b/Remotion/Web/Development.WebTesting.TestSite.NetFramework/Web.Development.WebTesting.TestSite.NetFramework.csproj
@@ -56,8 +56,8 @@
     <Reference Include="log4net, Version=2.0.15.0, Culture=neutral, PublicKeyToken=669e0ddf0bb1aa2a, processorArchitecture=MSIL">
       <HintPath>..\..\..\packages\log4net.2.0.15\lib\net45\log4net.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Bcl.AsyncInterfaces, Version=6.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\Microsoft.Bcl.AsyncInterfaces.6.0.0\lib\net461\Microsoft.Bcl.AsyncInterfaces.dll</HintPath>
+    <Reference Include="Microsoft.Bcl.AsyncInterfaces, Version=7.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Microsoft.Bcl.AsyncInterfaces.7.0.0\lib\net462\Microsoft.Bcl.AsyncInterfaces.dll</HintPath>
     </Reference>
     <Reference Include="mscorlib" />
     <Reference Include="System" />
@@ -80,11 +80,11 @@
     <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\..\..\packages\System.Runtime.CompilerServices.Unsafe.6.0.0\lib\net461\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
     </Reference>
-    <Reference Include="System.Text.Encodings.Web, Version=6.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\System.Text.Encodings.Web.6.0.0\lib\net461\System.Text.Encodings.Web.dll</HintPath>
+    <Reference Include="System.Text.Encodings.Web, Version=7.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\System.Text.Encodings.Web.7.0.0\lib\net462\System.Text.Encodings.Web.dll</HintPath>
     </Reference>
-    <Reference Include="System.Text.Json, Version=6.0.0.7, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\System.Text.Json.6.0.7\lib\net461\System.Text.Json.dll</HintPath>
+    <Reference Include="System.Text.Json, Version=7.0.0.3, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\System.Text.Json.7.0.3\lib\net462\System.Text.Json.dll</HintPath>
     </Reference>
     <Reference Include="System.Threading.Tasks.Extensions, Version=4.2.0.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51">
       <HintPath>..\..\..\packages\System.Threading.Tasks.Extensions.4.5.4\lib\net461\System.Threading.Tasks.Extensions.dll</HintPath>

--- a/Remotion/Web/Development.WebTesting.TestSite.NetFramework/packages.config
+++ b/Remotion/Web/Development.WebTesting.TestSite.NetFramework/packages.config
@@ -3,14 +3,14 @@
   <package id="CommonServiceLocator" version="2.0.6" targetFramework="net48" />
   <package id="JetBrains.Annotations" version="2022.1.0" targetFramework="net48" />
   <package id="log4net" version="2.0.15" targetFramework="net48" />
-  <package id="Microsoft.Bcl.AsyncInterfaces" version="6.0.0" targetFramework="net48" />
+  <package id="Microsoft.Bcl.AsyncInterfaces" version="7.0.0" targetFramework="net48" />
   <package id="Remotion.Infrastructure.Styles.Analyzer" version="1.1.3" targetFramework="net48" developmentDependency="true" />
   <package id="System.Buffers" version="4.5.1" targetFramework="net48" />
   <package id="System.Memory" version="4.5.5" targetFramework="net48" />
   <package id="System.Numerics.Vectors" version="4.5.0" targetFramework="net48" />
   <package id="System.Runtime.CompilerServices.Unsafe" version="6.0.0" targetFramework="net48" />
-  <package id="System.Text.Encodings.Web" version="6.0.0" targetFramework="net48" />
-  <package id="System.Text.Json" version="6.0.7" targetFramework="net48" />
+  <package id="System.Text.Encodings.Web" version="7.0.0" targetFramework="net48" />
+  <package id="System.Text.Json" version="7.0.3" targetFramework="net48" />
   <package id="System.Threading.Tasks.Extensions" version="4.5.4" targetFramework="net48" />
   <package id="System.ValueTuple" version="4.5.0" targetFramework="net48" />
 </packages>


### PR DESCRIPTION
Is to be merged after nunit upgrade on hotfix v4.10, thats why those other commits are currently there. This way we can have a mergequeue which still has to be merged manually, but at least I don't have to wait between merges for CI builds. (Only works if noone else wants to merge things onto hotfix v4.10)

https://re-motion.atlassian.net/browse/RM-8918