### PR TITLE
RM-9662 GHSA-4f7c-pmjv-c25w: log4net (2.0.17) - backport 8.0

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -18,7 +18,7 @@
     <PackageVersion Include="Castle.Core" Version="4.4.0" />
     <PackageVersion Include="Fork.Coypu" Version="3.5.0" />
     <PackageVersion Include="JetBrains.Annotations" Version="2025.2.0" />
-    <PackageVersion Include="log4net" Version="3.1.0" />
+    <PackageVersion Include="log4net" Version="3.3.1" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Analyzer.Testing" Version="1.1.3-beta1.25564.1" />
     <PackageVersion Include="Microsoft.Data.SqlClient" Version="6.1.1" />
     <PackageVersion Include="Microsoft.Maui.Graphics.Skia" Version="10.0.10" />


### PR DESCRIPTION
[Update log4net to 3.3.1 (backport 8.0).](https://jira.rubicon.eu/browse/RM-9662)