### PR TITLE
RM-9025 Support ARIA 1.2 for the BocAutoCompleteReferenceValue

### DIFF
--- a/Remotion/ObjectBinding/Web.ClientScript/Scripts/BocAutoCompleteReferenceValue.UI.ts
+++ b/Remotion/ObjectBinding/Web.ClientScript/Scripts/BocAutoCompleteReferenceValue.UI.ts
@@ -85,7 +85,6 @@ namespace Remotion.BocAutoCompleteReferenceValue
         max: number;
         isAutoPostBackEnabled: boolean;
         extraParams: Dictionary<unknown>;
-        combobox: HTMLElement;
         selectListID: string;
         informationPopUpID: string;
         dropDownButtonID: string;
@@ -121,8 +120,10 @@ namespace Remotion.BocAutoCompleteReferenceValue
         },
         formatItem: Options["formatItem"];
         formatMatch: Options["formatMatch"];
+        selectListID: Options["selectListID"];
+        informationPopUpID: Options["informationPopUpID"];
+        dropDownButtonID: Options["dropDownButtonID"];
         parse: Options["parse"];
-        combobox: Options["combobox"];
     };
 
     export type PositioningOptions = {
@@ -234,11 +235,6 @@ namespace Remotion.BocAutoCompleteReferenceValue
             serviceMethodSearch: serviceMethodSearch,
             serviceMethodSearchExact: serviceMethodSearchExact,
             data: null,
-            combobox: null,
-            selectListID: null,
-            informationPopUpID: null,
-            // re-motion: clicking this control will display the dropdown list with an assumed input of '' (regardless of textbox value)
-            dropDownButtonID: null
         }, initialOptions as RequiredOptions);
 
         // if highlight is set to false, replace it with a do-nothing function
@@ -1166,19 +1162,13 @@ namespace Remotion.BocAutoCompleteReferenceValue
                 return;
 
             this.element = document.createElement("div");
-            this.element.setAttribute('role', 'listbox');
-            this.element.setAttribute('id', this.options.selectListID);
             this.element.setAttribute('class', this.options.resultsClass);
             this.element.style.position = 'fixed';
             LayoutUtility.Hide(this.element);
 
             this.input.closest('div, td, th, body')!.appendChild(this.element);
 
-            this.options.combobox.setAttribute('aria-owns', this.options.selectListID);
-            const isAria11 = this.options.combobox !== this.input;
-            if (isAria11) {
-                this.options.combobox.setAttribute('aria-controls', this.options.selectListID);
-            }
+            this.input.setAttribute('aria-controls', this.options.selectListID);
 
             const elementStyle = window.getComputedStyle(this.element);
             this.element.dataset['originalMaxHeight'] = "" + parseInt(elementStyle.maxHeight, 10);
@@ -1209,6 +1199,8 @@ namespace Remotion.BocAutoCompleteReferenceValue
             });
 
             this.list = document.createElement("ul");
+            this.list.setAttribute('role', 'listbox');
+            this.list.setAttribute('id', this.options.selectListID);
             innerDiv.appendChild(this.list);
 
             this.list.addEventListener('mouseover', (event) => {
@@ -1480,8 +1472,8 @@ namespace Remotion.BocAutoCompleteReferenceValue
         public hide() {
             if (this.repositionTimer) 
                 clearTimeout(this.repositionTimer);
-            this.options.combobox.setAttribute("aria-expanded", "false");
-            this.input.removeAttribute("aria-activedescendant");
+            this.input.setAttribute("aria-expanded", "false");
+            this.input.setAttribute("aria-activedescendant", "");
             this.element && LayoutUtility.Hide(this.element);
             if (this.listItems) {
                 for (const listItem of this.listItems) {
@@ -1520,7 +1512,7 @@ namespace Remotion.BocAutoCompleteReferenceValue
             this.applyPositionToDropDown();
             
             LayoutUtility.Show(this.element);
-            this.options.combobox.setAttribute("aria-expanded", "true");
+            this.input.setAttribute("aria-expanded", "true");
             
             // re-motion: reposition element 
             if (this.repositionTimer) 
@@ -1617,8 +1609,8 @@ namespace Remotion.BocAutoCompleteReferenceValue
             LayoutUtility.Hide(this.element);
             this.input.closest('div, td, th, body')!.appendChild(this.element);
 
-            if (this.options.combobox.getAttribute('aria-labelledby') !== null) {
-                this.element.setAttribute("aria-labelledby", this.options.combobox.getAttribute('aria-labelledby')!);
+            if (this.input.getAttribute('aria-labelledby') !== null) {
+                this.element.setAttribute("aria-labelledby", this.input.getAttribute('aria-labelledby')!);
             }
 
             const elementStyle = window.getComputedStyle(this.element);

--- a/Remotion/ObjectBinding/Web.ClientScript/Scripts/BocAutoCompleteReferenceValue.ts
+++ b/Remotion/ObjectBinding/Web.ClientScript/Scripts/BocAutoCompleteReferenceValue.ts
@@ -33,7 +33,6 @@ class BocAutoCompleteReferenceValue //TODO RM-7715 - Make the TypeScript classes
 
   constructor (
     baseID: Nullable<string>,
-    comboboxOrSelector: CssSelectorOrElement<HTMLElement>,
     textboxOrSelector: CssSelectorOrElement<HTMLInputElement>,
     hiddenFieldOrSelector: CssSelectorOrElement<HTMLInputElement>,
     buttonOrSelector: CssSelectorOrElement<HTMLElement>,
@@ -53,7 +52,6 @@ class BocAutoCompleteReferenceValue //TODO RM-7715 - Make the TypeScript classes
     resources: BocReferenceValueBase_Resources)
   {
     ArgumentUtility.CheckTypeIsString('baseID', baseID);
-    ArgumentUtility.CheckNotNull('comboboxOrSelector', comboboxOrSelector);
     ArgumentUtility.CheckNotNull('textboxOrSelector', textboxOrSelector);
     ArgumentUtility.CheckNotNull('hiddenFieldOrSelector', hiddenFieldOrSelector);
     ArgumentUtility.CheckNotNull('buttonOrSelector', buttonOrSelector);
@@ -75,7 +73,6 @@ class BocAutoCompleteReferenceValue //TODO RM-7715 - Make the TypeScript classes
     }
     ArgumentUtility.CheckNotNullAndTypeIsObject('resources', resources);
 
-    let combobox = ElementResolverUtility.ResolveSingle(comboboxOrSelector);
     const textbox = ElementResolverUtility.ResolveSingle(textboxOrSelector);
     const hiddenField = ElementResolverUtility.ResolveSingle(hiddenFieldOrSelector);
     const button = ElementResolverUtility.ResolveSingle(buttonOrSelector);
@@ -129,7 +126,6 @@ class BocAutoCompleteReferenceValue //TODO RM-7715 - Make the TypeScript classes
         noDataFoundMessage: resources.NoDataFoundMessage,
         autoFill: true,
         matchContains: true,
-        combobox: combobox,
         selectListID: this._selectListID,
         informationPopUpID: this._informationPopUpID,
         dropDownButtonID: button.getAttribute('id')!,

--- a/Remotion/ObjectBinding/Web.Development.WebTesting/ControlObjects/BocAutoCompleteReferenceValueControlObject.cs
+++ b/Remotion/ObjectBinding/Web.Development.WebTesting/ControlObjects/BocAutoCompleteReferenceValueControlObject.cs
@@ -269,10 +269,7 @@ namespace Remotion.ObjectBinding.Web.Development.WebTesting.ControlObjects
 
     protected override ElementScope GetLabeledElementScope ()
     {
-      if (IsReadOnly())
-        return Scope.FindChild("TextValue");
-      else
-        return Scope.FindChild("TextValue").FindXPath("..");
+      return Scope.FindChild("TextValue");
     }
 
     private SearchServiceResultItem GetFirstAutoCompleteResult ([NotNull] string filter)

--- a/Remotion/ObjectBinding/Web.UnitTests/UI/Controls/BocReferenceValueImplementation/Rendering/BocAutoCompleteReferenceValueRendererTest.cs
+++ b/Remotion/ObjectBinding/Web.UnitTests/UI/Controls/BocReferenceValueImplementation/Rendering/BocAutoCompleteReferenceValueRendererTest.cs
@@ -505,14 +505,14 @@ namespace Remotion.ObjectBinding.Web.UnitTests.UI.Controls.BocReferenceValueImpl
     private void AssertDropDownListSpan (XmlNode contentSpan, AutoPostBack autoPostBack)
     {
       var inputSpan = contentSpan.GetAssertedChildElement("span", 0);
-      inputSpan.AssertAttributeValueEquals("role", "combobox");
-      inputSpan.AssertAttributeValueEquals(StubLabelReferenceRenderer.LabelReferenceAttribute, c_labelID);
-      inputSpan.AssertAttributeValueEquals(StubLabelReferenceRenderer.AccessibilityAnnotationsAttribute, "");
-
-      inputSpan.AssertAttributeValueEquals("aria-expanded", "false");
-      inputSpan.AssertAttributeValueEquals("aria-haspopup", "listbox");
       inputSpan.AssertChildElementCount(1);
+
       var inputField = inputSpan.GetAssertedChildElement("input", 0);
+      inputField.AssertAttributeValueEquals("role", "combobox");
+      inputField.AssertAttributeValueEquals(StubLabelReferenceRenderer.LabelReferenceAttribute, c_labelID);
+      inputField.AssertAttributeValueEquals(StubLabelReferenceRenderer.AccessibilityAnnotationsAttribute, "");
+      inputField.AssertAttributeValueEquals("aria-expanded", "false");
+      inputField.AssertAttributeValueEquals("aria-haspopup", "listbox");
       inputField.AssertAttributeValueEquals("type", "stub");
       inputField.AssertAttributeValueEquals(StubValidationErrorRenderer.ValidationErrorsIDAttribute, Control.Object.ClientID + "_ValidationErrors");
       inputField.AssertAttributeValueEquals(StubValidationErrorRenderer.ValidationErrorsAttribute, s_validationErrors);

--- a/Remotion/ObjectBinding/Web/UI/Controls/BocReferenceValueImplementation/Rendering/BocAutoCompleteReferenceValueRenderer.cs
+++ b/Remotion/ObjectBinding/Web/UI/Controls/BocReferenceValueImplementation/Rendering/BocAutoCompleteReferenceValueRenderer.cs
@@ -160,11 +160,6 @@ namespace Remotion.ObjectBinding.Web.UI.Controls.BocReferenceValueImplementation
       var script = new StringBuilder(1000);
       script.Append("new BocAutoCompleteReferenceValue(");
       script.AppendFormat("'{0}', ", renderingContext.Control.ClientID);
-      script.AppendFormat(
-          "'#{0} span[{1}={2}]', ",
-          renderingContext.Control.ClientID,
-          HtmlTextWriterAttribute2.Role,
-          HtmlRoleAttributeValue.Combobox);
       script.AppendFormat("'#{0}', ", renderingContext.Control.GetTextValueName());
       script.AppendFormat("'#{0}', ", renderingContext.Control.GetKeyValueName());
       script.AppendFormat("'#{0}',", GetDropDownButtonName(renderingContext));
@@ -305,12 +300,6 @@ namespace Remotion.ObjectBinding.Web.UI.Controls.BocReferenceValueImplementation
       ValidationErrorRenderer.SetValidationErrorsReferenceOnControl(textBox, validationErrorsID, validationErrors);
 
       renderingContext.Writer.AddAttribute(HtmlTextWriterAttribute.Class, CssClassInput + " " + CssClassThemed);
-      renderingContext.Writer.AddAttribute(HtmlTextWriterAttribute2.Role, HtmlRoleAttributeValue.Combobox);
-      renderingContext.Writer.AddAttribute(HtmlTextWriterAttribute2.AriaHasPopup, GetAriaHasPopupForCombobox());
-      renderingContext.Writer.AddAttribute(HtmlTextWriterAttribute2.AriaExpanded, HtmlAriaExpandedAttributeValue.False);
-
-      var labelIDs = renderingContext.Control.GetLabelIDs().ToArray();
-      LabelReferenceRenderer.AddLabelsReference(renderingContext.Writer, labelIDs);
 
       renderingContext.Writer.RenderBeginTag(HtmlTextWriterTag.Span);
 
@@ -375,7 +364,16 @@ namespace Remotion.ObjectBinding.Web.UI.Controls.BocReferenceValueImplementation
       textBox.Page = renderingContext.Control.Page!.WrappedInstance;
       textBox.ApplyStyle(renderingContext.Control.CommonStyle);
       renderingContext.Control.TextBoxStyle.ApplyStyle(textBox);
+
+      textBox.Attributes.Add(HtmlTextWriterAttribute2.Role, HtmlRoleAttributeValue.Combobox);
       textBox.Attributes.Add(HtmlTextWriterAttribute2.AriaAutoComplete, HtmlAriaAutoCompleteAttributeValue.Both);
+      textBox.Attributes.Add(HtmlTextWriterAttribute2.AriaExpanded, HtmlAriaExpandedAttributeValue.False);
+      textBox.Attributes.Add(HtmlTextWriterAttribute2.AriaHasPopup, GetAriaHasPopupForCombobox());
+      textBox.Attributes.Add(HtmlTextWriterAttribute2.AriaActiveDescendant, "");
+
+      var labelIDs = renderingContext.Control.GetLabelIDs().ToArray();
+      LabelReferenceRenderer.SetLabelReferenceOnControl(textBox, labelIDs);
+
       textBox.Attributes.Add("autocomplete", "off");
 
       if (renderingContext.Control.IsRequired)


### PR DESCRIPTION
https://re-motion.atlassian.net/browse/RM-9025

Solution implemented with the reference implementation https://raw.githack.com/w3c/aria-practices/aria1.2-combobox-proposal/examples/combobox/combobox-autocomplete-list.html in mind. Tested with JAWS 2021, JAWS 2023, NVDA, and Narrator. See repro in the issue description.

Open points @MichaelKetting:
 - [x] "Update WCAG samples/doc for combobox behavior." What samples/doc?