### PR TITLE
RM-9464 Fix broken selectors in TreeViewControlObjectTest and ImageButtonControlObject for when CSP is not enabled

### DIFF
--- a/Remotion/Web/Development.WebTesting.IntegrationTests/TreeViewControlObjectTest.cs
+++ b/Remotion/Web/Development.WebTesting.IntegrationTests/TreeViewControlObjectTest.cs
@@ -88,7 +88,9 @@ namespace Remotion.Web.Development.WebTesting.IntegrationTests
               .With.Message.EqualTo(
                   AssertionExceptionUtility.CreateExpectationException(
                       Driver,
-                      "The checkbox could not be found: Unable to find xpath: ./tbody/tr/td[a[contains(@data-event-content-onclick, 'TreeView_SelectNode')]]/input[@type='checkbox']").Message));
+                      "The checkbox could not be found: Unable to find xpath: "
+                      + "./tbody/tr/td[a[contains(@data-event-content-onclick, 'TreeView_SelectNode')]]/input[@type='checkbox']"
+                      + " | ./tbody/tr/td[a[contains(@onclick, 'TreeView_SelectNode')]]/input[@type='checkbox']").Message));
 
       rootNode.Scope.ElementFinder.Options.Timeout = backupTimeout;
 

--- a/Remotion/Web/Development.WebTesting.WebFormsControlObjects/ImageButtonControlObject.cs
+++ b/Remotion/Web/Development.WebTesting.WebFormsControlObjects/ImageButtonControlObject.cs
@@ -76,7 +76,8 @@ namespace Remotion.Web.Development.WebTesting.WebFormsControlObjects
     {
       const string doPostBackWithOptionsScript = "DoPostBackWithOptions";
 
-      return scope["data-event-content-onclick"] != null && scope["data-event-content-onclick"].Contains(doPostBackWithOptionsScript);
+      return (scope["onclick"] != null && scope["onclick"].Contains(doPostBackWithOptionsScript))
+          || (scope["data-event-content-onclick"] != null && scope["data-event-content-onclick"].Contains(doPostBackWithOptionsScript));
     }
   }
 }

--- a/Remotion/Web/Development.WebTesting.WebFormsControlObjects/TreeViewNodeControlObject.cs
+++ b/Remotion/Web/Development.WebTesting.WebFormsControlObjects/TreeViewNodeControlObject.cs
@@ -236,7 +236,7 @@ namespace Remotion.Web.Development.WebTesting.WebFormsControlObjects
     private void ClickNode (IWebTestActionOptions? actionOptions)
     {
       var actualCompletionDetector = MergeWithDefaultActionOptions(Scope, actionOptions);
-      const string nodeClickScopeXpath = "./tbody/tr/td[a[contains(@data-event-content-onclick, 'TreeView_SelectNode')]][last()]/a[last()]";
+      const string nodeClickScopeXpath = "./tbody/tr/td[a[contains(@data-event-content-onclick, 'TreeView_SelectNode')]][last()]/a[last()] | ./tbody/tr/td[a[contains(@onclick, 'TreeView_SelectNode')]][last()]/a[last()]";
       try
       {
         ExecuteAction(new ClickAction(this, Scope.FindXPath(nodeClickScopeXpath), Logger), actualCompletionDetector);
@@ -249,7 +249,7 @@ namespace Remotion.Web.Development.WebTesting.WebFormsControlObjects
 
     private ElementScope GetCheckboxScope ()
     {
-      const string xpath = "./tbody/tr/td[a[contains(@data-event-content-onclick, 'TreeView_SelectNode')]]/input[@type='checkbox']";
+      const string xpath = "./tbody/tr/td[a[contains(@data-event-content-onclick, 'TreeView_SelectNode')]]/input[@type='checkbox'] | ./tbody/tr/td[a[contains(@onclick, 'TreeView_SelectNode')]]/input[@type='checkbox']";
       return Scope.FindXPath(xpath);
     }
 


### PR DESCRIPTION
https://re-motion.atlassian.net/browse/RM-9464