### PR TITLE
RM-9154 Z-index on SmartPageErrorBody

### DIFF
--- a/Remotion/Web/Core/Res/Themes/NovaGray/HTML/SmartPage.css
+++ b/Remotion/Web/Core/Res/Themes/NovaGray/HTML/SmartPage.css
@@ -25,6 +25,7 @@
   right: 0;
   bottom: 0;
   padding: 0.5em;
+  z-index: 2147483647;
 }
 
 .SmartPageErrorBody > div

--- a/Remotion/Web/Core/Res/Themes/NovaViso/HTML/SmartPage.css
+++ b/Remotion/Web/Core/Res/Themes/NovaViso/HTML/SmartPage.css
@@ -23,6 +23,7 @@
   right: 0;
   bottom: 0;
   padding: 0.5em;
+  z-index: var(--z-index-max);
 }
 
 .SmartPageErrorBody > div


### PR DESCRIPTION
https://re-motion.atlassian.net/browse/RM-9154

The `SmartPageErrorMessage` is no real class or ID, the closest one being `SmartPageServerErrorMessage`, which does not display the error message itself. 

Since this seems to be what is required, the z-index is therefore added to `SmartPageErrorBody`.