### PR TITLE
RM-9278 BocAutoCompleteReferenceValue resets Value when losing focus (Backport 6.0)

### DIFF
--- a/Remotion/ObjectBinding/Web.ClientScript/Scripts/BocAutoCompleteReferenceValue.UI.ts
+++ b/Remotion/ObjectBinding/Web.ClientScript/Scripts/BocAutoCompleteReferenceValue.UI.ts
@@ -296,7 +296,7 @@ namespace Remotion.BocAutoCompleteReferenceValue
             lastKeyPressCode: -1,
             mouseDownOnSelect: false,
             // holds the last text the user entered into the input element
-            previousValue: '',
+            previousValue: input.value,
             lastKeyPressValue: null as Nullable<string>
         };
 


### PR DESCRIPTION
https://re-motion.atlassian.net/browse/RM-9278