### PR TITLE
Feature/rm 8945 boc list content width does not match column width for inline editing v5.0

### DIFF
--- a/Remotion/ObjectBinding/Web.Test/IndividualControlTests/BocListAsGridUserControl.ascx
+++ b/Remotion/ObjectBinding/Web.Test/IndividualControlTests/BocListAsGridUserControl.ascx
@@ -55,7 +55,7 @@
 <remotion:BocListItemCommand Type="None"></remotion:BocListItemCommand>
 </PersistedCommand>
 </remotion:BocCompoundColumnDefinition>
-<remotion:BocSimpleColumnDefinition PropertyPathIdentifier="Partner" Width="7em" ColumnTitle="Partner">
+<remotion:BocSimpleColumnDefinition PropertyPathIdentifier="Partner" Width="20em" ColumnTitle="Partner">
 <persistedcommand>
 <remotion:BocListItemCommand Type="None"></remotion:BocListItemCommand>
 </PersistedCommand>

--- a/Remotion/ObjectBinding/Web/Res/Themes/NovaViso/HTML/BocList.css
+++ b/Remotion/ObjectBinding/Web/Res/Themes/NovaViso/HTML/BocList.css
@@ -162,6 +162,13 @@ div.bocList table.bocListTable td.bocListDataCell *.bocListCellStructureElement 
   display: flex;
   align-items: center;
   box-sizing: border-box;  padding: calc(var(--remotion-themed-spacing) / 2) var(--remotion-themed-spacing);
+  width: 100%;
+}
+
+div.bocList table.bocListTable td.bocListDataCell > div.bocListContent > div[onclick],
+div.bocList table.bocListTable td.bocListDataCell *.bocListCellStructureElement > div.bocListContent > div[onclick]
+{
+  width: inherit;
 }
 
 div.bocList table.bocListTable td.bocListTitleCell.bocListTitleCellAllRowsSelector > span,


### PR DESCRIPTION
feature/RM-8945-BocList-content-width-does-not-match-column-width-for-inline-editing-v5.0