### PR TITLE
Feature/rm 9131 introduce public query id and query metadata to query factory create linq query

### DIFF
--- a/Remotion/Data/DomainObjects.ObjectBinding.UnitTests/TestDomain/StubDomainObjectQueryGenerator.cs
+++ b/Remotion/Data/DomainObjects.ObjectBinding.UnitTests/TestDomain/StubDomainObjectQueryGenerator.cs
@@ -27,7 +27,7 @@ namespace Remotion.Data.DomainObjects.ObjectBinding.UnitTests.TestDomain
 {
   public class StubDomainObjectQueryGenerator : IDomainObjectQueryGenerator
   {
-    public IExecutableQuery<T> CreateScalarQuery<T> (string id, StorageProviderDefinition storageProviderDefinition, QueryModel queryModel)
+    public IExecutableQuery<T> CreateScalarQuery<T> (string id, StorageProviderDefinition storageProviderDefinition, QueryModel queryModel, IReadOnlyDictionary<string, object> metadata)
     {
       throw new NotImplementedException();
     }
@@ -36,9 +36,10 @@ namespace Remotion.Data.DomainObjects.ObjectBinding.UnitTests.TestDomain
         string id,
         StorageProviderDefinition storageProviderDefinition,
         QueryModel queryModel,
-        IEnumerable<FetchQueryModelBuilder> fetchQueryModelBuilders)
+        IEnumerable<FetchQueryModelBuilder> fetchQueryModelBuilders,
+        IReadOnlyDictionary<string, object> metadata)
     {
-      return new StubSquenceQuery<T>(new QueryDefinition(id, storageProviderDefinition, "The Query", QueryType.CollectionReadWrite));
+      return new StubSquenceQuery<T>(new QueryDefinition(id, storageProviderDefinition, "The Query", QueryType.CollectionReadWrite, metaData: metadata));
     }
   }
 }

--- a/Remotion/Data/DomainObjects.UnitTests/Linq/DomainObjectQueryExecutorTest.cs
+++ b/Remotion/Data/DomainObjects.UnitTests/Linq/DomainObjectQueryExecutorTest.cs
@@ -23,6 +23,7 @@ using Remotion.Data.DomainObjects.Linq;
 using Remotion.Data.DomainObjects.Linq.ExecutableQueries;
 using Remotion.Data.DomainObjects.Persistence.Configuration;
 using Remotion.Data.DomainObjects.Queries;
+using Remotion.Data.DomainObjects.UnitTests.Queries;
 using Remotion.Data.DomainObjects.UnitTests.TestDomain;
 using Remotion.Development.UnitTesting.Reflection;
 using Remotion.Linq;
@@ -51,7 +52,8 @@ namespace Remotion.Data.DomainObjects.UnitTests.Linq
       base.SetUp();
 
       _queryGeneratorMock = new Mock<IDomainObjectQueryGenerator>(MockBehavior.Default);
-      _queryExecutor = new DomainObjectQueryExecutor(TestDomainStorageProviderDefinition, _queryGeneratorMock.Object);
+
+      _queryExecutor = new DomainObjectQueryExecutor(TestDomainStorageProviderDefinition, _queryGeneratorMock.Object, "<dynamic query>", QueryObjectMother.EmptyMetadata);
 
       _queryManagerMock = new Mock<IQueryManager>(MockBehavior.Strict);
       var transaction = ClientTransactionObjectMother.CreateTransactionWithQueryManager<ClientTransaction>(_queryManagerMock.Object);
@@ -71,10 +73,21 @@ namespace Remotion.Data.DomainObjects.UnitTests.Linq
     }
 
     [Test]
+    public void Initialize ()
+    {
+      var executor = new DomainObjectQueryExecutor(TestDomainStorageProviderDefinition, _queryGeneratorMock.Object, "dummyID", QueryObjectMother.EmptyMetadata);
+
+      Assert.That(executor.Metadata, Is.SameAs(QueryObjectMother.EmptyMetadata));
+      Assert.That(executor.ID, Is.EqualTo("dummyID"));
+      Assert.That(executor.StorageProviderDefinition, Is.SameAs(TestDomainStorageProviderDefinition));
+      Assert.That(executor.QueryGenerator, Is.SameAs(_queryGeneratorMock.Object));
+    }
+
+    [Test]
     public void ExecuteScalar ()
     {
       _queryGeneratorMock
-          .Setup(mock => mock.CreateScalarQuery<int>("<dynamic query>", TestDomainStorageProviderDefinition, _someQueryModel))
+          .Setup(mock => mock.CreateScalarQuery<int>("<dynamic query>", TestDomainStorageProviderDefinition, _someQueryModel, QueryObjectMother.EmptyMetadata))
           .Returns(_scalarExecutableQueryMock.Object)
           .Verifiable();
 
@@ -119,7 +132,8 @@ namespace Remotion.Data.DomainObjects.UnitTests.Linq
                   "<dynamic query>",
                   TestDomainStorageProviderDefinition,
                   _someQueryModel,
-                  It.Is<IEnumerable<FetchQueryModelBuilder>>(p => p.Count() == 0)))
+                  It.Is<IEnumerable<FetchQueryModelBuilder>>(p => p.Count() == 0),
+                  QueryObjectMother.EmptyMetadata))
           .Returns(_collectionExecutableQueryMock.Object)
           .Verifiable();
 
@@ -169,7 +183,8 @@ namespace Remotion.Data.DomainObjects.UnitTests.Linq
                   "<dynamic query>",
                   TestDomainStorageProviderDefinition,
                   _someQueryModel,
-                  It.Is<IEnumerable<FetchQueryModelBuilder>>(p => p.Count() == 0)))
+                  It.Is<IEnumerable<FetchQueryModelBuilder>>(p => p.Count() == 0),
+                  QueryObjectMother.EmptyMetadata))
           .Returns(_collectionExecutableQueryMock.Object)
           .Verifiable();
 
@@ -192,7 +207,8 @@ namespace Remotion.Data.DomainObjects.UnitTests.Linq
                   "<dynamic query>",
                   TestDomainStorageProviderDefinition,
                   _someQueryModel,
-                  It.Is<IEnumerable<FetchQueryModelBuilder>>(p => p.Count() == 0)))
+                  It.Is<IEnumerable<FetchQueryModelBuilder>>(p => p.Count() == 0),
+                  QueryObjectMother.EmptyMetadata))
           .Returns(_collectionExecutableQueryMock.Object)
           .Verifiable();
 
@@ -213,7 +229,8 @@ namespace Remotion.Data.DomainObjects.UnitTests.Linq
                   "<dynamic query>",
                   TestDomainStorageProviderDefinition,
                   _someQueryModel,
-                  It.Is<IEnumerable<FetchQueryModelBuilder>>(p => p.Count() == 0)))
+                  It.Is<IEnumerable<FetchQueryModelBuilder>>(p => p.Count() == 0),
+                  QueryObjectMother.EmptyMetadata))
           .Returns(_collectionExecutableQueryMock.Object)
           .Verifiable();
 
@@ -234,7 +251,8 @@ namespace Remotion.Data.DomainObjects.UnitTests.Linq
                   "<dynamic query>",
                   TestDomainStorageProviderDefinition,
                   _someQueryModel,
-                  It.Is<IEnumerable<FetchQueryModelBuilder>>(p => p.Count() == 0)))
+                  It.Is<IEnumerable<FetchQueryModelBuilder>>(p => p.Count() == 0),
+                  QueryObjectMother.EmptyMetadata))
           .Returns(_collectionExecutableQueryMock.Object)
           .Verifiable();
 
@@ -274,10 +292,11 @@ namespace Remotion.Data.DomainObjects.UnitTests.Linq
                   It.IsAny<string>(),
                   It.IsAny<StorageProviderDefinition>(),
                   queryModel,
-                  It.IsAny<IEnumerable<FetchQueryModelBuilder>>()))
+                  It.IsAny<IEnumerable<FetchQueryModelBuilder>>(),
+                  QueryObjectMother.EmptyMetadata))
           .Returns(fakeResult)
           .Callback(
-              (string id, StorageProviderDefinition _, QueryModel _, IEnumerable<FetchQueryModelBuilder> fetchQueryModelBuilders) =>
+              (string id, StorageProviderDefinition _, QueryModel _, IEnumerable<FetchQueryModelBuilder> fetchQueryModelBuilders, IReadOnlyDictionary<string, object> _) =>
               {
                 Assert.That(queryModel.ResultOperators, Is.EqualTo(new[] { nonTrailingFetchRequest, someResultOperator }));
 

--- a/Remotion/Data/DomainObjects.UnitTests/Queries/LinqProviderComponentFactoryTest.cs
+++ b/Remotion/Data/DomainObjects.UnitTests/Queries/LinqProviderComponentFactoryTest.cs
@@ -15,6 +15,7 @@
 // along with re-motion; if not, see http://www.gnu.org/licenses.
 // 
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using Moq;
 using NUnit.Framework;
@@ -123,7 +124,12 @@ namespace Remotion.Data.DomainObjects.UnitTests.Queries
     [Test]
     public void CreateQueryExecutor ()
     {
-      var executor = _factory.CreateQueryExecutor(TestDomainStorageProviderDefinition);
+      var metadata = new Dictionary<string, object>
+                     {
+                       { "dummyKey", "dummyValue" }
+                     };
+
+      var executor = _factory.CreateQueryExecutor(TestDomainStorageProviderDefinition, "dummyID", metadata);
 
       Assert.That(executor, Is.TypeOf<DomainObjectQueryExecutor>());
 
@@ -132,12 +138,14 @@ namespace Remotion.Data.DomainObjects.UnitTests.Queries
       Assert.That(
           ((DomainObjectQueryGenerator)domainObjectQueryExecutor.QueryGenerator).MappingConfiguration,
           Is.SameAs(MappingConfiguration.Current));
+      Assert.That(domainObjectQueryExecutor.ID, Is.EqualTo("dummyID"));
+      Assert.That(domainObjectQueryExecutor.Metadata, Is.SameAs(metadata));
     }
 
     [Test]
     public void CreateQueryExecutor_MethodCallTransformerProvider ()
     {
-      var executor = _factory.CreateQueryExecutor(TestDomainStorageProviderDefinition);
+      var executor = _factory.CreateQueryExecutor(TestDomainStorageProviderDefinition, "id", QueryObjectMother.EmptyMetadata);
       var provider = GetMethodCallTransformerProviderFromExecutor(executor);
 
       var toStringMethod = ToStringMethodCallTransformer.SupportedMethods[0];
@@ -154,7 +162,7 @@ namespace Remotion.Data.DomainObjects.UnitTests.Queries
     [Test]
     public void CreateQueryExecutor_ResultOperatorHandlerRegistry ()
     {
-      var executor = _factory.CreateQueryExecutor(TestDomainStorageProviderDefinition);
+      var executor = _factory.CreateQueryExecutor(TestDomainStorageProviderDefinition, "id", QueryObjectMother.EmptyMetadata);
       var nodeTypeRegistry = GetResultOperatorHandlerRegistryFromExecutor(executor);
 
       Assert.That(nodeTypeRegistry.GetItem(typeof(CountResultOperator)), Is.TypeOf(typeof(CountResultOperatorHandler)));

--- a/Remotion/Data/DomainObjects.UnitTests/Queries/QueryFactoryTest.cs
+++ b/Remotion/Data/DomainObjects.UnitTests/Queries/QueryFactoryTest.cs
@@ -15,6 +15,7 @@
 // along with re-motion; if not, see http://www.gnu.org/licenses.
 // 
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using Moq;
 using NUnit.Framework;
@@ -113,14 +114,36 @@ namespace Remotion.Data.DomainObjects.UnitTests.Queries
       var id = "id";
       var statement = "stmt";
       var parameterCollection = new QueryParameterCollection();
+      var metaData = new Dictionary<string, object>
+                     {
+                       { "dummyKey", "dummyValue" }
+                     };
 
-      IQuery query = QueryFactory.CreateScalarQuery(id, TestDomainStorageProviderDefinition, statement, parameterCollection);
+      IQuery query = QueryFactory.CreateScalarQuery(id, TestDomainStorageProviderDefinition, statement, parameterCollection, metaData);
       Assert.That(query.CollectionType, Is.Null);
       Assert.That(query.ID, Is.EqualTo(id));
       Assert.That(query.Parameters, Is.SameAs(parameterCollection));
       Assert.That(query.QueryType, Is.EqualTo(QueryType.ScalarReadOnly));
       Assert.That(query.Statement, Is.EqualTo(statement));
       Assert.That(query.StorageProviderDefinition, Is.SameAs(TestDomainStorageProviderDefinition));
+      Assert.That(query.Metadata, Is.SameAs(metaData));
+    }
+
+    [Test]
+    public void CreateScalarQuery_WithNullMetadata_EmptyMetadataCollection ()
+    {
+      var id = "id";
+      var statement = "stmt";
+      var parameterCollection = new QueryParameterCollection();
+
+      IQuery query = QueryFactory.CreateScalarQuery(id, TestDomainStorageProviderDefinition, statement, parameterCollection, null);
+      Assert.That(query.CollectionType, Is.Null);
+      Assert.That(query.ID, Is.EqualTo(id));
+      Assert.That(query.Parameters, Is.SameAs(parameterCollection));
+      Assert.That(query.QueryType, Is.EqualTo(QueryType.ScalarReadOnly));
+      Assert.That(query.Statement, Is.EqualTo(statement));
+      Assert.That(query.StorageProviderDefinition, Is.SameAs(TestDomainStorageProviderDefinition));
+      Assert.That(query.Metadata, Is.Empty);
     }
 
     [Test]
@@ -130,14 +153,37 @@ namespace Remotion.Data.DomainObjects.UnitTests.Queries
       var statement = "stmt";
       var parameterCollection = new QueryParameterCollection();
       var collectionType = typeof(OrderCollection);
+      var metaData = new Dictionary<string, object>
+                     {
+                       { "dummyKey", "dummyValue" }
+                     };
 
-      IQuery query = QueryFactory.CreateCollectionQuery(id, TestDomainStorageProviderDefinition, statement, parameterCollection, collectionType);
+      IQuery query = QueryFactory.CreateCollectionQuery(id, TestDomainStorageProviderDefinition, statement, parameterCollection, collectionType, metaData);
       Assert.That(query.ID, Is.EqualTo(id));
       Assert.That(query.CollectionType, Is.SameAs(collectionType));
       Assert.That(query.Parameters, Is.SameAs(parameterCollection));
       Assert.That(query.QueryType, Is.EqualTo(QueryType.CollectionReadOnly));
       Assert.That(query.Statement, Is.EqualTo(statement));
       Assert.That(query.StorageProviderDefinition, Is.SameAs(TestDomainStorageProviderDefinition));
+      Assert.That(query.Metadata, Is.SameAs(metaData));
+    }
+
+    [Test]
+    public void CreateCollectionQuery_WithNullMetadata_EmptyMetadataCollection ()
+    {
+      var id = "id";
+      var statement = "stmt";
+      var parameterCollection = new QueryParameterCollection();
+      var collectionType = typeof(OrderCollection);
+
+      IQuery query = QueryFactory.CreateCollectionQuery(id, TestDomainStorageProviderDefinition, statement, parameterCollection, collectionType, null);
+      Assert.That(query.ID, Is.EqualTo(id));
+      Assert.That(query.CollectionType, Is.SameAs(collectionType));
+      Assert.That(query.Parameters, Is.SameAs(parameterCollection));
+      Assert.That(query.QueryType, Is.EqualTo(QueryType.CollectionReadOnly));
+      Assert.That(query.Statement, Is.EqualTo(statement));
+      Assert.That(query.StorageProviderDefinition, Is.SameAs(TestDomainStorageProviderDefinition));
+      Assert.That(query.Metadata, Is.Empty);
     }
 
     [Test]
@@ -146,14 +192,36 @@ namespace Remotion.Data.DomainObjects.UnitTests.Queries
       var id = "id";
       var statement = "stmt";
       var parameterCollection = new QueryParameterCollection();
+      var metaData = new Dictionary<string, object>
+                     {
+                       { "dummyKey", "dummyValue" }
+                     };
 
-      IQuery query = QueryFactory.CreateCustomQuery(id, TestDomainStorageProviderDefinition, statement, parameterCollection);
+      IQuery query = QueryFactory.CreateCustomQuery(id, TestDomainStorageProviderDefinition, statement, parameterCollection, metaData);
       Assert.That(query.ID, Is.EqualTo(id));
       Assert.That(query.CollectionType, Is.Null);
       Assert.That(query.Parameters, Is.SameAs(parameterCollection));
       Assert.That(query.QueryType, Is.EqualTo(QueryType.CustomReadOnly));
       Assert.That(query.Statement, Is.EqualTo(statement));
       Assert.That(query.StorageProviderDefinition, Is.SameAs(TestDomainStorageProviderDefinition));
+      Assert.That(query.Metadata, Is.SameAs(metaData));
+    }
+
+    [Test]
+    public void CreateCustomQuery_WithNullMetadata_EmptyMetadataCollection ()
+    {
+      var id = "id";
+      var statement = "stmt";
+      var parameterCollection = new QueryParameterCollection();
+
+      IQuery query = QueryFactory.CreateCustomQuery(id, TestDomainStorageProviderDefinition, statement, parameterCollection, null);
+      Assert.That(query.ID, Is.EqualTo(id));
+      Assert.That(query.CollectionType, Is.Null);
+      Assert.That(query.Parameters, Is.SameAs(parameterCollection));
+      Assert.That(query.QueryType, Is.EqualTo(QueryType.CustomReadOnly));
+      Assert.That(query.Statement, Is.EqualTo(statement));
+      Assert.That(query.StorageProviderDefinition, Is.SameAs(TestDomainStorageProviderDefinition));
+      Assert.That(query.Metadata, Is.Empty);
     }
 
     [Test]
@@ -231,6 +299,11 @@ namespace Remotion.Data.DomainObjects.UnitTests.Queries
       var serviceLocator = DefaultServiceLocator.Create();
       serviceLocator.RegisterSingle<ILinqProviderComponentFactory>(() => factoryMock.Object);
       RegisterStandardConfiguration(serviceLocator);
+
+      var metadata = new Dictionary<string, object>
+                     {
+                       { "dummyKey", "dummyValue" }
+                     };
       using (new ServiceLocatorScope(serviceLocator))
       {
         var fakeExecutor = new Mock<IQueryExecutor>();
@@ -238,7 +311,7 @@ namespace Remotion.Data.DomainObjects.UnitTests.Queries
         var fakeResult = new Mock<IQueryable<Order>>();
 
         factoryMock
-            .Setup(mock => mock.CreateQueryExecutor(TestDomainStorageProviderDefinition))
+            .Setup(mock => mock.CreateQueryExecutor(TestDomainStorageProviderDefinition, "dummyID", metadata))
             .Returns(fakeExecutor.Object)
             .Verifiable();
         factoryMock
@@ -250,7 +323,7 @@ namespace Remotion.Data.DomainObjects.UnitTests.Queries
             .Returns(fakeResult.Object)
             .Verifiable();
 
-        var result = QueryFactory.CreateLinqQuery<Order>();
+        var result = QueryFactory.CreateLinqQuery<Order>("dummyID", metadata);
 
         factoryMock.Verify();
         Assert.That(result, Is.SameAs(fakeResult.Object));

--- a/Remotion/Data/DomainObjects.UnitTests/Queries/QueryObjectMother.cs
+++ b/Remotion/Data/DomainObjects.UnitTests/Queries/QueryObjectMother.cs
@@ -15,6 +15,7 @@
 // along with re-motion; if not, see http://www.gnu.org/licenses.
 // 
 using System;
+using System.Collections.Generic;
 using Remotion.Data.DomainObjects.Persistence.Configuration;
 using Remotion.Data.DomainObjects.Queries;
 using Remotion.Data.DomainObjects.Queries.Configuration;
@@ -23,6 +24,8 @@ namespace Remotion.Data.DomainObjects.UnitTests.Queries
 {
   public static class QueryObjectMother
   {
+    public static IReadOnlyDictionary<string, object> EmptyMetadata { get; } = new Dictionary<string, object>();
+
     public static IQuery Create (IStorageSettings storageSettings)
     {
       return new Query(CreateQueryDefinition(storageSettings), new QueryParameterCollection());

--- a/Remotion/Data/DomainObjects/Linq/DomainObjectQueryExecutor.cs
+++ b/Remotion/Data/DomainObjects/Linq/DomainObjectQueryExecutor.cs
@@ -33,14 +33,20 @@ namespace Remotion.Data.DomainObjects.Linq
   {
     private readonly StorageProviderDefinition _storageProviderDefinition;
     private readonly IDomainObjectQueryGenerator _queryGenerator;
+    private readonly string _id;
+    private readonly IReadOnlyDictionary<string, object> _metadata;
 
-    public DomainObjectQueryExecutor (StorageProviderDefinition storageProviderDefinition, IDomainObjectQueryGenerator queryGenerator)
+    public DomainObjectQueryExecutor (StorageProviderDefinition storageProviderDefinition, IDomainObjectQueryGenerator queryGenerator, string id, IReadOnlyDictionary<string, object> metadata)
     {
       ArgumentUtility.CheckNotNull("storageProviderDefinition", storageProviderDefinition);
       ArgumentUtility.CheckNotNull("queryGenerator", queryGenerator);
+      ArgumentUtility.CheckNotNullOrEmpty("id", id);
+      ArgumentUtility.CheckNotNull("metadata", metadata);
 
       _storageProviderDefinition = storageProviderDefinition;
       _queryGenerator = queryGenerator;
+      _id = id;
+      _metadata = metadata;
     }
 
     public StorageProviderDefinition StorageProviderDefinition
@@ -52,6 +58,10 @@ namespace Remotion.Data.DomainObjects.Linq
     {
       get { return _queryGenerator; }
     }
+
+    public string ID => _id;
+
+    public IReadOnlyDictionary<string, object> Metadata => _metadata;
 
     /// <summary>
     /// Creates and executes a given <see cref="QueryModel"/> as an <see cref="IQuery"/> using the current <see cref="ClientTransaction"/>'s
@@ -73,7 +83,7 @@ namespace Remotion.Data.DomainObjects.Linq
       if (fetchQueryModelBuilders.Any())
         throw new NotSupportedException("Scalar queries cannot perform eager fetching.");
 
-      var query = _queryGenerator.CreateScalarQuery<T>("<dynamic query>", _storageProviderDefinition, queryModel);
+      var query = _queryGenerator.CreateScalarQuery<T>("<dynamic query>", _storageProviderDefinition, queryModel, _metadata);
       return query.Execute(ClientTransaction.Current.QueryManager);
     }
 
@@ -125,7 +135,8 @@ namespace Remotion.Data.DomainObjects.Linq
           "<dynamic query>",
           _storageProviderDefinition,
           queryModel,
-          fetchQueryModelBuilders);
+          fetchQueryModelBuilders,
+          _metadata);
       return query.Execute(ClientTransaction.Current.QueryManager);
     }
 

--- a/Remotion/Data/DomainObjects/Linq/DomainObjectQueryGenerator.cs
+++ b/Remotion/Data/DomainObjects/Linq/DomainObjectQueryGenerator.cs
@@ -64,7 +64,8 @@ namespace Remotion.Data.DomainObjects.Linq
           string id,
           StorageProviderDefinition storageProviderDefinition,
           QueryModel queryModel,
-          IEnumerable<FetchQueryModelBuilder> fetchQueryModelBuilders);
+          IEnumerable<FetchQueryModelBuilder> fetchQueryModelBuilders,
+          IReadOnlyDictionary<string, object> metadata);
     }
 
     private class GenericCallHelper<T> : GenericCallHelper
@@ -78,9 +79,10 @@ namespace Remotion.Data.DomainObjects.Linq
           string id,
           StorageProviderDefinition storageProviderDefinition,
           QueryModel queryModel,
-          IEnumerable<FetchQueryModelBuilder> fetchQueryModelBuilders)
+          IEnumerable<FetchQueryModelBuilder> fetchQueryModelBuilders,
+          IReadOnlyDictionary<string, object> metadata)
       {
-        return domainObjectQueryGenerator.CreateSequenceQuery<T>(id, storageProviderDefinition, queryModel, fetchQueryModelBuilders);
+        return domainObjectQueryGenerator.CreateSequenceQuery<T>(id, storageProviderDefinition, queryModel, fetchQueryModelBuilders, metadata);
       }
     }
 
@@ -128,16 +130,21 @@ namespace Remotion.Data.DomainObjects.Linq
       get { return _mappingConfiguration; }
     }
 
-    public virtual IExecutableQuery<T> CreateScalarQuery<T> (string id, StorageProviderDefinition storageProviderDefinition, QueryModel queryModel)
+    public virtual IExecutableQuery<T> CreateScalarQuery<T> (
+        string id,
+        StorageProviderDefinition storageProviderDefinition,
+        QueryModel queryModel,
+        IReadOnlyDictionary<string, object> metadata)
     {
-      ArgumentUtility.CheckNotNull("id", id);
+      ArgumentUtility.CheckNotNullOrEmpty("id", id);
       ArgumentUtility.CheckNotNull("storageProviderDefinition", storageProviderDefinition);
       ArgumentUtility.CheckNotNull("queryModel", queryModel);
+      ArgumentUtility.CheckNotNull("metadata", metadata);
 
       var sqlQuery = _sqlQueryGenerator.CreateSqlQuery(queryModel);
       var sqlCommand = sqlQuery.SqlCommand;
 
-      var query = CreateQuery(id, storageProviderDefinition, sqlCommand.CommandText, sqlCommand.Parameters, QueryType.ScalarReadOnly, selectedEntityType: null);
+      var query = CreateQuery(id, storageProviderDefinition, sqlCommand.CommandText, sqlCommand.Parameters, QueryType.ScalarReadOnly, selectedEntityType: null, metadata);
 
       var projection = sqlCommand.GetInMemoryProjection<T>().Compile();
       return new ScalarQueryAdapter<T>(query, o => projection(new ScalarResultRowAdapter(o, _storageTypeInformationProvider)));
@@ -147,18 +154,20 @@ namespace Remotion.Data.DomainObjects.Linq
         string id,
         StorageProviderDefinition storageProviderDefinition,
         QueryModel queryModel,
-        IEnumerable<FetchQueryModelBuilder> fetchQueryModelBuilders)
+        IEnumerable<FetchQueryModelBuilder> fetchQueryModelBuilders,
+        IReadOnlyDictionary<string, object> metadata)
     {
       ArgumentUtility.CheckNotNullOrEmpty("id", id);
       ArgumentUtility.CheckNotNull("storageProviderDefinition", storageProviderDefinition);
       ArgumentUtility.CheckNotNull("queryModel", queryModel);
       ArgumentUtility.CheckNotNull("fetchQueryModelBuilders", fetchQueryModelBuilders);
+      ArgumentUtility.CheckNotNull("metadata", metadata);
 
       var sqlQuery = _sqlQueryGenerator.CreateSqlQuery(queryModel);
       var command = sqlQuery.SqlCommand;
 
       var queryType = sqlQuery.SelectedEntityType != null ? QueryType.CollectionReadOnly : QueryType.CustomReadOnly;
-      var query = CreateQuery(id, storageProviderDefinition, command.CommandText, command.Parameters, queryType, sqlQuery.SelectedEntityType);
+      var query = CreateQuery(id, storageProviderDefinition, command.CommandText, command.Parameters, queryType, sqlQuery.SelectedEntityType, metadata);
 
       if (queryType == QueryType.CollectionReadOnly)
       {
@@ -166,7 +175,7 @@ namespace Remotion.Data.DomainObjects.Linq
         var selectedEntityClassDefinition = _mappingConfiguration.GetTypeDefinition(sqlQuery.SelectedEntityType);
         Assertion.IsNotNull(selectedEntityClassDefinition, "We assume that in a re-store LINQ query, entities always have a mapping.");
 
-        var fetchQueries = CreateEagerFetchQueries(selectedEntityClassDefinition, fetchQueryModelBuilders);
+        var fetchQueries = CreateEagerFetchQueries(selectedEntityClassDefinition, fetchQueryModelBuilders, metadata);
         foreach (var fetchQuery in fetchQueries)
           query.EagerFetchQueries.Add(fetchQuery.Item1, fetchQuery.Item2);
 
@@ -188,12 +197,14 @@ namespace Remotion.Data.DomainObjects.Linq
         string statement,
         CommandParameter[] commandParameters,
         QueryType queryType,
-        Type? selectedEntityType)
+        Type? selectedEntityType,
+        IReadOnlyDictionary<string, object> metadata)
     {
       ArgumentUtility.CheckNotNullOrEmpty("id", id);
       ArgumentUtility.CheckNotNull("storageProviderDefinition", storageProviderDefinition);
       ArgumentUtility.CheckNotNull("statement", statement);
       ArgumentUtility.CheckNotNull("commandParameters", commandParameters);
+      ArgumentUtility.CheckNotNull("metadata", metadata);
 
       var queryParameters = new QueryParameterCollection();
       foreach (var commandParameter in commandParameters)
@@ -201,16 +212,17 @@ namespace Remotion.Data.DomainObjects.Linq
 
       return queryType switch
       {
-        QueryType.ScalarReadOnly => QueryFactory.CreateScalarQuery(id, storageProviderDefinition, statement, queryParameters),
-        QueryType.CollectionReadOnly => QueryFactory.CreateCollectionQuery(id, storageProviderDefinition, statement, queryParameters, GetCollectionType(selectedEntityType)),
-        QueryType.CustomReadOnly => QueryFactory.CreateCustomQuery(id, storageProviderDefinition, statement, queryParameters),
+        QueryType.ScalarReadOnly => QueryFactory.CreateScalarQuery(id, storageProviderDefinition, statement, queryParameters, metadata),
+        QueryType.CollectionReadOnly => QueryFactory.CreateCollectionQuery(id, storageProviderDefinition, statement, queryParameters, GetCollectionType(selectedEntityType), metadata),
+        QueryType.CustomReadOnly => QueryFactory.CreateCustomQuery(id, storageProviderDefinition, statement, queryParameters, metadata),
         _ => throw new ArgumentException("The requested query type '{0}' cannot be used with LiNQ. Only read-only query types are supported.", "queryType")
       };
     }
 
     private IEnumerable<Tuple<IRelationEndPointDefinition, IQuery>> CreateEagerFetchQueries (
         ClassDefinition previousClassDefinition,
-        IEnumerable<FetchQueryModelBuilder> fetchQueryModelBuilders)
+        IEnumerable<FetchQueryModelBuilder> fetchQueryModelBuilders,
+        IReadOnlyDictionary<string, object> metadata)
     {
       foreach (var fetchQueryModelBuilder in fetchQueryModelBuilders)
       {
@@ -245,7 +257,8 @@ namespace Remotion.Data.DomainObjects.Linq
             "<fetch query for " + fetchQueryModelBuilder.FetchRequest.RelationMember.Name + ">",
             previousClassDefinition.StorageEntityDefinition.StorageProviderDefinition,
             fetchQueryModel,
-            fetchQueryModelBuilder.CreateInnerBuilders());
+            fetchQueryModelBuilder.CreateInnerBuilders(),
+            metadata);
 
         yield return Tuple.Create(relationEndPointDefinition, fetchQuery);
       }

--- a/Remotion/Data/DomainObjects/Linq/ExecutableQueries/QueryAdapterBase.cs
+++ b/Remotion/Data/DomainObjects/Linq/ExecutableQueries/QueryAdapterBase.cs
@@ -15,6 +15,7 @@
 // along with re-motion; if not, see http://www.gnu.org/licenses.
 // 
 using System;
+using System.Collections.Generic;
 using Remotion.Data.DomainObjects.Persistence.Configuration;
 using Remotion.Data.DomainObjects.Queries;
 using Remotion.Data.DomainObjects.Queries.Configuration;
@@ -47,6 +48,11 @@ namespace Remotion.Data.DomainObjects.Linq.ExecutableQueries
     public string ID
     {
       get { return _query.ID; }
+    }
+
+    public IReadOnlyDictionary<string, object> Metadata
+    {
+      get { return _query.Metadata; }
     }
 
     public string Statement

--- a/Remotion/Data/DomainObjects/Linq/IDomainObjectQueryGenerator.cs
+++ b/Remotion/Data/DomainObjects/Linq/IDomainObjectQueryGenerator.cs
@@ -38,10 +38,11 @@ namespace Remotion.Data.DomainObjects.Linq
     /// <param name="id">The identifier for the resulting query.</param>
     /// <param name="storageProviderDefinition">The <see cref="StorageProvider"/> for the query.</param>
     /// <param name="queryModel">The <see cref="QueryModel"/> describing the query.</param>
+    /// <param name="metadata">The metadata for the query. This parameter can be used to e.g. provide diagnostic information or query hints to the system.</param>
     /// <returns>
     /// An <see cref="IExecutableQuery{T}"/> object corresponding to the given <paramref name="queryModel"/> that returns a scalar value when it is executed.
     /// </returns>
-    IExecutableQuery<T> CreateScalarQuery<T> (string id, StorageProviderDefinition storageProviderDefinition, QueryModel queryModel);
+    IExecutableQuery<T> CreateScalarQuery<T> (string id, StorageProviderDefinition storageProviderDefinition, QueryModel queryModel, IReadOnlyDictionary<string, object> metadata);
 
     /// <summary>
     /// Creates an <see cref="IExecutableQuery{T}"/> collection for a given <see cref="ClassDefinition"/> based on the given <see cref="QueryModel"/>.
@@ -51,6 +52,7 @@ namespace Remotion.Data.DomainObjects.Linq
     /// <param name="queryModel">The <see cref="QueryModel"/> describing the query.</param>
     /// <param name="fetchQueryModelBuilders">
     /// A number of <see cref="FetchQueryModelBuilder"/> instances for the fetch requests to be executed together with the query.</param>
+    /// <param name="metadata">The metadata for the query. This parameter can be used to e.g. provide diagnostic information or query hints to the system.</param>
     /// <returns>
     /// An <see cref="IExecutableQuery{T}"/> collection corresponding to the given <paramref name="queryModel"/>.
     /// </returns>
@@ -58,7 +60,8 @@ namespace Remotion.Data.DomainObjects.Linq
         string id,
         StorageProviderDefinition storageProviderDefinition,
         QueryModel queryModel,
-        IEnumerable<FetchQueryModelBuilder> fetchQueryModelBuilders);
+        IEnumerable<FetchQueryModelBuilder> fetchQueryModelBuilders,
+        IReadOnlyDictionary<string, object> metadata);
 
 
   }

--- a/Remotion/Data/DomainObjects/Queries/Configuration/QueryDefinition.cs
+++ b/Remotion/Data/DomainObjects/Queries/Configuration/QueryDefinition.cs
@@ -15,7 +15,9 @@
 // along with re-motion; if not, see http://www.gnu.org/licenses.
 // 
 using System;
+using System.Collections.Generic;
 using System.Runtime.Serialization;
+using Remotion.Collections;
 using Remotion.Data.DomainObjects.Persistence.Configuration;
 using Remotion.Data.DomainObjects.Persistence.NonPersistent;
 using Remotion.ServiceLocation;
@@ -44,6 +46,8 @@ public class QueryDefinition
   private static readonly NonPersistentProviderDefinition s_dummyStorageProviderDefinition =
       new NonPersistentProviderDefinition("NonSerializedStorageProviderDefinition", new NonPersistentStorageObjectFactory());
 
+  private static readonly IReadOnlyDictionary<string, object> s_emptyMetadata = new Dictionary<string, object>().AsReadOnly<string, object>();
+
   // member fields
 
   private readonly string _id;
@@ -52,8 +56,9 @@ public class QueryDefinition
   private readonly QueryType _queryType;
   private readonly Type? _collectionType;
   private readonly StorageProviderDefinition _storageProviderDefinition;
+  private IReadOnlyDictionary<string,object> _metadata;
 
-  // Note: _ispartOfQueryConfiguration is used only during the deserialization process. 
+  // Note: _ispartOfQueryConfiguration is used only during the deserialization process.
   // It is set only in the deserialization constructor and is used in IObjectReference.GetRealObject.
   private readonly bool _ispartOfQueryConfiguration;
 
@@ -74,40 +79,13 @@ public class QueryDefinition
   /// specified through <paramref name="storageProviderDefinition"/> must understand the syntax of the <paramref name="statement"/>. Must not be <see langword="null"/>.
   /// </param>
   /// <param name="queryType">
-  /// One of the <see cref="QueryType"/> enumeration constants.
-  /// </param>
-  /// <exception cref="System.ArgumentNullException">
-  ///   <paramref name="queryID"/> is <see langword="null"/>.<br /> -or- <br />
-  ///   <paramref name="storageProviderDefinition"/> is <see langword="null"/>.<br /> -or- <br />
-  ///   <paramref name="statement"/> is <see langword="null"/>.
-  /// </exception>
-  /// <exception cref="System.ArgumentException">
-  ///   <paramref name="queryID"/> is an empty string.<br /> -or- <br />
-  ///   <paramref name="statement"/> is an empty string.
-  /// </exception>
-  /// <exception cref="System.ArgumentOutOfRangeException"><paramref name="queryType"/> is not a valid enum value.</exception>
-  public QueryDefinition (string queryID, StorageProviderDefinition storageProviderDefinition, string statement, QueryType queryType)
-    : this(queryID, storageProviderDefinition, statement, queryType, null)
-  {
-  }
-
-  /// <summary>
-  /// Initializes a new instance of the <b>QueryDefinition</b> class.
-  /// </summary>
-  /// <param name="queryID">
-  /// The <paramref name="queryID"/> to be associated with this <b>QueryDefinition</b>. Must not be <see langword="null"/>.
-  /// </param>
-  /// <param name="storageProviderDefinition">
-  /// The <see cref="StorageProviderDefinition"/> used for executing instances of this <b>QueryDefinition</b>. Must not be <see langword="null"/>.
-  /// </param>
-  /// <param name="statement">
-  /// The <paramref name="statement"/> of the <b>QueryDefinition</b>. The <see cref="Remotion.Data.DomainObjects.Persistence.StorageProvider"/>
-  /// specified through <paramref name="storageProviderDefinition"/> must understand the syntax of the <paramref name="statement"/>. Must not be <see langword="null"/>.
-  /// </param>
-  /// <param name="queryType">
   /// One of the <see cref="QueryType"/> enumeration constants.</param>
   /// <param name="collectionType">If <paramref name="queryType"/> specifies a collection to be returned, <paramref name="collectionType"/> specifies the type of the collection.
   /// If <paramref name="queryType"/> is <see langword="null"/>, <see cref="DomainObjectCollection"/> is used.
+  /// </param>
+  /// <param name="metaData">
+  /// Adds metadata to a query which can e.g. provide diagnostic information or query hints to the system.
+  /// If the project uses serialization, the metadata dictionary and it's values need to be serializable.
   /// </param>
   /// <exception cref="System.ArgumentNullException">
   ///   <paramref name="queryID"/> is <see langword="null"/>.<br /> -or- <br />
@@ -124,7 +102,8 @@ public class QueryDefinition
       StorageProviderDefinition storageProviderDefinition,
       string statement,
       QueryType queryType,
-      Type? collectionType)
+      Type? collectionType = null,
+      IReadOnlyDictionary<string, object>? metaData = null)
   {
     ArgumentUtility.CheckNotNullOrEmpty("queryID", queryID);
     ArgumentUtility.CheckNotNull("storageProviderDefinition", storageProviderDefinition);
@@ -153,6 +132,7 @@ public class QueryDefinition
     _statement = statement;
     _queryType = queryType;
     _collectionType = collectionType;
+    _metadata = metaData ?? s_emptyMetadata;
   }
 
   /// <summary>
@@ -173,6 +153,7 @@ public class QueryDefinition
       _statement = info.GetString("Statement")!;
       _queryType = (QueryType)info.GetValue("QueryType", typeof(QueryType))!;
       _collectionType = (Type?)info.GetValue("CollectionType", typeof(Type));
+      _metadata = (IReadOnlyDictionary<string, object>)info.GetValue("Metadata", typeof(IReadOnlyDictionary<string, object>))!;
     }
     else
     {
@@ -181,6 +162,7 @@ public class QueryDefinition
       _statement = "statement has not been serialized";
       _queryType = (QueryType)(-1);
       _collectionType = null;
+      _metadata = s_emptyMetadata;
     }
   }
 
@@ -228,6 +210,14 @@ public class QueryDefinition
     get { return _collectionType; }
   }
 
+  /// <summary>
+  /// Gets the provided diagnostic information or query hints for this <b>QueryDefinition</b>.
+  /// </summary>
+  public IReadOnlyDictionary<string, object> Metadata
+  {
+    get { return _metadata; }
+  }
+
   #region ISerializable Members
 
   /// <summary>
@@ -269,6 +259,7 @@ public class QueryDefinition
       info.AddValue("Statement", _statement);
       info.AddValue("QueryType", _queryType);
       info.AddValue("CollectionType", _collectionType);
+      info.AddValue("Metadata", _metadata);
     }
   }
 

--- a/Remotion/Data/DomainObjects/Queries/ILinqProviderComponentFactory.cs
+++ b/Remotion/Data/DomainObjects/Queries/ILinqProviderComponentFactory.cs
@@ -15,6 +15,7 @@
 // along with re-motion; if not, see http://www.gnu.org/licenses.
 // 
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using Remotion.Data.DomainObjects.Persistence.Configuration;
 using Remotion.Linq;
@@ -29,6 +30,6 @@ namespace Remotion.Data.DomainObjects.Queries
   {
     IQueryable<T> CreateQueryable<T> (IQueryParser queryParser, IQueryExecutor executor);
     IQueryParser CreateQueryParser ();
-    IQueryExecutor CreateQueryExecutor (StorageProviderDefinition providerDefinition);
+    IQueryExecutor CreateQueryExecutor (StorageProviderDefinition providerDefinition, string id, IReadOnlyDictionary<string, object> metadata);
   }
 }

--- a/Remotion/Data/DomainObjects/Queries/IQuery.cs
+++ b/Remotion/Data/DomainObjects/Queries/IQuery.cs
@@ -15,6 +15,7 @@
 // along with re-motion; if not, see http://www.gnu.org/licenses.
 // 
 using System;
+using System.Collections.Generic;
 using Remotion.Data.DomainObjects.Mapping;
 using Remotion.Data.DomainObjects.Persistence.Configuration;
 using Remotion.Data.DomainObjects.Queries.Configuration;
@@ -31,6 +32,11 @@ namespace Remotion.Data.DomainObjects.Queries
     /// Gets a unique identifier for the query.
     /// </summary>
     string ID { get; }
+
+    /// <summary>
+    /// Gets metadata associated with the query. If provided, this information can be used for diagnostic and query-hint purposes.
+    /// </summary>
+    IReadOnlyDictionary<string, object> Metadata { get; }
 
     /// <summary>
     /// Gets the statement of the query.

--- a/Remotion/Data/DomainObjects/Queries/LinqProviderComponentFactory.cs
+++ b/Remotion/Data/DomainObjects/Queries/LinqProviderComponentFactory.cs
@@ -15,6 +15,7 @@
 // along with re-motion; if not, see http://www.gnu.org/licenses.
 // 
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using Remotion.Data.DomainObjects.Linq;
@@ -65,14 +66,18 @@ namespace Remotion.Data.DomainObjects.Queries
       return CreateQueryParser(expressionTreeParser);
     }
 
-    public virtual IQueryExecutor CreateQueryExecutor (StorageProviderDefinition providerDefinition)
+    public virtual IQueryExecutor CreateQueryExecutor (StorageProviderDefinition providerDefinition, string id, IReadOnlyDictionary<string, object> metadata)
     {
+      ArgumentUtility.CheckNotNull("providerDefinition", providerDefinition);
+      ArgumentUtility.CheckNotNullOrEmpty("id", id);
+      ArgumentUtility.CheckNotNull("metadata", metadata);
+
       var queryGenerator = providerDefinition.Factory.CreateDomainObjectQueryGenerator(
           providerDefinition,
           _methodCallTransformerProvider,
           _resultOperatorHandlerRegistry,
           MappingConfiguration.Current);
-      return new DomainObjectQueryExecutor(providerDefinition, queryGenerator);
+      return new DomainObjectQueryExecutor(providerDefinition, queryGenerator, id, metadata);
     }
 
     protected virtual IMethodCallTransformerProvider CreateMethodCallTransformerProvider ()

--- a/Remotion/Data/DomainObjects/Queries/Query.cs
+++ b/Remotion/Data/DomainObjects/Queries/Query.cs
@@ -15,6 +15,7 @@
 // along with re-motion; if not, see http://www.gnu.org/licenses.
 // 
 using System;
+using System.Collections.Generic;
 using Remotion.Data.DomainObjects.Persistence.Configuration;
 using Remotion.Data.DomainObjects.Queries.Configuration;
 using Remotion.Data.DomainObjects.Queries.EagerFetching;
@@ -66,6 +67,11 @@ namespace Remotion.Data.DomainObjects.Queries
     public QueryDefinition Definition
     {
       get { return _definition; }
+    }
+
+    public IReadOnlyDictionary<string, object> Metadata
+    {
+      get { return _definition.Metadata; }
     }
 
     /// <summary>

--- a/Remotion/Data/DomainObjects/Queries/QueryFactory.cs
+++ b/Remotion/Data/DomainObjects/Queries/QueryFactory.cs
@@ -15,7 +15,9 @@
 // along with re-motion; if not, see http://www.gnu.org/licenses.
 // 
 using System;
+using System.Collections.Generic;
 using System.Linq;
+using Remotion.Collections;
 using Remotion.Data.DomainObjects.Linq;
 using Remotion.Data.DomainObjects.Mapping;
 using Remotion.Data.DomainObjects.Persistence.Configuration;
@@ -40,15 +42,20 @@ namespace Remotion.Data.DomainObjects.Queries
         new DoubleCheckedLockingContainer<ILinqProviderComponentFactory>(() => SafeServiceLocator.Current.GetInstance<ILinqProviderComponentFactory>());
     private static readonly DoubleCheckedLockingContainer<IQueryParser> s_queryParser =
         new DoubleCheckedLockingContainer<IQueryParser>(() => s_linqProviderComponentFactory.Value.CreateQueryParser());
+    private static readonly IReadOnlyDictionary<string, object> s_emptyMetadata = new Dictionary<string, object>().AsReadOnly<string, object>();
 
     /// <summary>
-    /// Creates a <see cref="DomainObjectQueryable{T}"/> used as the entry point to a LINQ query with the default implementation of the SQL 
+    /// Creates a <see cref="DomainObjectQueryable{T}"/> used as the entry point to a LINQ query with the default implementation of the SQL
     /// generation.
     /// </summary>
     /// <typeparam name="T">The <see cref="DomainObject"/> type to be queried.</typeparam>
     /// <returns>A <see cref="DomainObjectQueryable{T}"/> object as an entry point to a LINQ query.</returns>
+    /// <remarks>
+    /// Calls <see cref="CreateLinqQuery{T}()"/> with a default id set to '&lt;dynamic query&gt;' and
+    /// an empty metadata dictionary.
+    /// </remarks>
     /// <example>
-    /// The following example used <see cref="CreateLinqQuery{T}()"/> to retrieve 
+    /// The following example used <see cref="CreateLinqQuery{T}()"/> to retrieve
     /// an entry point for a query that selects a number of <c>Order</c> objects, filters them by <c>OrderNumber</c>, and orders them by name of
     /// customer (which includes an implicit join between <c>Order</c> and <c>Customer</c> objects).
     /// <code>
@@ -63,10 +70,40 @@ namespace Remotion.Data.DomainObjects.Queries
     public static IQueryable<T> CreateLinqQuery<T> ()
         where T: DomainObject
     {
+      return CreateLinqQuery<T>("<dynamic query>", s_emptyMetadata);
+    }
+
+    /// <summary>
+    /// Creates a <see cref="DomainObjectQueryable{T}"/> used as the entry point to a LINQ query with the default implementation of the SQL 
+    /// generation.
+    /// </summary>
+    /// <typeparam name="T">The <see cref="DomainObject"/> type to be queried.</typeparam>
+    /// <returns>A <see cref="DomainObjectQueryable{T}"/> object as an entry point to a LINQ query.</returns>
+    /// <param name="id">The id that is configured for the create <see cref="IQueryable{T}"/>.</param>
+    /// <param name="metadata">The metadata can be used to e.g. provide diagnostic information or query hints.</param>
+    /// <example>
+    /// The following example used <see cref="CreateLinqQuery{T}(string, IReadOnlyDictionary{string,object})"/> to retrieve
+    /// an entry point for a query that selects a number of <c>Order</c> objects, filters them by <c>OrderNumber</c>, and orders them by name of
+    /// customer (which includes an implicit join between <c>Order</c> and <c>Customer</c> objects).
+    /// <code>
+    /// var query =
+    ///     from o in QueryFactory.CreateLinqQuery&lt;Order&gt; ("id", metadataDictionary)
+    ///     where o.OrderNumber &lt;= 4
+    ///     orderby o.Customer.Name
+    ///     select o;
+    ///  var result = query.ToArray();
+    /// </code>
+    /// </example>
+    public static IQueryable<T> CreateLinqQuery<T> (string id, IReadOnlyDictionary<string, object> metadata)
+        where T: DomainObject
+    {
+      ArgumentUtility.CheckNotNullOrEmpty("id", id);
+      ArgumentUtility.CheckNotNull("metadata", metadata);
+
       var startingClassDefinition = MappingConfiguration.Current.GetTypeDefinition(typeof(T));
       var providerDefinition = startingClassDefinition.StorageEntityDefinition.StorageProviderDefinition;
 
-      var executor = s_linqProviderComponentFactory.Value.CreateQueryExecutor(providerDefinition);
+      var executor = s_linqProviderComponentFactory.Value.CreateQueryExecutor(providerDefinition, id, metadata);
       return CreateLinqQuery<T>(s_queryParser.Value, executor);
     }
 
@@ -161,7 +198,8 @@ namespace Remotion.Data.DomainObjects.Queries
           id,
           queryExecutor.StorageProviderDefinition,
           queryModel,
-          fetchQueryModelBuilders);
+          fetchQueryModelBuilders,
+          queryExecutor.Metadata);
     }
 
 
@@ -198,19 +236,20 @@ namespace Remotion.Data.DomainObjects.Queries
     /// methods should usually be preferred to this method.
     /// </summary>
     /// <param name="id">A string identifying the query.</param>
-    /// <param name="storageProviderDefinition">The <see cref="StorageProviderDefinition"/> used to execute the query.</param>
     /// <param name="statement">The scalar query statement.</param>
+    /// <param name="storageProviderDefinition">The <see cref="StorageProviderDefinition"/> used to execute the query.</param>
+    /// <param name="metaData">The optional metadata can be used to e.g. provide diagnostic information or query hints.</param>
     /// <param name="queryParameterCollection">The parameter collection to be used for the query.</param>
     /// <returns>An implementation of <see cref="IQuery"/> with the given statement, parameters, and metadata.</returns>
     public static IQuery CreateScalarQuery (
-        string id, StorageProviderDefinition storageProviderDefinition, string statement, QueryParameterCollection queryParameterCollection)
+        string id, StorageProviderDefinition storageProviderDefinition, string statement, QueryParameterCollection queryParameterCollection, IReadOnlyDictionary<string, object>? metaData = null)
     {
       ArgumentUtility.CheckNotNull("id", id);
       ArgumentUtility.CheckNotNull("storageProviderDefinition", storageProviderDefinition);
       ArgumentUtility.CheckNotNull("statement", statement);
       ArgumentUtility.CheckNotNull("queryParameterCollection", queryParameterCollection);
 
-      var definition = new QueryDefinition(id, storageProviderDefinition, statement, QueryType.ScalarReadOnly);
+      var definition = new QueryDefinition(id, storageProviderDefinition, statement, QueryType.ScalarReadOnly, metaData: metaData);
       return new Query(definition, queryParameterCollection);
     }
 
@@ -226,13 +265,15 @@ namespace Remotion.Data.DomainObjects.Queries
     /// <param name="queryParameterCollection">The parameter collection to be used for the query.</param>
     /// <param name="collectionType">The collection type to be returned from the query. Pass <see cref="DomainObjectCollection"/> if you don't care
     /// about the collection type. The type passed here is used by <see cref="QueryResult{T}.ToCustomCollection"/>.</param>
+    /// <param name="metaData">The optional metadata can be used to e.g. provide diagnostic information or query hints.</param>
     /// <returns>An implementation of <see cref="IQuery"/> with the given statement, parameters, and metadata.</returns>
     public static IQuery CreateCollectionQuery (
         string id,
         StorageProviderDefinition storageProviderDefinition,
         string statement,
         QueryParameterCollection queryParameterCollection,
-        Type collectionType)
+        Type collectionType,
+        IReadOnlyDictionary<string, object>? metaData = null)
     {
       ArgumentUtility.CheckNotNull("id", id);
       ArgumentUtility.CheckNotNull("storageProviderDefinition", storageProviderDefinition);
@@ -240,7 +281,7 @@ namespace Remotion.Data.DomainObjects.Queries
       ArgumentUtility.CheckNotNull("queryParameterCollection", queryParameterCollection);
       ArgumentUtility.CheckNotNull("collectionType", collectionType);
 
-      var definition = new QueryDefinition(id, storageProviderDefinition, statement, QueryType.CollectionReadOnly, collectionType);
+      var definition = new QueryDefinition(id, storageProviderDefinition, statement, QueryType.CollectionReadOnly, collectionType, metaData);
       return new Query(definition, queryParameterCollection);
     }
 
@@ -254,14 +295,16 @@ namespace Remotion.Data.DomainObjects.Queries
     /// <param name="storageProviderDefinition">The <see cref="StorageProviderDefinition"/> of the storage provider used to execute the query.</param>
     /// <param name="statement">The custom query statement.</param>
     /// <param name="queryParameterCollection">The parameter collection to be used for the query.</param>
+    /// <param name="metaData">The optional metadata can be used to e.g. provide diagnostic information or query hints.</param>
     /// <returns>An implementation of <see cref="IQuery"/> with the given statement, parameters, and metadata.</returns>
     public static IQuery CreateCustomQuery (
         string id,
         StorageProviderDefinition storageProviderDefinition,
         string statement,
-        QueryParameterCollection queryParameterCollection)
+        QueryParameterCollection queryParameterCollection,
+        IReadOnlyDictionary<string, object>? metaData = null)
     {
-      var definition = new QueryDefinition(id, storageProviderDefinition, statement, QueryType.CustomReadOnly, null);
+      var definition = new QueryDefinition(id, storageProviderDefinition, statement, QueryType.CustomReadOnly, metaData: metaData);
       return new Query(definition, queryParameterCollection);
     }
   }

--- a/SecurityManager/Core/Domain/AccessControl/AccessEvaluation/SecurityContextRevisionBasedCacheBase.cs
+++ b/SecurityManager/Core/Domain/AccessControl/AccessEvaluation/SecurityContextRevisionBasedCacheBase.cs
@@ -84,7 +84,8 @@ namespace Remotion.SecurityManager.Domain.AccessControl.AccessEvaluation
             "<dynamic query>",
             queryExecutor.StorageProviderDefinition,
             queryModel,
-            Enumerable.Empty<FetchQueryModelBuilder>());
+            Enumerable.Empty<FetchQueryModelBuilder>(),
+            queryExecutor.Metadata);
       }
     }
   }


### PR DESCRIPTION
https://re-motion.atlassian.net/browse/RM-9131

The implementations of the different CreateLinqQuery<T> cannot use optional parameters because of expression tree limitations. (CS0854). I'm not sure what the best way to create those methods is, but this is one of them which the benefits backwards compatability and allows the user to only write the id and metadata when they care about it. 

We could also have overloads for only ID and only Metadata, but if another param is ever needed, it's going out of hand quickly.


We also need to check whether the default value for the id should be a predetermined string or null until it is required.