### PR TITLE
RM-9035 Clenaup for missed details in WebConfiguration tasks

### DIFF
--- a/Remotion/ObjectBinding/Web.Test/Global.asax.cs
+++ b/Remotion/ObjectBinding/Web.Test/Global.asax.cs
@@ -29,6 +29,7 @@ using Remotion.ObjectBinding.Sample.ReferenceDataSourceTestDomain;
 using Remotion.ObjectBinding.Web;
 using Remotion.ServiceLocation;
 using Remotion.Web;
+using Remotion.Web.ExecutionEngine;
 using Remotion.Web.Infrastructure;
 
 namespace OBWTest
@@ -63,6 +64,8 @@ namespace OBWTest
       var defaultServiceLocator = DefaultServiceLocator.Create();
 
       //defaultServiceLocator.RegisterSingle<ResourceTheme>(() => new ResourceTheme.NovaGray());
+
+      defaultServiceLocator.RegisterSingle(() => WxeUrlSettings.Create(urlMappingFile: "~/UrlMapping.xml"));
 
       ServiceLocator.SetLocatorProvider(() => defaultServiceLocator);
 

--- a/Remotion/Web/Core/Configuration/WebConfiguration.cs
+++ b/Remotion/Web/Core/Configuration/WebConfiguration.cs
@@ -34,8 +34,8 @@ public class WebConfiguration: IConfigurationSectionHandler
   public const string ElementName = "remotion.web";
 
   /// <summary> The namespace of the configuration section schema. </summary>
-  /// <remarks> <c>http://www.re-motion.org/web/configuration</c> </remarks>
-  public const string SchemaUri = "http://www.re-motion.org/web/configuration";
+  /// <remarks> <c>http://www.re-motion.org/web/configuration/v2</c> </remarks>
+  public const string SchemaUri = "http://www.re-motion.org/web/configuration/v2";
 
   private static readonly DoubleCheckedLockingContainer<WebConfiguration> s_current =
       new DoubleCheckedLockingContainer<WebConfiguration>(CreateConfig);

--- a/Remotion/Web/Core/Doc/include/Configuration/WebConfiguration.xml
+++ b/Remotion/Web/Core/Doc/include/Configuration/WebConfiguration.xml
@@ -42,7 +42,7 @@
     &lt;!-- Other configuration section registrations. --&gt;
   &lt;/configSections&gt;
   
-  &lt;remotion.web xmlns="http://www.re-motion.org/web/configuration"&gt; 
+  &lt;remotion.web xmlns="http://www.re-motion.org/web/configuration/v2"&gt;
     &lt;!-- The configuration section entries. --&gt;
     &lt;<see cref="ExecutionEngineConfiguration">executionEngine</see> 
         defaultWxeHandler="~/WxeHandler.ashx"

--- a/Remotion/Web/Core/ExecutionEngine/WxeUrlSettings.cs
+++ b/Remotion/Web/Core/ExecutionEngine/WxeUrlSettings.cs
@@ -81,7 +81,28 @@ namespace Remotion.Web.ExecutionEngine
     {
       UrlMappingFile = urlMappingFile;
       MaximumUrlLength = maximumUrlLength;
-      DefaultWxeHandler = defaultWxeHandler;
+      DefaultWxeHandler = CheckDefaultWxeHandler(defaultWxeHandler);
+    }
+
+    private string? CheckDefaultWxeHandler (string? defaultWxeHandler)
+    {
+      if (string.IsNullOrEmpty(defaultWxeHandler))
+      {
+        return null;
+      }
+      else
+      {
+        defaultWxeHandler = defaultWxeHandler.Trim();
+        ArgumentUtility.CheckNotNullOrEmpty(nameof(defaultWxeHandler), defaultWxeHandler);
+
+        if (defaultWxeHandler.StartsWith("/") || defaultWxeHandler.IndexOf(":") != -1)
+          throw new ArgumentException($"No absolute paths are allowed. Resource: '{defaultWxeHandler}'", nameof(defaultWxeHandler));
+
+        if (!defaultWxeHandler.StartsWith("~/"))
+          defaultWxeHandler = "~/" + defaultWxeHandler;
+
+        return defaultWxeHandler;
+      }
     }
   }
 }

--- a/Remotion/Web/Core/Schemas/WebConfiguration.xsd
+++ b/Remotion/Web/Core/Schemas/WebConfiguration.xsd
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <xs:schema 
     xmlns:xs="http://www.w3.org/2001/XMLSchema"
-    xmlns:c="http://www.re-motion.org/web/configuration" 
+    xmlns:c="http://www.re-motion.org/web/configuration/v2"
     elementFormDefault="qualified" 
     attributeFormDefault="unqualified" 
-    targetNamespace="http://www.re-motion.org/web/configuration">
+    targetNamespace="http://www.re-motion.org/web/configuration/v2">
   <xs:element name="remotion.web">
     <xs:complexType>
       <xs:all>
@@ -13,11 +13,6 @@
             <xs:attribute name="functionTimeout" type="xs:int" default="20" />
             <xs:attribute name="enableSessionManagement" type="xs:boolean" default="true" />
             <xs:attribute name="refreshInterval" type="xs:int" default="10" />
-          </xs:complexType>
-        </xs:element>
-        <xs:element name="resources" minOccurs="0" maxOccurs="1">
-          <xs:complexType>
-            <xs:attribute name="root" type="xs:string" default="res" />
           </xs:complexType>
         </xs:element>
       </xs:all>

--- a/Remotion/Web/Test.NetFramework/Web.config
+++ b/Remotion/Web/Test.NetFramework/Web.config
@@ -4,7 +4,7 @@
 		<section name="remotion.web" type="Remotion.Web.Configuration.WebConfiguration, Remotion.Web" />
 		<section name="log4net" type="log4net.Config.Log4NetConfigurationSectionHandler, log4net" />
   </configSections>
-	<remotion.web xmlns="http://www.re-motion.org/web/configuration">
+	<remotion.web xmlns="http://www.re-motion.org/web/configuration/v2">
 		<executionEngine functionTimeout="16" refreshInterval="5"/>
 	</remotion.web>
 <log4net debug="true">

--- a/Remotion/Web/UnitTests/Core/ExecutionEngine/WxeUrlSettingsTest.cs
+++ b/Remotion/Web/UnitTests/Core/ExecutionEngine/WxeUrlSettingsTest.cs
@@ -1,4 +1,6 @@
-﻿using NUnit.Framework;
+﻿using System.Threading;
+using NUnit.Framework;
+using Remotion.Development.NUnit.UnitTesting;
 using Remotion.ServiceLocation;
 using Remotion.Web.ExecutionEngine;
 
@@ -49,11 +51,46 @@ namespace Remotion.Web.UnitTests.Core.ExecutionEngine
     [Test]
     public void Create ()
     {
-      var settings = WxeUrlSettings.Create("someFile", 42, "someWxeHandler");
+      var settings = WxeUrlSettings.Create("someFile", 42, " ~/someWxeHandler ");
 
       Assert.That(settings.UrlMappingFile, Is.EqualTo("someFile"));
       Assert.That(settings.MaximumUrlLength, Is.EqualTo(42));
-      Assert.That(settings.DefaultWxeHandler, Is.EqualTo("someWxeHandler"));
+      Assert.That(settings.DefaultWxeHandler, Is.EqualTo("~/someWxeHandler"));
+    }
+
+    [Test]
+    public void Create_NullValues ()
+    {
+      var settings = WxeUrlSettings.Create(null, 0, null);
+
+      Assert.That(settings.UrlMappingFile, Is.Null);
+      Assert.That(settings.DefaultWxeHandler, Is.Null);
+    }
+
+    [Test]
+    public void Create_WithDefaultWxeHandlerAsAbsoluteFilePath_Throws ()
+    {
+      Assert.That(
+          () => WxeUrlSettings.Create(null, 0, "C:\\myhandler"),
+          Throws.ArgumentException
+              .With.ArgumentExceptionMessageEqualTo("No absolute paths are allowed. Resource: 'C:\\myhandler'", "defaultWxeHandler"));
+    }
+
+    [Test]
+    public void Create_WithDefaultWxeHandlerAsAbsoluteUrlPath_Throws ()
+    {
+      Assert.That(
+          () => WxeUrlSettings.Create(null, 0, "/myhandler"),
+          Throws.ArgumentException
+              .With.ArgumentExceptionMessageEqualTo("No absolute paths are allowed. Resource: '/myhandler'", "defaultWxeHandler"));
+    }
+
+    [Test]
+    public void Create_WithRelativePath_IsMadeApplicationRelative ()
+    {
+      var settings = WxeUrlSettings.Create(null, 0, " someWxeHandler ");
+
+      Assert.That(settings.DefaultWxeHandler, Is.EqualTo("~/someWxeHandler"));
     }
   }
 }

--- a/SecurityManager/Clients.Web.Test/SecurityManager.Clients.Web.Test.csproj
+++ b/SecurityManager/Clients.Web.Test/SecurityManager.Clients.Web.Test.csproj
@@ -58,7 +58,9 @@
   </ItemGroup>
   <ItemGroup>
     <Content Include="Default.aspx" />
-    <Content Include="UrlMapping.xml" />
+    <Content Include="UrlMapping.xml">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
     <Content Include="Web.config">
       <SubType>Designer</SubType>
     </Content>

--- a/SecurityManager/Clients.Web.Test/Web.config
+++ b/SecurityManager/Clients.Web.Test/Web.config
@@ -8,7 +8,7 @@
     </sectionGroup>
   </configSections>
 
-  <remotion.web xmlns="http://www.re-motion.org/web/configuration">
+  <remotion.web xmlns="http://www.re-motion.org/web/configuration/v2">
     <executionEngine functionTimeout="20" refreshInterval="10" />
   </remotion.web>
 

--- a/SecurityManager/Clients.Web/Web.config
+++ b/SecurityManager/Clients.Web/Web.config
@@ -8,7 +8,7 @@
     </sectionGroup>
   </configSections>
 
-  <remotion.web xmlns="http://www.re-motion.org/web/configuration">
+  <remotion.web xmlns="http://www.re-motion.org/web/configuration/v2">
     <executionEngine functionTimeout="20" refreshInterval="10" defaultWxeHandler="WxeHandler.ashx" urlMappingFile="~/bin/SecurityManagerUrlMapping.xml" />
   </remotion.web>
 


### PR DESCRIPTION
https://re-motion.atlassian.net/browse/RM-9035

I did not update the `WebConfiguration` to use the .NET Framework 2.0 syntax as I felt that there would be no benefit to it. We are replacing the `ConfigurationManager` implementation anyway so if it works now I think we should just leave it as is.