### PR TITLE
bugfix/RM-8952-Missing-Culture-Specification-in-AssemblyInfo-for-Remotion.Validation.Globalization-v5.0

### DIFF
--- a/Remotion/Validation/Globalization/Properties/AssemblyInfo.cs
+++ b/Remotion/Validation/Globalization/Properties/AssemblyInfo.cs
@@ -20,7 +20,7 @@ using System.Resources;
 using Remotion.Globalization;
 
 [assembly: NeutralResourcesLanguage("en")]
-[assembly: AvailableResourcesLanguages("", "de", "fr", "it")]
+[assembly: AvailableResourcesLanguages("", "de", "de-ch", "fr", "it")]
 
 [assembly: AssemblyCulture("")]
 [assembly: CLSCompliant(true)]


### PR DESCRIPTION
https://re-motion.atlassian.net/browse/RM-8952