### PR TITLE
BocList validation icons have incorrect focus behavior (Backport 5.1)

### DIFF
--- a/Remotion/ObjectBinding/Web.UnitTests/UI/Controls/BocListImplementation/Rendering/BocColumnRendererBaseTest.cs
+++ b/Remotion/ObjectBinding/Web.UnitTests/UI/Controls/BocListImplementation/Rendering/BocColumnRendererBaseTest.cs
@@ -442,13 +442,15 @@ namespace Remotion.ObjectBinding.Web.UnitTests.UI.Controls.BocListImplementation
 
       var iconSpan = Html.GetAssertedChildElement(cellStructureDiv, "span", 0);
       Html.AssertAttribute(iconSpan, "class", _bocListCssClassDefinition.ValidationErrorMarker);
-      Html.AssertAttribute(iconSpan, "id", "MyList_C6_R0_ValidationMarker");
       Html.AssertAttribute(iconSpan, "title", "error message\r\n");
-      Html.AssertAttribute(iconSpan, "tabindex", "-1");
       Html.AssertAttribute(iconSpan, "aria-hidden", "true");
-      Html.AssertChildElementCount(iconSpan, 1);
+      Html.AssertChildElementCount(iconSpan, 2);
 
-      var img = Html.GetAssertedChildElement(iconSpan, "img", 0);
+      var jumpMarker = Html.GetAssertedChildElement(iconSpan, "span", 0);
+      Html.AssertAttribute(jumpMarker, "id", "MyList_C6_R0_ValidationMarker");
+      Html.AssertAttribute(jumpMarker, "tabindex", "-1");
+
+      var img = Html.GetAssertedChildElement(iconSpan, "img", 1);
       Html.AssertAttribute(img, "src", "/fake/Remotion.Web/Themes/Fake/Image/sprite.svg#ValidationError");
 
       var div = Html.GetAssertedChildElement(cellStructureDiv, "div", 1);

--- a/Remotion/ObjectBinding/Web.UnitTests/UI/Controls/BocListImplementation/Rendering/BocListValidationSummaryRendererTest.cs
+++ b/Remotion/ObjectBinding/Web.UnitTests/UI/Controls/BocListImplementation/Rendering/BocListValidationSummaryRendererTest.cs
@@ -38,7 +38,8 @@ namespace Remotion.ObjectBinding.Web.UnitTests.UI.Controls.BocListImplementation
     {
       None = 0,
       ScreenReader = 1,
-      DiagnosticMetadata = 2
+      DiagnosticMetadata = 2,
+      NoLinks = 4
     }
 
     private BocListCssClassDefinition _bocListCssClassDefinition;
@@ -80,6 +81,33 @@ namespace Remotion.ObjectBinding.Web.UnitTests.UI.Controls.BocListImplementation
           TestSettings.None,
           validationFailures,
           new[] { CreateTextAssert("Failure A"), CreateTextAssert("Failure B") });
+    }
+
+    [Test]
+    public void Render_CellFailureWithoutLink ()
+    {
+      var propertyStub = new Mock<IBusinessObjectProperty>();
+      propertyStub.Setup(e => e.DisplayName).Returns("ColumnName");
+
+      var columnDefinitionStub1 = new Mock<BocColumnDefinition>();
+      columnDefinitionStub1.Setup(e => e.ColumnTitle).Returns(WebString.CreateFromText("Incorrect title"));
+      columnDefinitionStub1.Setup(e => e.ColumnTitleDisplayValue).Returns(WebString.CreateFromText("MyColumnTitle"));
+      columnDefinitionStub1.Setup(e => e.ItemID).Returns("MyColumnItemID");
+
+      _columnIndexProviderMock.Setup(e => e.GetVisibleColumnIndex(columnDefinitionStub1.Object)).Returns(1);
+
+      var validationFailures = new[]
+                               {
+                                   CreateCellValidationFailure("My first failure", propertyStub.Object, columnDefinitionStub1.Object),
+                               };
+
+      RenderAndAssertValidationSummary(
+          TestSettings.NoLinks,
+          validationFailures,
+          new[]
+          {
+              CreateTextAssert("ColumnName: My first failure"),
+          });
     }
 
     [Test]
@@ -228,7 +256,8 @@ namespace Remotion.ObjectBinding.Web.UnitTests.UI.Controls.BocListImplementation
       var renderArguments = new BocListValidationSummaryRenderArguments(
           _columnIndexProviderMock.Object,
           validationFailures,
-          3);
+          3,
+          renderCellValidationFailuresAsLinks: (settings & TestSettings.NoLinks) == 0);
       validationSummaryRenderer.Render(bocRenderingContext, in renderArguments);
 
       return Html.GetResultDocument();

--- a/Remotion/ObjectBinding/Web/Res/Themes/NovaGray/Html/BocList.css
+++ b/Remotion/ObjectBinding/Web/Res/Themes/NovaGray/Html/BocList.css
@@ -642,7 +642,7 @@ span.bocListAvailableViewsListLabel
   padding-top: 0.1em;
 }
 
-.bocList .validationErrorMarker:focus
+.bocList .validationErrorMarker:focus-within
 {
   outline: auto 5px -webkit-focus-ring-color;
 }

--- a/Remotion/ObjectBinding/Web/Res/Themes/NovaViso/HTML/BocList.css
+++ b/Remotion/ObjectBinding/Web/Res/Themes/NovaViso/HTML/BocList.css
@@ -386,8 +386,8 @@ div.bocList .bocListCellStructureElement > .validationErrorMarker
   padding: calc(var(--remotion-themed-spacing) / 2);
 }
 
-div.bocList .bocListCellStructureElement > .validationErrorMarker:focus,
-div.bocList .bocListContent > .validationErrorMarker:focus
+div.bocList .bocListCellStructureElement > .validationErrorMarker:focus-within,
+div.bocList .bocListContent > .validationErrorMarker:focus-within
 {
   outline: none;
   background-color: var(--remotion-themed-background-color-focus);

--- a/Remotion/ObjectBinding/Web/UI/Controls/BocListImplementation/Rendering/BocColumnRendererBase.cs
+++ b/Remotion/ObjectBinding/Web/UI/Controls/BocListImplementation/Rendering/BocColumnRendererBase.cs
@@ -390,12 +390,17 @@ namespace Remotion.ObjectBinding.Web.UI.Controls.BocListImplementation.Rendering
           tooltipStringBuilder.AppendLine(validationFailure.Failure.ErrorMessage);
         }
 
-        renderingContext.Writer.AddAttribute(HtmlTextWriterAttribute.Id, BocRowRenderer.GetCellIDForValidationMarker(renderingContext.Control, arguments.RowIndex, renderingContext.VisibleColumnIndex));
         renderingContext.Writer.AddAttribute(HtmlTextWriterAttribute.Title, tooltipStringBuilder.ToString());
-        renderingContext.Writer.AddAttribute(HtmlTextWriterAttribute.Tabindex, "-1");
         renderingContext.Writer.AddAttribute(HtmlTextWriterAttribute.Class, CssClasses.ValidationErrorMarker);
         renderingContext.Writer.AddAttribute(HtmlTextWriterAttribute2.AriaHidden, HtmlAriaHiddenAttributeValue.True);
         renderingContext.Writer.RenderBeginTag(HtmlTextWriterTag.Span);
+
+        // Render a special zero-sized span that is used as jump target for the validation messages below the current row.
+        // We need a separate zero-sized element here as tabindex="-1" allows click-focus, which is not wanted in this case.
+        renderingContext.Writer.AddAttribute(HtmlTextWriterAttribute.Id, BocRowRenderer.GetCellIDForValidationMarker(renderingContext.Control, arguments.RowIndex, renderingContext.VisibleColumnIndex));
+        renderingContext.Writer.AddAttribute(HtmlTextWriterAttribute.Tabindex, "-1");
+        renderingContext.Writer.RenderBeginTag(HtmlTextWriterTag.Span);
+        renderingContext.Writer.RenderEndTag();
 
         var iconInfo = new IconInfo(_resourceUrlFactory.CreateThemedResourceUrl(typeof(InfrastructureResourceUrlFactory), ResourceType.Image, c_validationIndicatorIcon).GetUrl());
         iconInfo.Render(renderingContext.Writer, renderingContext.Control);

--- a/Remotion/ObjectBinding/Web/UI/Controls/BocListImplementation/Rendering/BocListValidationSummaryRenderArguments.cs
+++ b/Remotion/ObjectBinding/Web/UI/Controls/BocListImplementation/Rendering/BocListValidationSummaryRenderArguments.cs
@@ -41,10 +41,16 @@ namespace Remotion.ObjectBinding.Web.UI.Controls.BocListImplementation.Rendering
     /// </summary>
     public int RowIndex { get; }
 
+    /// <summary>
+    /// Indicates that cell validation failure messages should be rendered as links.
+    /// </summary>
+    public bool RenderCellValidationFailuresAsLinks { get; }
+
     public BocListValidationSummaryRenderArguments (
         IBocListColumnIndexProvider columnIndexProvider,
         IEnumerable<BocListValidationFailureWithLocationInformation> validationFailures,
-        int rowIndex)
+        int rowIndex,
+        bool renderCellValidationFailuresAsLinks)
     {
       ArgumentUtility.CheckNotNull(nameof(columnIndexProvider), columnIndexProvider);
       ArgumentUtility.CheckNotNull(nameof(validationFailures), validationFailures);
@@ -52,6 +58,7 @@ namespace Remotion.ObjectBinding.Web.UI.Controls.BocListImplementation.Rendering
       ColumnIndexProvider = columnIndexProvider;
       ValidationFailures = validationFailures;
       RowIndex = rowIndex;
+      RenderCellValidationFailuresAsLinks = renderCellValidationFailuresAsLinks;
     }
   }
 }

--- a/Remotion/ObjectBinding/Web/UI/Controls/BocListImplementation/Rendering/BocListValidationSummaryRenderer.cs
+++ b/Remotion/ObjectBinding/Web/UI/Controls/BocListImplementation/Rendering/BocListValidationSummaryRenderer.cs
@@ -52,7 +52,7 @@ namespace Remotion.ObjectBinding.Web.UI.Controls.BocListImplementation.Rendering
       renderingContext.Writer.RenderBeginTag(HtmlTextWriterTag.Ul);
 
       foreach (var validationFailureWithLocation in arguments.ValidationFailures)
-        RenderValidationFailure(renderingContext, validationFailureWithLocation, arguments.RowIndex, arguments.ColumnIndexProvider);
+        RenderValidationFailure(renderingContext, validationFailureWithLocation, in arguments);
 
       renderingContext.Writer.RenderEndTag();
     }
@@ -65,8 +65,7 @@ namespace Remotion.ObjectBinding.Web.UI.Controls.BocListImplementation.Rendering
     private void RenderValidationFailure (
         BocRenderingContext<IBocList> renderingContext,
         BocListValidationFailureWithLocationInformation validationFailureWithLocation,
-        int rowIndex,
-        IBocListColumnIndexProvider columnIndexProvider)
+        in BocListValidationSummaryRenderArguments arguments)
     {
       if (_renderingFeatures.EnableDiagnosticMetadata)
       {
@@ -82,7 +81,7 @@ namespace Remotion.ObjectBinding.Web.UI.Controls.BocListImplementation.Rendering
       renderingContext.Writer.RenderBeginTag(HtmlTextWriterTag.Li);
 
       var columnDefinition = validationFailureWithLocation.ColumnDefinition;
-      if (columnDefinition == null)
+      if (columnDefinition == null || !arguments.RenderCellValidationFailuresAsLinks)
       {
         renderingContext.Writer.RenderBeginTag(HtmlTextWriterTag.Span);
 
@@ -95,10 +94,10 @@ namespace Remotion.ObjectBinding.Web.UI.Controls.BocListImplementation.Rendering
       }
       else
       {
-        var visibleColumnIndex = columnIndexProvider.GetVisibleColumnIndex(columnDefinition);
+        var visibleColumnIndex = arguments.ColumnIndexProvider.GetVisibleColumnIndex(columnDefinition);
         Assertion.IsTrue(visibleColumnIndex != -1, "visibleColumnIndex != -1");
 
-        var validationMarkerCellID = BocRowRenderer.GetCellIDForValidationMarker(renderingContext.Control, rowIndex, visibleColumnIndex);
+        var validationMarkerCellID = BocRowRenderer.GetCellIDForValidationMarker(renderingContext.Control, arguments.RowIndex, visibleColumnIndex);
         renderingContext.Writer.AddAttribute(HtmlTextWriterAttribute.Href, $"#{validationMarkerCellID}");
         renderingContext.Writer.AddAttribute(HtmlTextWriterAttribute.Onclick, c_onInlineValidationEntryClickScript);
         renderingContext.Writer.RenderBeginTag(HtmlTextWriterTag.A);

--- a/Remotion/ObjectBinding/Web/UI/Controls/BocListImplementation/Rendering/BocRowRenderer.cs
+++ b/Remotion/ObjectBinding/Web/UI/Controls/BocListImplementation/Rendering/BocRowRenderer.cs
@@ -252,7 +252,11 @@ namespace Remotion.ObjectBinding.Web.UI.Controls.BocListImplementation.Rendering
       renderingContext.Writer.RenderBeginTag(HtmlTextWriterTag.Div);
 
       var columnIndexProvider = new BocListColumnIndexProvider(columnRenderers);
-      var arguments = new BocListValidationSummaryRenderArguments(columnIndexProvider ,validationFailuresWithLocationInfo, rowIndex);
+      var arguments = new BocListValidationSummaryRenderArguments(
+          columnIndexProvider,
+          validationFailuresWithLocationInfo,
+          rowIndex,
+          renderCellValidationFailuresAsLinks: true);
 
       _validationSummaryRenderer.Render(renderingContext, arguments);
 

--- a/Remotion/ObjectBinding/Web/UI/Controls/BocListImplementation/Rendering/BocValidationErrorIndicatorColumnRenderer.cs
+++ b/Remotion/ObjectBinding/Web/UI/Controls/BocListImplementation/Rendering/BocValidationErrorIndicatorColumnRenderer.cs
@@ -91,7 +91,8 @@ namespace Remotion.ObjectBinding.Web.UI.Controls.BocListImplementation.Rendering
         var renderArguments = new BocListValidationSummaryRenderArguments(
             renderingContext.ColumnIndexProvider,
             validationFailures,
-            arguments.RowIndex);
+            arguments.RowIndex,
+            renderCellValidationFailuresAsLinks: false);
 
         renderingContext.Writer.AddAttribute(HtmlTextWriterAttribute.Class, CssClasses.CssClassScreenReaderText);
         renderingContext.Writer.RenderBeginTag(HtmlTextWriterTag.Span);


### PR DESCRIPTION
https://re-motion.atlassian.net/browse/RM-9066

backport of #1001 