### PR TITLE
Feature/rm 9152 change tree view to improve support for wcag

### DIFF
--- a/Remotion/ObjectBinding/Web.Development.WebTesting.TestSite.Shared/Controls/BocTreeViewUserControl.ascx.cs
+++ b/Remotion/ObjectBinding/Web.Development.WebTesting.TestSite.Shared/Controls/BocTreeViewUserControl.ascx.cs
@@ -29,10 +29,12 @@ namespace Remotion.ObjectBinding.Web.Development.WebTesting.TestSite.Shared.Cont
     protected override void OnInit (EventArgs e)
     {
       base.OnInit(e);
+#pragma warning disable CS0618 // Type or member is obsolete
       Normal.MenuItemProvider = new TestBocTreeViewContextMenu();
       ContextMenu_Delayed.MenuItemProvider = new TestBocTreeViewContextMenu();
       ContextMenu_DelayedLongerThanTimeout.MenuItemProvider = new TestBocTreeViewContextMenu();
       ContextMenu_Error.MenuItemProvider = new TestBocTreeViewContextMenu();
+#pragma warning restore CS0618 // Type or member is obsolete
     }
 
     protected override void OnPreRender (EventArgs e)

--- a/Remotion/ObjectBinding/Web.Test/SingleTestTreeView.aspx.cs
+++ b/Remotion/ObjectBinding/Web.Test/SingleTestTreeView.aspx.cs
@@ -161,8 +161,10 @@ namespace OBWTest
 
       WebTreeView.SetEvaluateTreeNodeDelegate(new EvaluateWebTreeNode(EvaluateTreeNode));
 
+#pragma warning disable CS0618 // Type or member is obsolete
       WebTreeView.MenuItemProvider = new TestWebTreeViewMenuItemProvider();
       PersonTreeViewWithMenus.MenuItemProvider = new TestBocTreeViewMenuItemProvider();
+#pragma warning restore CS0618 // Type or member is obsolete
     }
 
     private void EvaluateTreeNode (WebTreeNode node)

--- a/Remotion/ObjectBinding/Web/UI/Controls/BocTreeView.cs
+++ b/Remotion/ObjectBinding/Web/UI/Controls/BocTreeView.cs
@@ -1012,6 +1012,7 @@ namespace Remotion.ObjectBinding.Web.UI.Controls
       get { return (BocTreeNode?)_treeView.SelectedNode; }
     }
 
+    [Obsolete("Context menu is not compatible with keyboard navigation. See RM-9153", false)]
     [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
     [Browsable(false)]
     public BocTreeViewMenuItemProvider? MenuItemProvider

--- a/Remotion/Web/Core/Res/Themes/NovaGray/HTML/TreeView.css
+++ b/Remotion/Web/Core/Res/Themes/NovaGray/HTML/TreeView.css
@@ -34,7 +34,7 @@ ul.treeViewNodeChildrenNoLines
   list-style: none;
 }
 
-ul.treeViewRoot li
+ul.treeViewRoot a
 {
   outline: none;
 }
@@ -126,9 +126,9 @@ span.treeViewNodeHeadSelected a
   color: Black;
 }
 
-li:focus > span.treeViewNode span.treeViewNodeHead a,
+span.treeViewNodeHead a:focus,
 span.treeViewNodeHead a:hover,
-li:focus > span.treeViewNode span.treeViewNodeHeadSelected a,
+span.treeViewNodeHeadSelected a:focus,
 span.treeViewNodeHeadSelected a:hover
 {
   padding: 1px;
@@ -146,9 +146,9 @@ span.treeViewNodeHeadSelected a:focus
   outline: none;
 }
 
-li:focus > span.treeViewNode span.treeViewNodeHead a > span,
-li:focus > span.treeViewNode span.treeViewNodeHead a:hover > span,
-li:focus > span.treeViewNode span.treeViewNodeHeadSelected a > span
+span.treeViewNodeHead a:focus > span,
+span.treeViewNodeHead a:focus:hover > span,
+span.treeViewNodeHeadSelected a:focus > span
 {
   text-decoration: underline;
 }

--- a/Remotion/Web/Core/Res/Themes/NovaViso/HTML/TreeView.css
+++ b/Remotion/Web/Core/Res/Themes/NovaViso/HTML/TreeView.css
@@ -48,7 +48,7 @@ ul.treeViewRoot ul.treeViewTopLevelNodeChildren
 }
 
 ul.treeViewRoot span.treeViewNodeHeadSelected a:focus,
-ul.treeViewRoot li[role=treeitem]
+ul.treeViewRoot a[role=treeitem]
 {
   outline: none;
 }
@@ -60,20 +60,20 @@ ul.treeViewRoot li > span.treeViewNode
   border-radius: var(--remotion-themed-border-radius);
 }
 
-ul.treeViewRoot li[aria-selected=true] > span.treeViewNode
+ul.treeViewRoot span.treeViewNode:has(a[aria-selected=true])
 {
   background-color: var(--color-highlight);
   border-color: var(--color-highlight);
 }
 
-ul.treeViewRoot li > span.treeViewNode:hover
+ul.treeViewRoot span.treeViewNode:hover
 {
   background-color: var(--remotion-themed-background-color-hover);
   border: var(--remotion-themed-border-hover);
   box-shadow: var(--remotion-themed-box-shadow-hover);
 }
 
-ul.treeViewRoot li:focus > span.treeViewNode
+ul.treeViewRoot span.treeViewNode:has(a:focus)
 {
   outline: var(--remotion-themed-outline-focus);
   outline-offset: var(--remotion-themed-outline-offset-focus);
@@ -82,7 +82,7 @@ ul.treeViewRoot li:focus > span.treeViewNode
   box-shadow: var(--remotion-themed-box-shadow-focus);
 }
 
-ul.treeViewRoot li:focus > span.treeViewNode:hover
+ul.treeViewRoot span.treeViewNode:hover:has(a:focus)
 {
   outline: var(--remotion-themed-outline-focus-hover);
   outline-offset: var(--remotion-themed-outline-offset-focus-hover);
@@ -91,7 +91,7 @@ ul.treeViewRoot li:focus > span.treeViewNode:hover
   box-shadow: var(--remotion-themed-box-shadow-focus-hover);
 }
 
-ul.treeViewRoot li[aria-selected=true]:focus > span.treeViewNode
+ul.treeViewRoot span.treeViewNode:has(a[aria-selected=true]:focus)
 {
   outline: var(--remotion-themed-outline-focus);
   outline-offset: var(--remotion-themed-outline-offset-focus);
@@ -100,7 +100,7 @@ ul.treeViewRoot li[aria-selected=true]:focus > span.treeViewNode
   box-shadow: var(--remotion-themed-box-shadow-focus);
 }
 
-ul.treeViewRoot li[aria-selected=true]:focus > span.treeViewNode:hover
+ul.treeViewRoot span.treeViewNode:hover:has(a[aria-selected=true]:focus)
 {
   outline: var(--remotion-themed-outline-focus-hover);
   outline-offset: var(--remotion-themed-outline-offset-focus-hover);
@@ -174,8 +174,8 @@ ul.treeViewRoot span.treeViewNode span.treeViewNodeBadge
   align-self: start;
 }
 
-ul.treeViewRoot li:focus > ul > li:first-of-type span.treeViewNode:not(:hover) span.treeViewNodeBadge,
-ul.treeViewRoot li:focus + li span.treeViewNode:not(:hover) span.treeViewNodeBadge
+ul.treeViewRoot li:has(a:focus) > ul > li:first-of-type span.treeViewNode:not(:hover) span.treeViewNodeBadge,
+ul.treeViewRoot li:has(a:focus) + li span.treeViewNode:not(:hover) span.treeViewNodeBadge
 {
   /* Simulate continued box-shadow from previous element due to the badge-element hiding the shadow-effect. */
   --rounding-value: 0.5px;
@@ -183,8 +183,8 @@ ul.treeViewRoot li:focus + li span.treeViewNode:not(:hover) span.treeViewNodeBad
   box-shadow: inset 0 calc(1px + var(--treeview-node-padding-vertical) + var(--rounding-value)) 5px -5px rgba(0, 0, 0, 0.3);
 }
 
-ul.treeViewRoot li[aria-selected=true] > span.treeViewNode span.treeViewNodeBadge,
-ul.treeViewRoot li[aria-selected=true]:focus > span.treeViewNode span.treeViewNodeBadge
+ul.treeViewRoot span.treeViewNode:has(a[aria-selected=true]) span.treeViewNodeBadge,
+ul.treeViewRoot span.treeViewNode:has(a[aria-selected=true]:focus) span.treeViewNodeBadge
 {
   background-color: var(--color-highlight);
 }
@@ -194,12 +194,12 @@ ul.treeViewRoot span.treeViewNode:hover span.treeViewNodeBadge
   background-color: var(--remotion-themed-background-color-hover);
 }
 
-ul.treeViewRoot li:focus > span.treeViewNode span.treeViewNodeBadge
+ul.treeViewRoot span.treeViewNode:has(a:focus) span.treeViewNodeBadge
 {
   background-color: var(--remotion-themed-background-color-focus);
 }
 
-ul.treeViewRoot li:focus > span.treeViewNode:hover span.treeViewNodeBadge
+ul.treeViewRoot span.treeViewNode:hover:has(a:focus) span.treeViewNodeBadge
 {
   background-color: var(--remotion-themed-background-color-focus-hover);
 }

--- a/Remotion/Web/Core/UI/Controls/WebTreeView.cs
+++ b/Remotion/Web/Core/UI/Controls/WebTreeView.cs
@@ -836,7 +836,7 @@ namespace Remotion.Web.UI.Controls
 
       writer.AddAttribute(HtmlTextWriterAttribute.Class, CssClassScreenReaderText);
       writer.RenderBeginTag(HtmlTextWriterTag.Span);
-      writer.Write(".");
+      writer.Write(", ");
       badge.Description.WriteTo(writer);
       writer.RenderEndTag();
     }

--- a/Remotion/Web/Core/UI/Controls/WebTreeView.cs
+++ b/Remotion/Web/Core/UI/Controls/WebTreeView.cs
@@ -1277,6 +1277,7 @@ namespace Remotion.Web.UI.Controls
       }
     }
 
+    [Obsolete("Context menu is not compatible with keyboard navigation. See RM-9153", false)]
     [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
     [Browsable(false)]
     public WebTreeViewMenuItemProvider? MenuItemProvider


### PR DESCRIPTION
https://re-motion.atlassian.net/browse/RM-9152

Problems that are still existent:
* Cannot enter the tree with tab, seems like some tabindex=0 went missing along the way
* Default highlighting doesn't work properly (probably lost focus somewhere)
* We can go through the whole tree while in browse mode using NVDA, whereas in the WCAG example using NVDA, the tree is skipped. 