### PR TITLE
RM-9227 Move overflow: auto back out of the webkit guard (Backport 4.11)

### DIFF
--- a/Remotion/Web/Core/Res/Themes/NovaViso/HTML/Common.css
+++ b/Remotion/Web/Core/Res/Themes/NovaViso/HTML/Common.css
@@ -515,12 +515,16 @@ img.disabled,
   filter: grayscale(100%);
 }
 
+.remotion-themed.scrollable
+{
+  overflow: auto;
+}
+
 /* If either scrollbar-width`/`scrollbar-color` is specified, the `::-webkit-scrollbar` selectors won't work  */
 @supports not selector(::-webkit-scrollbar)
 {
   .remotion-themed.scrollable
   {
-    overflow: auto;
     scrollbar-width: var(--remotion-themed-scrollbar-style);
     scrollbar-color: var(--remotion-themed-scrollbar-color);
   }


### PR DESCRIPTION
https://re-motion.atlassian.net/browse/RM-9227

Backport of #1142