### PR TITLE
RM-9151 .NET 8 SDK breaks source linking for .NET Framework (Backport 5.0)

### DIFF
--- a/Build/Shared.build.props
+++ b/Build/Shared.build.props
@@ -48,6 +48,7 @@
   <PropertyGroup>
     <ProjectFeaturesRoot>$(MSBuildThisFileDirectory)ProjectFeatures\</ProjectFeaturesRoot>
     <!-- Enable source link for .NET Core but not for .NET Framework -->
+    <SuppressImplicitGitSourceLink Condition="'$(TargetFramework)' == 'net48'">true</SuppressImplicitGitSourceLink>
     <UseSourceLink Condition="'$(UseSourceLink)' == '' AND '$(TargetFramework)' == 'net48'">false</UseSourceLink>
     <UseSourceLink Condition="'$(UseSourceLink)' == ''">true</UseSourceLink>
   </PropertyGroup>


### PR DESCRIPTION
https://re-motion.atlassian.net/browse/RM-9151

Backport of #1055