### PR TITLE
bugfix/RM-9399-StopwatchScope-uses-incorrect-formatstring-for-logging

### DIFF
--- a/Remotion/Core/Core/Utilities/StopwatchScope.cs
+++ b/Remotion/Core/Core/Utilities/StopwatchScope.cs
@@ -135,14 +135,22 @@ namespace Remotion.Utilities
     public static StopwatchScope CreateScope (ILogger logger, LogLevel logLevel, string formatString)
     {
       var actualFormatString = ReplacePlaceholders(formatString);
-      return new StopwatchScope((context, scope) => logger.Log(
-              logLevel,
+      return new StopwatchScope(Log, "end");
+
+      void Log (string context, StopwatchScope scope)
+      {
+        if (logger.IsEnabled(logLevel))
+        {
+          var logMessage = string.Format(
               actualFormatString,
               context,
               scope.ElapsedTotal.ToString(),
               scope.ElapsedTotal.TotalMilliseconds.ToString(),
               scope.ElapsedSinceLastCheckpoint.ToString(),
-              scope.ElapsedSinceLastCheckpoint.TotalMilliseconds.ToString()), "end");
+              scope.ElapsedSinceLastCheckpoint.TotalMilliseconds.ToString());
+          logger.Log(logLevel, logMessage);
+        }
+      }
     }
 
     /// <summary>

--- a/Remotion/Core/UnitTests/Utilities/StopwatchScopeTest.cs
+++ b/Remotion/Core/UnitTests/Utilities/StopwatchScopeTest.cs
@@ -253,6 +253,29 @@ namespace Remotion.UnitTests.Utilities
     }
 
     [Test]
+    public void CreateScope_Log_WithPartialFormatStringPlaceholders ()
+    {
+      var fakeLogger = new FakeLogger();
+
+      var scope = StopwatchScope.CreateScope(fakeLogger, LogLevel.Information, "{context}#{elapsed:ms}#{elapsedCP:ms}");
+
+      Wait(TimeSpan.FromMilliseconds(1.0));
+
+      scope.Pause();
+
+      var firstElapsed = scope.ElapsedTotal;
+      var firstElapsedCP = scope.ElapsedSinceLastCheckpoint;
+      scope.Checkpoint("one");
+
+      scope.Dispose();
+
+      var logEntries = fakeLogger.Collector.GetSnapshot();
+      Assert.That(logEntries.Count, Is.EqualTo(2));
+      Assert.That(logEntries[0].Level, Is.EqualTo(LogLevel.Information));
+      Assert.That(logEntries[0].Message, Is.EqualTo($"one#{firstElapsed.TotalMilliseconds}#{firstElapsedCP.TotalMilliseconds}"));
+    }
+
+    [Test]
     public void CreateScope_Console ()
     {
       var oldOut = Console.Out;


### PR DESCRIPTION
https://re-motion.atlassian.net/browse/RM-9399