### PR TITLE
RM-9204 DomainObjectQueryExecutor does not pass the ID to the generated query

### DIFF
--- a/Remotion/Data/DomainObjects.UnitTests/Linq/DomainObjectQueryExecutorTest.cs
+++ b/Remotion/Data/DomainObjects.UnitTests/Linq/DomainObjectQueryExecutorTest.cs
@@ -53,7 +53,7 @@ namespace Remotion.Data.DomainObjects.UnitTests.Linq
 
       _queryGeneratorMock = new Mock<IDomainObjectQueryGenerator>(MockBehavior.Default);
 
-      _queryExecutor = new DomainObjectQueryExecutor(TestDomainStorageProviderDefinition, _queryGeneratorMock.Object, "<dynamic query>", QueryObjectMother.EmptyMetadata);
+      _queryExecutor = new DomainObjectQueryExecutor(TestDomainStorageProviderDefinition, _queryGeneratorMock.Object, "DefinitelyUniqueQueryID", QueryObjectMother.EmptyMetadata);
 
       _queryManagerMock = new Mock<IQueryManager>(MockBehavior.Strict);
       var transaction = ClientTransactionObjectMother.CreateTransactionWithQueryManager<ClientTransaction>(_queryManagerMock.Object);
@@ -87,7 +87,7 @@ namespace Remotion.Data.DomainObjects.UnitTests.Linq
     public void ExecuteScalar ()
     {
       _queryGeneratorMock
-          .Setup(mock => mock.CreateScalarQuery<int>("<dynamic query>", TestDomainStorageProviderDefinition, _someQueryModel, QueryObjectMother.EmptyMetadata))
+          .Setup(mock => mock.CreateScalarQuery<int>("DefinitelyUniqueQueryID", TestDomainStorageProviderDefinition, _someQueryModel, QueryObjectMother.EmptyMetadata))
           .Returns(_scalarExecutableQueryMock.Object)
           .Verifiable();
 
@@ -129,7 +129,7 @@ namespace Remotion.Data.DomainObjects.UnitTests.Linq
       _queryGeneratorMock
           .Setup(
               mock => mock.CreateSequenceQuery<Order>(
-                  "<dynamic query>",
+                  "DefinitelyUniqueQueryID",
                   TestDomainStorageProviderDefinition,
                   _someQueryModel,
                   It.Is<IEnumerable<FetchQueryModelBuilder>>(p => p.Count() == 0),
@@ -180,7 +180,7 @@ namespace Remotion.Data.DomainObjects.UnitTests.Linq
       _queryGeneratorMock
           .Setup(
               mock => mock.CreateSequenceQuery<Order>(
-                  "<dynamic query>",
+                  "DefinitelyUniqueQueryID",
                   TestDomainStorageProviderDefinition,
                   _someQueryModel,
                   It.Is<IEnumerable<FetchQueryModelBuilder>>(p => p.Count() == 0),
@@ -204,7 +204,7 @@ namespace Remotion.Data.DomainObjects.UnitTests.Linq
       _queryGeneratorMock
           .Setup(
               mock => mock.CreateSequenceQuery<Order>(
-                  "<dynamic query>",
+                  "DefinitelyUniqueQueryID",
                   TestDomainStorageProviderDefinition,
                   _someQueryModel,
                   It.Is<IEnumerable<FetchQueryModelBuilder>>(p => p.Count() == 0),
@@ -226,7 +226,7 @@ namespace Remotion.Data.DomainObjects.UnitTests.Linq
       _queryGeneratorMock
           .Setup(
               mock => mock.CreateSequenceQuery<Order>(
-                  "<dynamic query>",
+                  "DefinitelyUniqueQueryID",
                   TestDomainStorageProviderDefinition,
                   _someQueryModel,
                   It.Is<IEnumerable<FetchQueryModelBuilder>>(p => p.Count() == 0),
@@ -248,7 +248,7 @@ namespace Remotion.Data.DomainObjects.UnitTests.Linq
       _queryGeneratorMock
           .Setup(
               mock => mock.CreateSequenceQuery<Order>(
-                  "<dynamic query>",
+                  "DefinitelyUniqueQueryID",
                   TestDomainStorageProviderDefinition,
                   _someQueryModel,
                   It.Is<IEnumerable<FetchQueryModelBuilder>>(p => p.Count() == 0),

--- a/Remotion/Data/DomainObjects/Linq/DomainObjectQueryExecutor.cs
+++ b/Remotion/Data/DomainObjects/Linq/DomainObjectQueryExecutor.cs
@@ -83,7 +83,7 @@ namespace Remotion.Data.DomainObjects.Linq
       if (fetchQueryModelBuilders.Any())
         throw new NotSupportedException("Scalar queries cannot perform eager fetching.");
 
-      var query = _queryGenerator.CreateScalarQuery<T>("<dynamic query>", _storageProviderDefinition, queryModel, _metadata);
+      var query = _queryGenerator.CreateScalarQuery<T>(_id, _storageProviderDefinition, queryModel, _metadata);
       return query.Execute(ClientTransaction.Current.QueryManager);
     }
 
@@ -132,7 +132,7 @@ namespace Remotion.Data.DomainObjects.Linq
       var fetchQueryModelBuilders = RemoveTrailingFetchRequests(queryModel);
 
       var query = _queryGenerator.CreateSequenceQuery<T>(
-          "<dynamic query>",
+          _id,
           _storageProviderDefinition,
           queryModel,
           fetchQueryModelBuilders,


### PR DESCRIPTION
https://re-motion.atlassian.net/browse/RM-9204