### PR TITLE
bugfix/RM-9565-Mixin-validation-failes-with-protected-internal-members

### DIFF
--- a/Remotion/Mixins/Core/Definitions/ClassDefinitionBase.cs
+++ b/Remotion/Mixins/Core/Definitions/ClassDefinitionBase.cs
@@ -188,7 +188,7 @@ namespace Remotion.Mixins.Definitions
     public IEnumerable<MethodDefinition> GetProtectedOverriders ()
     {
       return from m in GetAllMethods()
-             where m.Base != null && m.MethodInfo.IsFamily || m.MethodInfo.IsFamilyOrAssembly
+             where m.Base != null && (m.MethodInfo.IsFamily || m.MethodInfo.IsFamilyOrAssembly)
              select m;
     }
 

--- a/Remotion/Mixins/UnitTests/Core/Definitions/ClassDefinitionBaseTest.cs
+++ b/Remotion/Mixins/UnitTests/Core/Definitions/ClassDefinitionBaseTest.cs
@@ -256,7 +256,7 @@ namespace Remotion.Mixins.UnitTests.Core.Definitions
     }
 
     [Test]
-    public void GetProtectedOverriders_True ()
+    public void GetProtectedOverriders_WithOverriddenProtectedMethod_ReturnsProtectedMethod ()
     {
       var overrider1 = DefinitionObjectMother.CreateMethodDefinition(_classDefinition1, _methodInfoProtected);
       var overrider2 = DefinitionObjectMother.CreateMethodDefinition(_classDefinition1, _methodInfo1);
@@ -265,26 +265,50 @@ namespace Remotion.Mixins.UnitTests.Core.Definitions
 
       DefinitionObjectMother.DeclareOverride(overrider1, overridden1);
       DefinitionObjectMother.DeclareOverride(overrider2, overridden2);
+      Assert.That(_methodInfoProtected.IsFamily, Is.True);
 
       Assert.That(_classDefinition1.GetProtectedOverriders().ToArray(), Is.EqualTo(new[] { overrider1 }));
     }
 
     [Test]
-    public void GetProtectedOverriders_True_ProtectedInternal ()
+    public void GetProtectedOverriders_WithOverriddenProtectedInternalMethod_ReturnsProtectedInternalMethod ()
     {
       var overrider = DefinitionObjectMother.CreateMethodDefinition(_classDefinition1, _methodInfoProtectedInternal);
       var overridden = DefinitionObjectMother.CreateMethodDefinition(_classDefinition1, _methodInfo2);
       DefinitionObjectMother.DeclareOverride(overrider, overridden);
+      Assert.That(_methodInfoProtectedInternal.IsFamily, Is.False);
+      Assert.That(_methodInfoProtectedInternal.IsFamilyOrAssembly, Is.True);
 
       Assert.That(_classDefinition1.GetProtectedOverriders().ToArray(), Is.EqualTo(new[] { overrider }));
     }
 
     [Test]
-    public void GetProtectedOverriders_False ()
+    public void GetProtectedOverriders_WithOverriddenPublicMethod_ReturnsNone ()
     {
       var overrider = DefinitionObjectMother.CreateMethodDefinition(_classDefinition1, _methodInfo1);
       var overridden = DefinitionObjectMother.CreateMethodDefinition(_classDefinition1, _methodInfo2);
       DefinitionObjectMother.DeclareOverride(overrider, overridden);
+      Assert.That(_methodInfo1.IsPublic, Is.True);
+      Assert.That(_methodInfo2.IsPublic, Is.True);
+
+      Assert.That(_classDefinition1.GetProtectedOverriders().ToArray(), Is.Empty);
+    }
+
+    [Test]
+    public void GetProtectedOverriders_WithNotOverriddenProtectedMethod_ReturnsNone ()
+    {
+      DefinitionObjectMother.CreateMethodDefinition(_classDefinition1, _methodInfoProtected);
+      Assert.That(_methodInfoProtected.IsFamily, Is.True);
+
+      Assert.That(_classDefinition1.GetProtectedOverriders().ToArray(), Is.Empty);
+    }
+
+    [Test]
+    public void GetProtectedOverriders_WithNotOverriddenProtectedInternalMethod_ReturnsNone ()
+    {
+      DefinitionObjectMother.CreateMethodDefinition(_classDefinition1, _methodInfoProtectedInternal);
+      Assert.That(_methodInfoProtectedInternal.IsFamilyOrAssembly, Is.True);
+      Assert.That(_methodInfoProtectedInternal.IsFamily, Is.False);
 
       Assert.That(_classDefinition1.GetProtectedOverriders().ToArray(), Is.Empty);
     }

--- a/Remotion/Mixins/UnitTests/Core/TestDomain/BT1Mixin1.cs
+++ b/Remotion/Mixins/UnitTests/Core/TestDomain/BT1Mixin1.cs
@@ -15,6 +15,7 @@
 // along with re-motion; if not, see http://www.gnu.org/licenses.
 // 
 using System;
+using JetBrains.Annotations;
 
 namespace Remotion.Mixins.UnitTests.Core.TestDomain
 {
@@ -74,5 +75,17 @@ namespace Remotion.Mixins.UnitTests.Core.TestDomain
 
     [BT1M1]
     public event EventHandler IntroducedEvent;
+
+    /// <summary>Required for testing mixin validation of non-overridden methods.</summary>
+    [UsedImplicitly]
+    protected internal void NonVirtualProtectedInternalMember ()
+    {
+    }
+
+    /// <summary>Required for testing mixin validation of non-overridden methods.</summary>
+    [UsedImplicitly]
+    protected void NonVirtualProtectedMember ()
+    {
+    }
   }
 }


### PR DESCRIPTION
https://jira.rubicon.eu/browse/RM-9565