### PR TITLE
RM-8789 Use all created dependency management nuget packages

### DIFF
--- a/Remotion/Core/Core/Core.Core.csproj
+++ b/Remotion/Core/Core/Core.Core.csproj
@@ -20,6 +20,8 @@
   <ItemGroup>
     <PackageReference Include="log4net" Version="2.0.15" />
     <PackageReference Remove="JetBrains.Annotations" />
+    <PackageReference Include="Remotion.ThirdParty.Dependency.Jetbrains.Annotations" Version="2022.1.0" />
+    <PackageReference Include="Remotion.ThirdPartyDependency.CommonServiceLocator" Version="2.0.6" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net48'">
     <Reference Include="System.Configuration" />

--- a/Remotion/Core/Reflection.CodeGeneration.TypePipe/Core.Reflection.CodeGeneration.TypePipe.csproj
+++ b/Remotion/Core/Reflection.CodeGeneration.TypePipe/Core.Reflection.CodeGeneration.TypePipe.csproj
@@ -14,6 +14,7 @@
     <ProjectReference Include="..\Core\Core.Core.csproj" />
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="Remotion.ThirdPartyDependency.DynamicLanguageRuntime" Version="1.1.0.10" />
     <PackageReference Include="Remotion.TypePipe" Version="3.2.0" />
     <PackageReference Remove="JetBrains.Annotations" />
   </ItemGroup>

--- a/Remotion/ObjectBinding/Web.ClientScript/ObjectBinding.Web.ClientScript.csproj
+++ b/Remotion/ObjectBinding/Web.ClientScript/ObjectBinding.Web.ClientScript.csproj
@@ -15,5 +15,8 @@
       <Link>Scripts\typings\common.d.ts</Link>
     </TypeScriptCompile>
   </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Remotion.ThirdPartyDependency.JQuery.Autocomplete" Version="1.1.0-pre" />
+  </ItemGroup>
   <Import Project="..\..\..\Build\Shared.build.targets" />
 </Project>

--- a/Remotion/Web/Core/Web.Core.csproj
+++ b/Remotion/Web/Core/Web.Core.csproj
@@ -35,5 +35,11 @@
     <None Include="..\Development.Analyzers\bin\$(Configuration)\netstandard2.0\Remotion.Web.Development.Analyzers.dll" Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false" />
     <None Update="..\..\Remotion LGPL.licenseheader" Pack="true" PackagePath="res/" Visible="false" />
   </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Remotion.ThirdPartyDependency.RobotoFonts" Version="2.137.0" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' != 'net48'">
+    <PackageReference Include="Remotion.ThirdPartyDependency.System.Web" Version="4.8.0" />
+  </ItemGroup>
   <Import Project="..\..\..\Build\Shared.build.targets" />
 </Project>


### PR DESCRIPTION
https://re-motion.atlassian.net/browse/RM-8789

There were some thoughts about copying files to the project. The only one where such a thing could happen would be roboto fonts. As those probably won't get any updates though, it might not make sense to include such a functionality. Thoughts?