### PR TITLE
feature/RM-8925-Add-support-for-NET-7-to-Roslyn-Analyzer-Tests-v4.10

### DIFF
--- a/Build/ProjectTypes/Analyzer.props
+++ b/Build/ProjectTypes/Analyzer.props
@@ -1,9 +1,6 @@
 ﻿<Project>
   <PropertyGroup>
-    <!-- Analyzers do not support .NET 7.0 when using Toolset before v4.7.0. First available toolset with .NET 7.0 support is MSBuild 1.17.7.
-         https://learn.microsoft.com/en-us/visualstudio/extensibility/roslyn-version-support?view=vs-2022
-    -->
-    <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net6.0;net7.0</TargetFrameworks>
 <!--Langversion 9 is required for compatibility with netstandard2.0 -->
     <LangVersion>9</LangVersion>
     <Nullable>enable</Nullable>

--- a/Remotion/Core/Development.Analyzers.IntegrationTests/CSharpAnalyzerVerifier.cs
+++ b/Remotion/Core/Development.Analyzers.IntegrationTests/CSharpAnalyzerVerifier.cs
@@ -15,6 +15,9 @@
 // along with re-motion; if not, see http://www.gnu.org/licenses.
 //
 using System;
+using System.IO;
+using System.Reflection;
+using System.Runtime.Versioning;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Testing;
@@ -33,6 +36,9 @@ namespace Remotion.Core.Development.Analyzers.IntegrationTests
     {
     }
 
+    private static readonly Lazy<ReferenceAssemblies> s_net70 =
+        new(() => new ReferenceAssemblies("net7.0", new PackageIdentity("Microsoft.NETCore.App.Ref", "7.0.0"), Path.Combine("ref", "net7.0")));
+
     public static DiagnosticResult Diagnostic (DiagnosticDescriptor desc) => AnalyzerVerifier<TAnalyzer>.Diagnostic(desc);
 
     public static Task VerifyAnalyzerAsync (string source, bool withSafeContextReference, params DiagnosticResult[] expected )
@@ -42,7 +48,7 @@ namespace Remotion.Core.Development.Analyzers.IntegrationTests
       var test = new Test
                  {
                      TestCode = source,
-                     ReferenceAssemblies = ReferenceAssemblies.Net.Net60,
+                     ReferenceAssemblies = GetReferenceAssemblies(typeof(SafeContext).Assembly),
                      SolutionTransforms =
                      {
                          (solution, id) =>
@@ -60,6 +66,16 @@ namespace Remotion.Core.Development.Analyzers.IntegrationTests
       test.ExpectedDiagnostics.AddRange(expected);
 
       return test.RunAsync();
+    }
+
+    private static ReferenceAssemblies GetReferenceAssemblies (Assembly assembly)
+    {
+      return assembly.GetCustomAttribute<TargetFrameworkAttribute>()!.FrameworkName switch
+      {
+          ".NETCoreApp,Version=v6.0" => ReferenceAssemblies.Net.Net60,
+          ".NETCoreApp,Version=v7.0" => s_net70.Value,
+          var frameworkName => throw new NotSupportedException($"'{frameworkName}' is not supported.")
+      };
     }
   }
 }

--- a/Remotion/Core/Development.Analyzers.IntegrationTests/RMCORE0001_SafeContextAnalyzerTests.cs
+++ b/Remotion/Core/Development.Analyzers.IntegrationTests/RMCORE0001_SafeContextAnalyzerTests.cs
@@ -1,15 +1,11 @@
 ﻿using System;
 using System.Threading.Tasks;
-using Core.Development.Analyzers;
 using NUnit.Framework;
 using Verifier = Remotion.Core.Development.Analyzers.IntegrationTests.CSharpAnalyzerVerifier<Core.Development.Analyzers.RMCORE0001_SafeContextAnalyzer>;
 using Analyzer = Core.Development.Analyzers.RMCORE0001_SafeContextAnalyzer;
 
 namespace Remotion.Core.Development.Analyzers.IntegrationTests
 {
-#if NET7_0
-  [Ignore("MSBuild Tools v4.7.0 or higher are required for testing Roslyn Analyzers in .NET 7.")]
-#endif  
   [TestFixture]
   public class RMCORE0001_SafeContextAnalyzerTests
   {

--- a/Remotion/Web/Development.Analyzers.IntegrationTests/CSharpAnalyzerVerifier.cs
+++ b/Remotion/Web/Development.Analyzers.IntegrationTests/CSharpAnalyzerVerifier.cs
@@ -15,6 +15,9 @@
 // along with re-motion; if not, see http://www.gnu.org/licenses.
 //
 using System;
+using System.IO;
+using System.Reflection;
+using System.Runtime.Versioning;
 using System.Threading.Tasks;
 using System.Web.UI;
 using Microsoft.CodeAnalysis;
@@ -33,6 +36,9 @@ namespace Remotion.Web.Development.Analyzers.IntegrationTests
     {
     }
 
+    private static readonly Lazy<ReferenceAssemblies> s_net70 =
+        new(() => new ReferenceAssemblies("net7.0", new PackageIdentity("Microsoft.NETCore.App.Ref", "7.0.0"), Path.Combine("ref", "net7.0")));
+
     public static DiagnosticResult Diagnostic () => AnalyzerVerifier<TAnalyzer>.Diagnostic();
 
     public static Task VerifyAnalyzerAsync (string source, params DiagnosticResult[] expected)
@@ -43,7 +49,7 @@ namespace Remotion.Web.Development.Analyzers.IntegrationTests
       var test = new Test
                  {
                      TestCode = source,
-                     ReferenceAssemblies = ReferenceAssemblies.Net.Net60,
+                     ReferenceAssemblies = GetReferenceAssemblies(typeof(WebString).Assembly),
                      SolutionTransforms = { (solution, id) =>
                      {
                        var project = solution.GetProject(id);
@@ -56,6 +62,16 @@ namespace Remotion.Web.Development.Analyzers.IntegrationTests
       test.ExpectedDiagnostics.AddRange(expected);
 
       return test.RunAsync();
+    }
+
+    private static ReferenceAssemblies GetReferenceAssemblies (Assembly assembly)
+    {
+      return assembly.GetCustomAttribute<TargetFrameworkAttribute>()!.FrameworkName switch
+      {
+          ".NETCoreApp,Version=v6.0" => ReferenceAssemblies.Net.Net60,
+          ".NETCoreApp,Version=v7.0" => s_net70.Value,
+          var frameworkName => throw new NotSupportedException($"'{frameworkName}' is not supported.")
+      };
     }
   }
 }

--- a/Remotion/Web/Development.Analyzers.IntegrationTests/RMWEB0001_WebStringAnalyzerTests.cs
+++ b/Remotion/Web/Development.Analyzers.IntegrationTests/RMWEB0001_WebStringAnalyzerTests.cs
@@ -21,9 +21,6 @@ using Verifier = Remotion.Web.Development.Analyzers.IntegrationTests.CSharpAnaly
 
 namespace Remotion.Web.Development.Analyzers.IntegrationTests
 {
-#if NET7_0
-  [Ignore("MSBuild Tools v4.7.0 or higher are required for testing Roslyn Analyzers in .NET 7.")]
-#endif  
   [TestFixture]
   public class RMWEB0001_WebStringAnalyzerTests
   {


### PR DESCRIPTION
https://re-motion.atlassian.net/browse/RM-8925