### PR TITLE
RM-9257 Nova viso has remotion-scrollable-theme to use scrollbar them…

### DIFF
--- a/Remotion/Web/Core/Res/Themes/NovaViso/HTML/Common.css
+++ b/Remotion/Web/Core/Res/Themes/NovaViso/HTML/Common.css
@@ -471,6 +471,7 @@ img.disabled,
   filter: grayscale(100%);
 }
 
+.remotion-scrollable,
 .remotion-themed.scrollable
 {
   overflow: auto;
@@ -478,6 +479,7 @@ img.disabled,
   scrollbar-color: var(--remotion-themed-scrollbar-color);
 }
 
+.remotion-scrollable > *,
 .remotion-themed.scrollable > *
 {
   scrollbar-color: initial; /* Stop inheriting the scrollbar color to child elements */


### PR DESCRIPTION
…e without remotion themed

Fix for issue: https://github.com/re-motion/Framework/pull/1189#discussion_r1711135329

We cant add remotion-scrollable instead of normal scrollable because this would destroy nova gray, which does not have special rules for remotion-themed.scrollable