### PR TITLE
feature/RM-8903-Optimize-iteration-on-ClientTransactionExtensionCollection

### DIFF
--- a/Remotion/Data/DomainObjects.UnitTests/ClientTransactionExtensionCollectionTest.cs
+++ b/Remotion/Data/DomainObjects.UnitTests/ClientTransactionExtensionCollectionTest.cs
@@ -15,6 +15,7 @@
 // along with re-motion; if not, see http://www.gnu.org/licenses.
 // 
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Diagnostics;
@@ -70,6 +71,39 @@ namespace Remotion.Data.DomainObjects.UnitTests
     }
 
     [Test]
+    public void GetEnumerator_IEnumerableGeneric ()
+    {
+      _collection.Add(_extension1.Object);
+      _collection.Add(_extension2.Object);
+
+      using IEnumerator<IClientTransactionExtension> enumerator = ((IEnumerable<IClientTransactionExtension>)_collection).GetEnumerator();
+
+      Assert.That(enumerator.Current, Is.Null);
+      Assert.That(enumerator.MoveNext(), Is.True);
+      Assert.That(enumerator.Current, Is.EqualTo(_extension1.Object));
+      Assert.That(enumerator.MoveNext(), Is.True);
+      Assert.That(enumerator.Current, Is.EqualTo(_extension2.Object));
+      Assert.That(enumerator.MoveNext(), Is.False);
+    }
+
+    [Test]
+    public void GetEnumerator_ForIEnumerable ()
+    {
+      _collection.Add(_extension1.Object);
+      _collection.Add(_extension2.Object);
+
+      // ReSharper disable once NotDisposedResource
+      IEnumerator enumerator = ((IEnumerable)_collection).GetEnumerator();
+
+      Assert.That(enumerator.Current, Is.Null);
+      Assert.That(enumerator.MoveNext(), Is.True);
+      Assert.That(enumerator.Current, Is.EqualTo(_extension1.Object));
+      Assert.That(enumerator.MoveNext(), Is.True);
+      Assert.That(enumerator.Current, Is.EqualTo(_extension2.Object));
+      Assert.That(enumerator.MoveNext(), Is.False);
+    }
+
+    [Test]
     public void Add ()
     {
       Assert.That(_collection.Count, Is.EqualTo(0));
@@ -95,10 +129,11 @@ namespace Remotion.Data.DomainObjects.UnitTests
     [Test]
     public void Remove ()
     {
+      _collection.Add(_extension2.Object);
       _collection.Add(_extension1.Object);
-      Assert.That(_collection.Count, Is.EqualTo(1));
+      Assert.That(_collection.Count, Is.EqualTo(2));
       _collection.Remove(_extension1.Object.Key);
-      Assert.That(_collection.Count, Is.EqualTo(0));
+      Assert.That(_collection.Count, Is.EqualTo(1));
       _collection.Remove(_extension1.Object.Key);
       //expectation: no exception
     }
@@ -113,12 +148,13 @@ namespace Remotion.Data.DomainObjects.UnitTests
     }
 
     [Test]
-    public void IndexerWithName ()
+    public void IndexerWithKey ()
     {
       _collection.Add(_extension1.Object);
       _collection.Add(_extension2.Object);
       Assert.That(_collection[_extension1.Object.Key], Is.SameAs(_extension1.Object));
       Assert.That(_collection[_extension2.Object.Key], Is.SameAs(_extension2.Object));
+      Assert.That(_collection["unknown"], Is.Null);
     }
 
     [Test]
@@ -144,7 +180,7 @@ namespace Remotion.Data.DomainObjects.UnitTests
     }
 
     [Test]
-    public void InsertWithDuplicateName ()
+    public void InsertWithDuplicateKey ()
     {
       _collection.Insert(0, _extension1.Object);
 

--- a/Remotion/Data/DomainObjects/ClientTransactionExtensionCollection.cs
+++ b/Remotion/Data/DomainObjects/ClientTransactionExtensionCollection.cs
@@ -212,6 +212,7 @@ namespace Remotion.Data.DomainObjects
         this[i].ObjectsLoaded(clientTransaction, loadedDomainObjects);
     }
 
+    [EditorBrowsable(EditorBrowsableState.Never)]
     public void ObjectsUnloading (ClientTransaction clientTransaction, IReadOnlyList<DomainObject> unloadedDomainObjects)
     {
       ArgumentUtility.DebugCheckNotNull("unloadedDomainObjects", unloadedDomainObjects);
@@ -220,6 +221,7 @@ namespace Remotion.Data.DomainObjects
         this[i].ObjectsUnloading(clientTransaction, unloadedDomainObjects);
     }
 
+    [EditorBrowsable(EditorBrowsableState.Never)]
     public void ObjectsUnloaded (ClientTransaction clientTransaction, IReadOnlyList<DomainObject> unloadedDomainObjects)
     {
       ArgumentUtility.DebugCheckNotNull("unloadedDomainObjects", unloadedDomainObjects);

--- a/Remotion/Data/DomainObjects/ClientTransactionExtensionCollection.cs
+++ b/Remotion/Data/DomainObjects/ClientTransactionExtensionCollection.cs
@@ -15,6 +15,7 @@
 // along with re-motion; if not, see http://www.gnu.org/licenses.
 // 
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
@@ -30,9 +31,10 @@ namespace Remotion.Data.DomainObjects
   /// A collection of <see cref="IClientTransactionExtension"/>s.
   /// </summary>
   [Serializable]
-  public class ClientTransactionExtensionCollection : CommonCollection, IClientTransactionExtension
+  public class ClientTransactionExtensionCollection : IClientTransactionExtension, IReadOnlyList<IClientTransactionExtension>
   {
     private readonly string _key;
+    private readonly List<KeyValuePair<string, IClientTransactionExtension>> _extensions = new();
 
     public ClientTransactionExtensionCollection (string key)
     {
@@ -53,7 +55,7 @@ namespace Remotion.Data.DomainObjects
       {
         ArgumentUtility.CheckNotNullOrEmpty("key", key);
 
-        return (IClientTransactionExtension?)BaseGetObject(key);
+        return _extensions.FirstOrDefault(e => KeyPredicate(e, key)).Value;
       }
     }
 
@@ -64,7 +66,7 @@ namespace Remotion.Data.DomainObjects
     /// <returns>The <see cref="IClientTransactionExtension"/> of the given <paramref name="index"/>.</returns>
     public IClientTransactionExtension this[int index]
     {
-      get { return (IClientTransactionExtension)BaseGetObject(index); }
+      get { return _extensions[index].Value; }
     }
 
     string IClientTransactionExtension.Key
@@ -86,10 +88,10 @@ namespace Remotion.Data.DomainObjects
       var key = clientTransactionExtension.Key;
       Assertion.IsNotNull(key, "IClientTransactionExtension.Key must not return null");
 
-      if (BaseContainsKey(key))
+      if (_extensions.Any(e => KeyPredicate(e, key)))
         throw new InvalidOperationException(string.Format("An extension with key '{0}' is already part of the collection.", key));
 
-      BaseAdd(key, clientTransactionExtension);
+      _extensions.Add(new KeyValuePair<string, IClientTransactionExtension>(key, clientTransactionExtension));
     }
 
     /// <summary>
@@ -100,7 +102,7 @@ namespace Remotion.Data.DomainObjects
     {
       ArgumentUtility.CheckNotNullOrEmpty("key", key);
 
-      BaseRemove(key);
+      _extensions.RemoveAll(e => KeyPredicate(e, key));
     }
 
     /// <summary>
@@ -112,7 +114,7 @@ namespace Remotion.Data.DomainObjects
     {
       ArgumentUtility.CheckNotNullOrEmpty("key", key);
 
-      return BaseIndexOfKey(key);
+      return _extensions.FindIndex(e => KeyPredicate(e, key));
     }
 
     /// <summary>
@@ -130,11 +132,19 @@ namespace Remotion.Data.DomainObjects
       var key = clientTransactionExtension.Key;
       Assertion.IsNotNull(key, "IClientTransactionExtension.Key must not return null");
 
-      if (BaseContainsKey(key))
+      if (_extensions.Any(e => KeyPredicate(e, key)))
         throw new InvalidOperationException(string.Format("An extension with key '{0}' is already part of the collection.", key));
 
-      BaseInsert(index, key, clientTransactionExtension);
+      _extensions.Insert(index, new KeyValuePair<string, IClientTransactionExtension>(key, clientTransactionExtension));
     }
+
+    IEnumerator<IClientTransactionExtension> IEnumerable<IClientTransactionExtension>.GetEnumerator () => _extensions.Select(e => e.Value).GetEnumerator();
+
+    IEnumerator IEnumerable.GetEnumerator () => ((IEnumerable<IClientTransactionExtension>)this).GetEnumerator();
+
+    public int Count => _extensions.Count;
+
+    private static bool KeyPredicate (KeyValuePair<string, IClientTransactionExtension> extension, string key) => string.Equals(extension.Key, key, StringComparison.Ordinal);
 
     #region Notification methods
 


### PR DESCRIPTION
https://re-motion.atlassian.net/browse/RM-8903

Design notes:
Split ClientTransactionExtensionCollection into ClientTransactionExtensionCollection and CompundClientTransactionExtension, similiar to CompoundClientTransactionListener. The ClientTransactionExtensionCollection then no longer exposes the IClientTransactionExtension interface and thus prevents non-infrastructure code from triggering the events, which would be cosnidered incorrect API usage anyway (see the EditorBrowsableNeverAttribute currently applied to the interface memberes). The collection API is still exposed via the ClientTransaction.Extensions property to allow registering/removing of IClientTransactionExtension implementations. Possibly, a new name (e.g. ClientTransactionExtensionRegistry would be best.