### PR TITLE
bugfix/RM-8960-MaxLength-constraint-is-not-applied-to-single-row-BocTextValue-v5.0

### DIFF
--- a/Remotion/ObjectBinding/Web/UI/Controls/Styles.cs
+++ b/Remotion/ObjectBinding/Web/UI/Controls/Styles.cs
@@ -332,10 +332,13 @@ namespace Remotion.ObjectBinding.Web.UI.Controls
       SingleRowTextBoxStyle? ts = s as SingleRowTextBoxStyle;
       if (ts != null)
       {
-        if (_checkClientSideMaxLength != false)
-          _maxLength = ts.MaxLength;
-        _columns = ts.Columns;
-        _readOnly = ts.ReadOnly;
+        this._columns = ts._columns;
+        this._maxLength = ts._maxLength;
+        this._maxLengthByPropertyConstraint = ts._maxLengthByPropertyConstraint;
+        this._maxLengthFromDomainModel = ts._maxLengthFromDomainModel;
+        this._readOnly = ts._readOnly;
+        this._autoPostBack = ts._autoPostBack;
+        this._checkClientSideMaxLength = ts._checkClientSideMaxLength;
       }
     }
 
@@ -507,11 +510,11 @@ namespace Remotion.ObjectBinding.Web.UI.Controls
       TextBoxStyle? ts = s as TextBoxStyle;
       if (ts != null)
       {
-        Rows = ts.Rows;
-        TextMode = ts.TextMode;
-        Wrap = ts.Wrap;
-        Placeholder = ts.Placeholder;
-        AutoComplete = ts.AutoComplete;
+        this._rows = ts._rows;
+        this._textMode = ts._textMode;
+        this._wrap = ts._wrap;
+        this._placeholder = ts._placeholder;
+        this._autoComplete = ts._autoComplete;
       }
     }
 

--- a/Remotion/ObjectBinding/Web/UI/Controls/Styles.cs
+++ b/Remotion/ObjectBinding/Web/UI/Controls/Styles.cs
@@ -313,8 +313,9 @@ namespace Remotion.ObjectBinding.Web.UI.Controls
     {
       textBox.ApplyStyle(this);
 
-      if (_maxLength != null && _checkClientSideMaxLength != false)
-        textBox.MaxLength = _maxLength.Value;
+      var maxLength = GetMaxLength();
+      if (maxLength != null && _checkClientSideMaxLength != false)
+        textBox.MaxLength = maxLength.Value;
 
       if (_columns != null)
         textBox.Columns = _columns.Value;

--- a/Remotion/ObjectBinding/Web/UI/Controls/Styles.cs
+++ b/Remotion/ObjectBinding/Web/UI/Controls/Styles.cs
@@ -333,7 +333,7 @@ namespace Remotion.ObjectBinding.Web.UI.Controls
       if (ts != null)
       {
         if (_checkClientSideMaxLength != false)
-          _maxLength = ts.GetMaxLength();
+          _maxLength = ts.MaxLength;
         _columns = ts.Columns;
         _readOnly = ts.ReadOnly;
       }


### PR DESCRIPTION
https://re-motion.atlassian.net/browse/RM-8960