### PR TITLE
bugfix/RM-9034-WxeFunctionStateManagerTest.HasSessionAndGetCurrentInSeparateThreads-is-broken

### DIFF
--- a/Remotion/Web/UnitTests/Core/ExecutionEngine/WxeFunctionStateManagerTest.cs
+++ b/Remotion/Web/UnitTests/Core/ExecutionEngine/WxeFunctionStateManagerTest.cs
@@ -170,13 +170,17 @@ namespace Remotion.Web.UnitTests.Core.ExecutionEngine
       HttpContextHelper.SetCurrent(HttpContextHelper.CreateHttpContext("get", "default.aspx", string.Empty));
       Assert.That(WxeFunctionStateManager.HasSession, Is.False);
       Assert.That(WxeFunctionStateManager.Current, Is.Not.Null);
+      Assert.That(WxeFunctionStateManager.HasSession, Is.True);
       ThreadRunner.Run(
           delegate
           {
-            HttpContextHelper.SetCurrent(HttpContextHelper.CreateHttpContext("get", "default.aspx", string.Empty));
-            Assert.That(WxeFunctionStateManager.HasSession, Is.False);
-            Assert.That(WxeFunctionStateManager.Current, Is.Not.Null);
-            Assert.That(WxeFunctionStateManager.HasSession, Is.True);
+            using (SafeContext.Instance.OpenSafeContextBoundary())
+            {
+              HttpContextHelper.SetCurrent(HttpContextHelper.CreateHttpContext("get", "default.aspx", string.Empty));
+              Assert.That(WxeFunctionStateManager.HasSession, Is.False);
+              Assert.That(WxeFunctionStateManager.Current, Is.Not.Null);
+              Assert.That(WxeFunctionStateManager.HasSession, Is.True);
+            }
           });
     }
 


### PR DESCRIPTION
https://re-motion.atlassian.net/browse/RM-9034

NOTE:
* This also covers https://re-motion.atlassian.net/browse/RM-9027
* We need to verify that the change is correct and the cause is not an issue in CoreForms.