### PR TITLE
Feature/rm 8939 boc list validation marker column should only be shown if there are validation errors

### DIFF
--- a/Remotion/ObjectBinding/Web.UnitTests/UI/Controls/BocListImplementation/Rendering/BocColumnRendererArrayBuilderTest.cs
+++ b/Remotion/ObjectBinding/Web.UnitTests/UI/Controls/BocListImplementation/Rendering/BocColumnRendererArrayBuilderTest.cs
@@ -21,7 +21,9 @@ using Moq;
 using NUnit.Framework;
 using Remotion.Development.UnitTesting;
 using Remotion.ObjectBinding.Web.UI.Controls;
+using Remotion.ObjectBinding.Web.UI.Controls.BocListImplementation;
 using Remotion.ObjectBinding.Web.UI.Controls.BocListImplementation.Rendering;
+using Remotion.ObjectBinding.Web.UI.Controls.Validation;
 using Remotion.ServiceLocation;
 using Remotion.Web.UI;
 
@@ -54,6 +56,227 @@ namespace Remotion.ObjectBinding.Web.UnitTests.UI.Controls.BocListImplementation
       Assert.That(bocColumnRenderers.Length, Is.EqualTo(1));
       Assert.That(PrivateInvoke.GetNonPublicField(bocColumnRenderers[0], "_columnRenderer"), Is.TypeOf(typeof(StubColumnRenderer)));
       Assert.That(bocColumnRenderers[0].ColumnDefinition, Is.SameAs(_stubColumnDefinition));
+      Assert.That(bocColumnRenderers[0].ColumnIndex, Is.EqualTo(0));
+    }
+
+    [Test]
+    public void GetColumnRenderers_WithBocValidationErrorIndicatorColumnDefinition_AlwaysVisibility_WithoutFailures_ContainsNullColumnRenderer ()
+    {
+      var bocListStub = new Mock<IBocList>();
+      bocListStub.Setup(_ => _.ValidationFailureRepository).Returns(new Mock<IBocListValidationFailureRepository>().Object);
+
+      var validationErrorColumn = new BocValidationErrorIndicatorColumnDefinition
+                                  {
+                                    OwnerControl = bocListStub.Object,
+                                    Visibility = BocValidationErrorIndicatorColumnDefinitionVisibility.Always
+                                  };
+
+      var builder = new BocColumnRendererArrayBuilder(CreateColumnCollection(validationErrorColumn), _serviceLocator, _wcagHelperStub.Object);
+
+      var bocColumnRenderers = builder.CreateColumnRenderers();
+
+      Assert.That(bocColumnRenderers.Length, Is.EqualTo(1));
+      Assert.That(PrivateInvoke.GetNonPublicField(bocColumnRenderers[0], "_columnRenderer"), Is.TypeOf(typeof(BocValidationErrorIndicatorColumnRenderer)));
+      Assert.That(bocColumnRenderers[0].ColumnDefinition, Is.SameAs(validationErrorColumn));
+      Assert.That(bocColumnRenderers[0].ColumnIndex, Is.EqualTo(0));
+    }
+
+    [Test]
+    public void GetColumnRenderers_WithBocValidationErrorIndicatorColumnDefinition_AlwaysVisibility_WithListFailures_ContainsValidationErrorColumnRenderer ()
+    {
+      var validationRepositoryStub = new Mock<IBocListValidationFailureRepository>();
+      validationRepositoryStub.Setup(_ => _.GetListFailureCount()).Returns(1);
+
+      var bocListStub = new Mock<IBocList>();
+      bocListStub.Setup(_ => _.ValidationFailureRepository).Returns(validationRepositoryStub.Object);
+
+      var validationErrorColumn = new BocValidationErrorIndicatorColumnDefinition
+                                  {
+                                    OwnerControl = bocListStub.Object,
+                                    Visibility = BocValidationErrorIndicatorColumnDefinitionVisibility.Always
+                                  };
+
+      var builder = new BocColumnRendererArrayBuilder(CreateColumnCollection(validationErrorColumn), _serviceLocator, _wcagHelperStub.Object);
+
+      var bocColumnRenderers = builder.CreateColumnRenderers();
+
+      Assert.That(bocColumnRenderers.Length, Is.EqualTo(1));
+      Assert.That(PrivateInvoke.GetNonPublicField(bocColumnRenderers[0], "_columnRenderer"), Is.TypeOf(typeof(BocValidationErrorIndicatorColumnRenderer)));
+      Assert.That(bocColumnRenderers[0].ColumnDefinition, Is.SameAs(validationErrorColumn));
+      Assert.That(bocColumnRenderers[0].ColumnIndex, Is.EqualTo(0));
+    }
+
+    [Test]
+    public void GetColumnRenderers_WithBocValidationErrorIndicatorColumnDefinition_AlwaysVisibility_WithRowOrCellFailures_ContainsValidationErrorColumnRenderer ()
+    {
+      var validationRepositoryStub = new Mock<IBocListValidationFailureRepository>();
+      validationRepositoryStub.Setup(_ => _.GetListFailureCount()).Returns(0);
+      validationRepositoryStub.Setup(_ => _.GetRowAndCellFailureCount()).Returns(1);
+
+      var bocListStub = new Mock<IBocList>();
+      bocListStub.Setup(_ => _.ValidationFailureRepository).Returns(validationRepositoryStub.Object);
+
+      var validationErrorColumn = new BocValidationErrorIndicatorColumnDefinition
+                                  {
+                                    OwnerControl = bocListStub.Object,
+                                    Visibility = BocValidationErrorIndicatorColumnDefinitionVisibility.Always
+                                  };
+
+      var builder = new BocColumnRendererArrayBuilder(CreateColumnCollection(validationErrorColumn), _serviceLocator, _wcagHelperStub.Object);
+
+      var bocColumnRenderers = builder.CreateColumnRenderers();
+
+      Assert.That(bocColumnRenderers.Length, Is.EqualTo(1));
+      Assert.That(PrivateInvoke.GetNonPublicField(bocColumnRenderers[0], "_columnRenderer"), Is.TypeOf(typeof(BocValidationErrorIndicatorColumnRenderer)));
+      Assert.That(bocColumnRenderers[0].ColumnDefinition, Is.SameAs(validationErrorColumn));
+      Assert.That(bocColumnRenderers[0].ColumnIndex, Is.EqualTo(0));
+    }
+
+    [Test]
+    public void GetColumnRenderers_WithBocValidationErrorIndicatorColumnDefinition_AnyValidationFailureVisibility_WithoutFailures_ContainsNullColumnRenderer ()
+    {
+      var bocListStub = new Mock<IBocList>();
+      bocListStub.Setup(_ => _.ValidationFailureRepository).Returns(new Mock<IBocListValidationFailureRepository>().Object);
+
+      var validationErrorColumn = new BocValidationErrorIndicatorColumnDefinition
+                                  {
+                                    OwnerControl = bocListStub.Object,
+                                    Visibility = BocValidationErrorIndicatorColumnDefinitionVisibility.AnyValidationFailure
+                                  };
+
+      var builder = new BocColumnRendererArrayBuilder(CreateColumnCollection(validationErrorColumn), _serviceLocator, _wcagHelperStub.Object);
+
+      var bocColumnRenderers = builder.CreateColumnRenderers();
+
+      Assert.That(bocColumnRenderers.Length, Is.EqualTo(1));
+      Assert.That(PrivateInvoke.GetNonPublicField(bocColumnRenderers[0], "_columnRenderer"), Is.TypeOf(typeof(NullColumnRenderer)));
+      Assert.That(bocColumnRenderers[0].ColumnDefinition, Is.SameAs(validationErrorColumn));
+      Assert.That(bocColumnRenderers[0].ColumnIndex, Is.EqualTo(0));
+    }
+
+    [Test]
+    public void GetColumnRenderers_WithBocValidationErrorIndicatorColumnDefinition_AnyValidationFailureVisibility_WithListFailures_ContainsValidationErrorColumnRenderer ()
+    {
+      var validationRepositoryStub = new Mock<IBocListValidationFailureRepository>();
+      validationRepositoryStub.Setup(_ => _.GetListFailureCount()).Returns(1);
+
+      var bocListStub = new Mock<IBocList>();
+      bocListStub.Setup(_ => _.ValidationFailureRepository).Returns(validationRepositoryStub.Object);
+
+      var validationErrorColumn = new BocValidationErrorIndicatorColumnDefinition
+                                  {
+                                    OwnerControl = bocListStub.Object,
+                                    Visibility = BocValidationErrorIndicatorColumnDefinitionVisibility.AnyValidationFailure
+                                  };
+
+      var builder = new BocColumnRendererArrayBuilder(CreateColumnCollection(validationErrorColumn), _serviceLocator, _wcagHelperStub.Object);
+
+      var bocColumnRenderers = builder.CreateColumnRenderers();
+
+      Assert.That(bocColumnRenderers.Length, Is.EqualTo(1));
+      Assert.That(PrivateInvoke.GetNonPublicField(bocColumnRenderers[0], "_columnRenderer"), Is.TypeOf(typeof(BocValidationErrorIndicatorColumnRenderer)));
+      Assert.That(bocColumnRenderers[0].ColumnDefinition, Is.SameAs(validationErrorColumn));
+      Assert.That(bocColumnRenderers[0].ColumnIndex, Is.EqualTo(0));
+    }
+
+    [Test]
+    public void GetColumnRenderers_WithBocValidationErrorIndicatorColumnDefinition_AnyValidationFailureVisibility_WithRowOrCellFailures_ContainsValidationErrorColumnRenderer ()
+    {
+      var validationRepositoryStub = new Mock<IBocListValidationFailureRepository>();
+      validationRepositoryStub.Setup(_ => _.GetListFailureCount()).Returns(0);
+      validationRepositoryStub.Setup(_ => _.GetRowAndCellFailureCount()).Returns(1);
+
+      var bocListStub = new Mock<IBocList>();
+      bocListStub.Setup(_ => _.ValidationFailureRepository).Returns(validationRepositoryStub.Object);
+
+      var validationErrorColumn = new BocValidationErrorIndicatorColumnDefinition
+                                  {
+                                    OwnerControl = bocListStub.Object,
+                                    Visibility = BocValidationErrorIndicatorColumnDefinitionVisibility.AnyValidationFailure
+                                  };
+
+      var builder = new BocColumnRendererArrayBuilder(CreateColumnCollection(validationErrorColumn), _serviceLocator, _wcagHelperStub.Object);
+
+      var bocColumnRenderers = builder.CreateColumnRenderers();
+
+      Assert.That(bocColumnRenderers.Length, Is.EqualTo(1));
+      Assert.That(PrivateInvoke.GetNonPublicField(bocColumnRenderers[0], "_columnRenderer"), Is.TypeOf(typeof(BocValidationErrorIndicatorColumnRenderer)));
+      Assert.That(bocColumnRenderers[0].ColumnDefinition, Is.SameAs(validationErrorColumn));
+      Assert.That(bocColumnRenderers[0].ColumnIndex, Is.EqualTo(0));
+    }
+
+    [Test]
+    public void GetColumnRenderers_WithBocValidationErrorIndicatorColumnDefinition_AnyRowOrCellValidationFailureVisibility_WithoutFailures_ContainsNullColumnRenderer ()
+    {
+      var bocListStub = new Mock<IBocList>();
+      bocListStub.Setup(_ => _.ValidationFailureRepository).Returns(new Mock<IBocListValidationFailureRepository>().Object);
+
+      var validationErrorColumn = new BocValidationErrorIndicatorColumnDefinition
+                                  {
+                                    OwnerControl = bocListStub.Object,
+                                    Visibility = BocValidationErrorIndicatorColumnDefinitionVisibility.AnyRowOrCellValidationFailure
+                                  };
+
+      var builder = new BocColumnRendererArrayBuilder(CreateColumnCollection(validationErrorColumn), _serviceLocator, _wcagHelperStub.Object);
+
+      var bocColumnRenderers = builder.CreateColumnRenderers();
+
+      Assert.That(bocColumnRenderers.Length, Is.EqualTo(1));
+      Assert.That(PrivateInvoke.GetNonPublicField(bocColumnRenderers[0], "_columnRenderer"), Is.TypeOf(typeof(NullColumnRenderer)));
+      Assert.That(bocColumnRenderers[0].ColumnDefinition, Is.SameAs(validationErrorColumn));
+      Assert.That(bocColumnRenderers[0].ColumnIndex, Is.EqualTo(0));
+    }
+
+    [Test]
+    public void GetColumnRenderers_WithBocValidationErrorIndicatorColumnDefinition_AnyRowOrCellValidationFailureVisibility_WithListFailures_ContainsNullColumnRenderer ()
+    {
+      var validationRepositoryStub = new Mock<IBocListValidationFailureRepository>();
+      validationRepositoryStub.Setup(_ => _.GetListFailureCount()).Returns(1);
+      validationRepositoryStub.Setup(_ => _.GetRowAndCellFailureCount()).Returns(0);
+
+      var bocListStub = new Mock<IBocList>();
+      bocListStub.Setup(_ => _.ValidationFailureRepository).Returns(validationRepositoryStub.Object);
+
+      var validationErrorColumn = new BocValidationErrorIndicatorColumnDefinition
+                                  {
+                                    OwnerControl = bocListStub.Object,
+                                    Visibility = BocValidationErrorIndicatorColumnDefinitionVisibility.AnyRowOrCellValidationFailure
+                                  };
+
+      var builder = new BocColumnRendererArrayBuilder(CreateColumnCollection(validationErrorColumn), _serviceLocator, _wcagHelperStub.Object);
+
+      var bocColumnRenderers = builder.CreateColumnRenderers();
+
+      Assert.That(bocColumnRenderers.Length, Is.EqualTo(1));
+      Assert.That(PrivateInvoke.GetNonPublicField(bocColumnRenderers[0], "_columnRenderer"), Is.TypeOf(typeof(NullColumnRenderer)));
+      Assert.That(bocColumnRenderers[0].ColumnDefinition, Is.SameAs(validationErrorColumn));
+      Assert.That(bocColumnRenderers[0].ColumnIndex, Is.EqualTo(0));
+    }
+
+
+    [Test]
+    public void GetColumnRenderers_WithBocValidationErrorIndicatorColumnDefinition_AnyRowOrCellValidationFailureVisibility_WithRowOrCellFailures_ContainsValidationErrorColumnRenderer ()
+    {
+      var validationRepositoryStub = new Mock<IBocListValidationFailureRepository>();
+      validationRepositoryStub.Setup(_ => _.GetListFailureCount()).Returns(0);
+      validationRepositoryStub.Setup(_ => _.GetRowAndCellFailureCount()).Returns(2);
+
+      var bocListStub = new Mock<IBocList>();
+      bocListStub.Setup(_ => _.ValidationFailureRepository).Returns(validationRepositoryStub.Object);
+
+      var validationErrorColumn = new BocValidationErrorIndicatorColumnDefinition
+                                  {
+                                    OwnerControl = bocListStub.Object,
+                                    Visibility = BocValidationErrorIndicatorColumnDefinitionVisibility.AnyRowOrCellValidationFailure
+                                  };
+
+      var builder = new BocColumnRendererArrayBuilder(CreateColumnCollection(validationErrorColumn), _serviceLocator, _wcagHelperStub.Object);
+
+      var bocColumnRenderers = builder.CreateColumnRenderers();
+
+      Assert.That(bocColumnRenderers.Length, Is.EqualTo(1));
+      Assert.That(PrivateInvoke.GetNonPublicField(bocColumnRenderers[0], "_columnRenderer"), Is.TypeOf(typeof(BocValidationErrorIndicatorColumnRenderer)));
+      Assert.That(bocColumnRenderers[0].ColumnDefinition, Is.SameAs(validationErrorColumn));
       Assert.That(bocColumnRenderers[0].ColumnIndex, Is.EqualTo(0));
     }
 

--- a/Remotion/ObjectBinding/Web/UI/Controls/BocListImplementation/Rendering/BocColumnRendererArrayBuilder.cs
+++ b/Remotion/ObjectBinding/Web/UI/Controls/BocListImplementation/Rendering/BocColumnRendererArrayBuilder.cs
@@ -16,7 +16,6 @@
 // 
 using System;
 using System.Collections.Generic;
-using System.Collections.ObjectModel;
 using Remotion.Collections;
 using Remotion.ServiceLocation;
 using Remotion.Utilities;
@@ -164,9 +163,35 @@ namespace Remotion.ObjectBinding.Web.UI.Controls.BocListImplementation.Rendering
 
       var columnAsDropDownMenuColumn = column as BocDropDownMenuColumnDefinition;
       if (columnAsDropDownMenuColumn != null)
-        return IsColumnVisibleForBocDropDownMenuColumnDefinition(columnAsDropDownMenuColumn);
+      {
+        if (!IsColumnVisibleForBocDropDownMenuColumnDefinition(columnAsDropDownMenuColumn))
+          return false;
+      }
+
+      var columnAsValidationErrorIndicatorColumn = column as BocValidationErrorIndicatorColumnDefinition;
+      if (columnAsValidationErrorIndicatorColumn != null)
+      {
+        if (!IsColumnVisibleForBocValidationErrorIndicatorColumnDefinition(columnAsValidationErrorIndicatorColumn))
+          return false;
+      }
 
       return true;
+    }
+
+    private bool IsColumnVisibleForBocValidationErrorIndicatorColumnDefinition (BocValidationErrorIndicatorColumnDefinition columnAsValidationErrorIndicatorColumn)
+    {
+      var bocList = (IBocList?)columnAsValidationErrorIndicatorColumn.OwnerControl;
+      if (bocList == null)
+        return true;
+
+      var repository = bocList.ValidationFailureRepository;
+      return columnAsValidationErrorIndicatorColumn.Visibility switch
+      {
+        BocValidationErrorIndicatorColumnDefinitionVisibility.Always => true,
+        BocValidationErrorIndicatorColumnDefinitionVisibility.AnyValidationFailure => (repository.GetListFailureCount() + repository.GetRowAndCellFailureCount()) > 0,
+        BocValidationErrorIndicatorColumnDefinitionVisibility.AnyRowOrCellValidationFailure => repository.GetRowAndCellFailureCount() > 0,
+        _ => throw new ArgumentOutOfRangeException()
+      };
     }
 
     private bool IsColumnVisibleForBocCommandColumnDefinition (BocCommandColumnDefinition columnAsCommandColumn)

--- a/Remotion/ObjectBinding/Web/UI/Controls/BocValidationErrorIndicatorColumnDefinition.cs
+++ b/Remotion/ObjectBinding/Web/UI/Controls/BocValidationErrorIndicatorColumnDefinition.cs
@@ -18,14 +18,12 @@ using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Web.UI;
-using System.Web.UI.WebControls;
 using Remotion.ObjectBinding.Web.UI.Controls.BocListImplementation;
 using Remotion.ObjectBinding.Web.UI.Controls.BocListImplementation.Rendering;
 using Remotion.ServiceLocation;
 using Remotion.Utilities;
 using Remotion.Web;
 using Remotion.Web.Globalization;
-using Remotion.Web.Infrastructure;
 using Remotion.Web.UI.Controls;
 
 namespace Remotion.ObjectBinding.Web.UI.Controls
@@ -84,6 +82,13 @@ namespace Remotion.ObjectBinding.Web.UI.Controls
     [DefaultValue(true)]
     [NotifyParentProperty(true)]
     public bool IsSortable { get; set; } = true;
+
+    /// <summary> Determines the visibility of the column depending on the existence of validation failures. </summary>
+    [PersistenceMode(PersistenceMode.Attribute)]
+    [Category("Appearance")]
+    [Description("Determines the visibility of the column depending on the existence of validation failures.")]
+    [DefaultValue(BocValidationErrorIndicatorColumnDefinitionVisibility.Always)]
+    public BocValidationErrorIndicatorColumnDefinitionVisibility Visibility { get; set; } = BocValidationErrorIndicatorColumnDefinitionVisibility.Always;
 
     public IComparer<BocListRow> CreateCellValueComparer ()
     {

--- a/Remotion/ObjectBinding/Web/UI/Controls/BocValidationErrorIndicatorColumnDefinitionVisibility.cs
+++ b/Remotion/ObjectBinding/Web/UI/Controls/BocValidationErrorIndicatorColumnDefinitionVisibility.cs
@@ -1,0 +1,41 @@
+﻿// This file is part of the re-motion Core Framework (www.re-motion.org)
+// Copyright (c) rubicon IT GmbH, www.rubicon.eu
+//
+// The re-motion Core Framework is free software; you can redistribute it
+// and/or modify it under the terms of the GNU Lesser General Public License
+// as published by the Free Software Foundation; either version 2.1 of the
+// License, or (at your option) any later version.
+//
+// re-motion is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with re-motion; if not, see http://www.gnu.org/licenses.
+//
+using Remotion.ObjectBinding.Web.UI.Controls.BocListImplementation;
+
+namespace Remotion.ObjectBinding.Web.UI.Controls
+{
+  /// <summary>
+  /// Defines the visibility behavior of the <see cref="BocValidationErrorIndicatorColumnDefinition"/> in a <see cref="IBocList"/>.
+  /// </summary>
+  public enum BocValidationErrorIndicatorColumnDefinitionVisibility
+  {
+    /// <summary>
+    /// The <see cref="BocValidationErrorIndicatorColumnDefinition"/> is always visible.
+    /// </summary>
+    Always,
+
+    /// <summary>
+    /// The <see cref="BocValidationErrorIndicatorColumnDefinition"/> is visible if any row or cell validation failure is associated with the <see cref="IBocList"/>.
+    /// </summary>
+    AnyRowOrCellValidationFailure,
+
+    /// <summary>
+    /// The <see cref="BocValidationErrorIndicatorColumnDefinition"/> is displayed if any validation failure is associated with the <see cref="IBocList"/>.
+    /// </summary>
+    AnyValidationFailure
+  }
+}


### PR DESCRIPTION
https://re-motion.atlassian.net/browse/RM-8939

Tested Remotion/ObjectBinding/Web.Development.WebTesting.IntegrationTests/BocListControlObjectTest.cs, did work with alternative standard of not showing the validation column.